### PR TITLE
On Win include types_win32.h

### DIFF
--- a/src/surf/mb_sapi.h
+++ b/src/surf/mb_sapi.h
@@ -48,8 +48,10 @@
 #ifndef __SAPI__
 
 #ifndef _WIN32
-#include <rpc/types.h>
-#include <rpc/xdr.h>
+#	include <rpc/types.h>
+#	include <rpc/xdr.h>
+#else
+#	include "types_win32.h"
 #endif
 
 #ifdef __LP64__


### PR DESCRIPTION
Let me start a series of PR to bring up my Win branch in sync to master. This one just includes types_win32.h instead of ``<rpc/types.h>``