### PR TITLE
fix CHE packet parsing and update dbg5 formating

### DIFF
--- a/src/mbio/mbsys_kmbes.h
+++ b/src/mbio/mbsys_kmbes.h
@@ -1174,7 +1174,7 @@ struct mbsys_kmbes_che_data
 struct mbsys_kmbes_che
 {
     struct mbsys_kmbes_header header;
-    struct mbsys_kmbes_s_common cmnPart;
+    struct mbsys_kmbes_m_body cmnPart;
     struct mbsys_kmbes_che_data data;
 };
 


### PR DESCRIPTION
Hi Dave, 

This commit should take care of the parsing errors we've been seeing. The cause was an erroneous definition of the CHE data format, which led to misalignments in the .mb261 file...  Also did some clean-up in the dbg printouts. 

As I mentioned earlier today, I've found that in some of the example kmall files provided by Kongsberg there's an error in a few of the MRZ datagrams. The malformed packets contained duplicate information that's appended at the tail of the nominal data format (after the seabed image samples). The indexing algorithm successfully filters those packets out.

I'll continue testing as we discussed. 

Thanks!
Ben