### PR TITLE
Mostly Win stuff

### DIFF
--- a/src/mbtrn/iowrap-posix.h
+++ b/src/mbtrn/iowrap-posix.h
@@ -71,12 +71,67 @@
 /////////////////////////
 
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
+#ifdef _WIN32
+#	include <winsock2.h>
+#else
+#	include <sys/socket.h>
+#	include <netinet/in.h>
+#	include <netdb.h>
+#endif
 #include <pthread.h>
-#include <netdb.h>
 #include <fcntl.h>
 #include <unistd.h>
+
+
+#ifdef _WIN32
+#	include <sys/stat.h>
+#   include <io.h>
+
+typedef int mode_t;
+
+/// @Note If STRICT_UGO_PERMISSIONS is not defined, then setting Read for any
+///       of User, Group, or Other will set Read for User and setting Write
+///       will set Write for User.  Otherwise, Read and Write for Group and
+///       Other are ignored.
+///
+/// @Note For the POSIX modes that do not have a Windows equivalent, the modes
+///       defined here use the POSIX values left shifted 16 bits.
+
+static const mode_t S_ISUID      = 0x08000000;           ///< does nothing
+static const mode_t S_ISGID      = 0x04000000;           ///< does nothing
+static const mode_t S_ISVTX      = 0x02000000;           ///< does nothing
+static const mode_t S_IRUSR      = (mode_t)(_S_IREAD);     ///< read by user
+static const mode_t S_IWUSR      = (mode_t)(_S_IWRITE);    ///< write by user
+static const mode_t S_IXUSR      = 0x00400000;           ///< does nothing
+#   ifndef STRICT_UGO_PERMISSIONS
+static const mode_t S_IRGRP      = (mode_t)(_S_IREAD);     ///< read by *USER*
+static const mode_t S_IWGRP      = (mode_t)(_S_IWRITE);    ///< write by *USER*
+static const mode_t S_IXGRP      = 0x00080000;           ///< does nothing
+static const mode_t S_IROTH      = (mode_t)(_S_IREAD);     ///< read by *USER*
+static const mode_t S_IWOTH      = (mode_t)(_S_IWRITE);    ///< write by *USER*
+static const mode_t S_IXOTH      = 0x00010000;           ///< does nothing
+#   else
+static const mode_t S_IRGRP      = 0x00200000;           ///< does nothing
+static const mode_t S_IWGRP      = 0x00100000;           ///< does nothing
+static const mode_t S_IXGRP      = 0x00080000;           ///< does nothing
+static const mode_t S_IROTH      = 0x00040000;           ///< does nothing
+static const mode_t S_IWOTH      = 0x00020000;           ///< does nothing
+static const mode_t S_IXOTH      = 0x00010000;           ///< does nothing
+#   endif
+static const mode_t MS_MODE_MASK = 0x0000ffff;           ///< low word
+
+#if !defined (S_IRWXU)
+#	define S_IRWXU 00700         /* read, write, execute: owner. */
+#endif /* !S_IRWXU */
+#if !defined (S_IRWXG)
+#	define S_IRWXG 00070
+#endif /* S_IRWXG */
+#if !defined (S_IRWXO)
+#	define S_IRWXO 00007
+#endif /* S_IRWXO */
+
+#endif
+
 
 /////////////////////////
 // Type Definitions

--- a/src/mbtrn/iowrap.h
+++ b/src/mbtrn/iowrap.h
@@ -86,14 +86,23 @@
 /// @brief TBD
 #define WIN_DECLSPEC
 #endif
-#elif defined(__WIN32)
+#elif defined(_WIN32)
 //#pragma message "Compiling __WIN32"
 //define something for Windows (32-bit and 64-bit, this part is common)
-#include "iowrap-win.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include "iowrap-posix.h"
+#include "merror.h"
+#if _MSC_VER < 1900
+#	define snprintf _snprintf
+#endif
+#define IOW_ADDR_LEN sizeof(struct sockaddr_in)
 #ifdef _WIN64
 //define something for Windows (64-bit only)
+#	define WIN_DECLSPEC __declspec(dllimport)
 #else
 //define something for Windows (32-bit only)
+#	define WIN_DECLSPEC __declspec(dllimport)
 #endif
 #endif
 

--- a/src/mbtrn/mbtrn-server.c
+++ b/src/mbtrn/mbtrn-server.c
@@ -90,6 +90,9 @@ GNU General Public License for more details
 #include <netinet/in.h>
 #include <string.h>
 #include <errno.h>
+#else
+#	include <winsock2.h>
+#	include <WS2tcpip.h>
 #endif
 
 #include <stdio.h>

--- a/src/mbtrn/mlog.c
+++ b/src/mbtrn/mlog.c
@@ -65,9 +65,14 @@ GNU General Public License for more details
 #include <stdarg.h>
 #include <string.h>
 #include <stdlib.h>
-#include <dirent.h>
+#ifdef _WIN32
+#	include "mlog.h"
+#	include "windirent.h"
+#else
+#	include <dirent.h>
+#	include "mlog.h"
+#endif
 
-#include "mlog.h"
 #include "mdebug.h"
 
 /////////////////////////
@@ -535,7 +540,7 @@ static int s_log_set_seg(mlog_t *self, int16_t segno)
 		// for delimiter(s), NULL
         len += 2;
         // init buffer
-        char new_name[len];
+        char new_name[1024];		// char new_name[len];  is not valid C. JL 
         memset(new_name,0,len);
         char *bp = new_name;
 //        MDEBUG("path[%s] name[%s] ext[%s] len[%d]\n",self->path,self->name,self->ext,len);


### PR DESCRIPTION
But there is one more case. I had to replace ``byte buf[x];`` in ``r7kc.c`` because AFAIK that's not valid C code and Visual Studio agrees with me (though apparently both clang and gcc let go). 
There are other cases like this but not in PRs yet.