### PR TITLE
Make all headers have include guards (mbio only).

### DIFF
--- a/src/mbio/mb_config.h.in
+++ b/src/mbio/mb_config.h.in
@@ -1,5 +1,8 @@
 /* src/mbio/mb_config.h.in.  Generated from configure.ac by autoheader.  */
 
+#ifndef MB_CONFIG_H_
+#define MB_CONFIG_H_
+
 /* Machine is littleendian, (Byteswapping on) */
 #undef BYTESWAPPED
 
@@ -120,3 +123,5 @@
 /* Define to the type of a signed integer type of width exactly 8 bits if such
    a type exists and the standard includes do not define it. */
 #undef int8_t
+
+#endif  /* MB_CONFIG_H_ */

--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -23,9 +23,8 @@
  *
  */
 
-/* include this code only once */
-#ifndef MB_DEFINE_DEF
-#define MB_DEFINE_DEF
+#ifndef MB_DEFINE_H_
+#define MB_DEFINE_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -624,5 +623,4 @@ int mb_rt(int verbose, void *modelptr, double source_depth, double source_angle,
 } /* extern "C" */
 #endif
 
-/* end conditional include */
-#endif
+#endif  /* MB_DEFINE_H_ */

--- a/src/mbio/mb_format.h
+++ b/src/mbio/mb_format.h
@@ -21,14 +21,10 @@
  *
  */
 
-/* make sure mb_status.h has been included */
-#ifndef MB_STATUS_DEF
-#include "mb_status.h"
-#endif
+#ifndef MB_FORMAT_H_
+#define MB_FORMAT_H_
 
-/* include this code only once */
-#ifndef MB_FORMAT_DEF
-#define MB_FORMAT_DEF
+#include "mb_status.h"
 
 /* define date of last format update */
 #define MB_FORMAT_UPDATEDATE "$Id$ $Revision: $"
@@ -1033,5 +1029,5 @@ int mbr_info_kemkmall(int verbose, int *system, int *beams_bath_max, int *beams_
                      int *traveltime, int *beam_flagging, int *platform_source, int *nav_source, int *sensordepth_source,
                      int *heading_source, int *attitude_source, int *svp_source, double *beamwidth_xtrack,
                      double *beamwidth_ltrack, int *error);
-/* end conditional include */
-#endif
+
+#endif  /* MB_FORTMAT_H_ */

--- a/src/mbio/mb_info.h
+++ b/src/mbio/mb_info.h
@@ -22,9 +22,8 @@
  *
  */
 
-/* include this code only once */
-#ifndef MB_INFO_DEF
-#define MB_INFO_DEF
+#ifndef MB_INFO_H_
+#define MB_INFO_H_
 
 #define MB_INFO_MASK_DIM 20
 
@@ -110,4 +109,4 @@ int mb_info_init(int verbose, struct mb_info_struct *mb_info, int *error);
 int mb_get_info(int verbose, char *file, struct mb_info_struct *mb_info, int lonflip, int *error);
 int mb_get_info_datalist(int verbose, char *read_file, int *format, struct mb_info_struct *mb_info, int lonflip, int *error);
 
-#endif
+#endif  /* MB_INFO_H_ */

--- a/src/mbio/mb_io.h
+++ b/src/mbio/mb_io.h
@@ -22,9 +22,8 @@
  *
  */
 
-/* include this code only once */
-#ifndef MB_IO_DEF
-#define MB_IO_DEF
+#ifndef MB_IO_H_
+#define MB_IO_H_
 
 #include "mb_define.h"
 #include "mb_status.h"
@@ -794,5 +793,4 @@ struct mb_imagelist_struct {
 	struct mb_imagelist_struct *imagelist;
 };
 
-/* end conditional include */
-#endif
+#endif  /* MB_IO_H_ */

--- a/src/mbio/mb_process.h
+++ b/src/mbio/mb_process.h
@@ -563,16 +563,10 @@
  *
  */
 
-/* start this include */
-#ifndef MB_PROCESS_DEF
+#ifndef MB_PROCESS_H_
+#define MB_PROCESS_H_
 
-/* header file flag */
-#define MB_PROCESS_DEF 1
-
-/* include mb_io.h if needed */
-#ifndef MB_IO_DEF
 #include "mb_io.h"
-#endif
 
 /* mbprocess value defines */
 #define MBP_FILENAMESIZE MB_PATH_MAXLINE
@@ -1089,5 +1083,4 @@ int mb_pr_unlockswathfile(int verbose, char *file, int purpose, char *program, i
 int mb_pr_lockinfo(int verbose, char *file, int *locked, int *purpose, char *program, char *user, char *cpu, char *date,
                    int *error);
 
-/* end this include */
-#endif
+#endif  /* MB_PROCESS_H_ */

--- a/src/mbio/mb_segy.h
+++ b/src/mbio/mb_segy.h
@@ -27,6 +27,9 @@
  *
  */
 
+#ifndef MB_SEGY_H_
+#define MB_SEGY_H_
+
 /* Standard SEGY format sizes */
 #define MB_SEGY_ASCIIHEADER_LENGTH 3200
 #define MB_SEGY_FILEHEADER_LENGTH 400
@@ -190,3 +193,5 @@ int mb_segy_read_trace(int verbose, void *mbsegyio_ptr, struct mb_segytraceheade
 int mb_segy_write_trace(int verbose, void *mbsegyio_ptr, struct mb_segytraceheader_struct *traceheader, float *trace, int *error);
 void hilbert(int n, double delta[], double kappa[]);
 void hilbert2(int n, double data[]);
+
+#endif  /* MB_SEGY_H_ */

--- a/src/mbio/mb_status.h
+++ b/src/mbio/mb_status.h
@@ -22,9 +22,8 @@
  *
  */
 
-/* include this code only once */
-#ifndef MB_STATUS_DEF
-#define MB_STATUS_DEF
+#ifndef MB_STATUS_H_
+#define MB_STATUS_H_
 
 /* MBIO function boolean convention */
 #define MB_YES 1
@@ -461,5 +460,4 @@ static char *unknown_notice_msg[] = {"Unknown notice identifier detritus"};
 #define MB_PULSE_DOWNCHIRP 3
 #define MB_PULSE_LIDAR 4
 
-/* end conditional include */
-#endif
+#endif  /* MB_STATUS_H_ */

--- a/src/mbio/mb_swap.h
+++ b/src/mbio/mb_swap.h
@@ -26,17 +26,12 @@
  *
  */
 
-/*--------------------------------------------------------------------*/
-
-/* include this code only once */
-#ifndef MB_SWAP_DEF
-#define MB_SWAP_DEF
+#ifndef MB_SWAP_H_
+#define MB_SWAP_H_
 
 #define mb_swap_short(a) (((a & 0xff) << 8) | ((unsigned short)(a) >> 8))
 
 #define mb_swap_int(a) (((a) << 24) | (((a) << 8) & 0x00ff0000) | (((a) >> 8) & 0x0000ff00) | ((unsigned int)(a) >> 24))
 
-/* end conditional include */
-#endif
+#endif  /* MB_SWAP_H_ */
 
-/*--------------------------------------------------------------------*/

--- a/src/mbio/mbf_bchrtunb.h
+++ b/src/mbio/mbf_bchrtunb.h
@@ -51,6 +51,9 @@
  *
  */
 
+#ifndef MB_BCHRTUNB_H_
+#define MB_BCHRTUNB_H_
+
 /* maximum number of beams and pixels */
 #define MBF_BCHRTUNB_MAXBEAMS 56
 #define MBF_BCHRTUNB_COMMENT_LENGTH 200
@@ -174,3 +177,5 @@ struct mbf_bchrtunb_struct {
 	int beams_bath;  /* number of beams stored */
 	struct mbf_bchrtunb_profile_struct profile[7];
 };
+
+#endif  /* MB_BCHRTUNB_H_ */

--- a/src/mbio/mbf_bchrxunb.h
+++ b/src/mbio/mbf_bchrxunb.h
@@ -54,6 +54,9 @@
  *
  */
 
+#ifndef MBF_BCHRXUNB_H_
+#define MBF_BCHRXUNB_H_
+
 /* maximum number of beams and pixels */
 #define MBF_BCHRXUNB_MAXBEAMS 56
 #define MBF_BCHRXUNB_COMMENT_LENGTH 200
@@ -177,3 +180,5 @@ struct mbf_bchrxunb_struct {
 	int beams_bath;  /* number of beams stored */
 	struct mbf_bchrxunb_profile_struct profile[7];
 };
+
+#endif  /* MBF_BCHRXUNB_H_ */

--- a/src/mbio/mbf_cbat8101.h
+++ b/src/mbio/mbf_cbat8101.h
@@ -412,6 +412,9 @@
  *
  */
 
+#ifndef MBF_CBAT8101_H_
+#define MBF_CBAT8101_H_
+
 /* maximum number of beams and pixels */
 #define MBF_CBAT8101_MAXBEAMS 101
 #define MBF_CBAT8101_COMMENT_LENGTH 200
@@ -527,3 +530,5 @@ struct mbf_cbat8101_struct {
 	short int amp[MBSYS_RESON_MAXBEAMS];
 	/* ??? */
 };
+
+#endif  /* MBF_CBAT8101_H_ */

--- a/src/mbio/mbf_cbat9001.h
+++ b/src/mbio/mbf_cbat9001.h
@@ -79,6 +79,9 @@
  *
  */
 
+#ifndef MBF_CBAT9001_H_
+#define MBF_CBAT9001_H_
+
 /* maximum number of beams and pixels */
 #define MBF_CBAT9001_MAXBEAMS 60
 #define MBF_CBAT9001_COMMENT_LENGTH 200
@@ -194,3 +197,5 @@ struct mbf_cbat9001_struct {
 	short int amp[MBSYS_RESON_MAXBEAMS];
 	/* ??? */
 };
+
+#endif  /* MBF_CBAT9001_H_ */

--- a/src/mbio/mbf_dsl120pf.h
+++ b/src/mbio/mbf_dsl120pf.h
@@ -82,6 +82,9 @@
  *
  */
 
+#ifndef MBF_DSL120PF_H_
+#define MBF_DSL120PF_H_
+
 /* maximum number of beams and pixels */
 #define MBF_DSL120PF_MAXBEAMS_SIDE 1024
 #define MBF_DSL120PF_MAXBEAMS 2 * MBF_DSL120PF_MAXBEAMS_SIDE
@@ -152,3 +155,5 @@ struct mbf_dsl120pf_struct {
 	/* comment */
 	char comment[MBF_DSL120PF_COMMENT_LENGTH];
 };
+
+#endif  /* MBF_DSL120PF_H_ */

--- a/src/mbio/mbf_dsl120sf.h
+++ b/src/mbio/mbf_dsl120sf.h
@@ -82,6 +82,9 @@
  *
  */
 
+#ifndef MBF_DSL120SF_H_
+#define MBF_DSL120SF_H_
+
 /* maximum number of beams and pixels */
 #define MBF_DSL120SF_MAXBEAMS_SIDE 1024
 #define MBF_DSL120SF_MAXBEAMS 2 * MBF_DSL120SF_MAXBEAMS_SIDE
@@ -152,3 +155,5 @@ struct mbf_dsl120sf_struct {
 	/* comment */
 	char comment[MBF_DSL120SF_COMMENT_LENGTH];
 };
+
+#endif  /* MBF_DSL120SF_H_ */

--- a/src/mbio/mbf_elmk2unb.h
+++ b/src/mbio/mbf_elmk2unb.h
@@ -51,6 +51,10 @@
  *
  */
 
+
+#ifndef MBF_ELMK2UNB_H_
+#define MBF_ELMK2UNB_H_
+
 /* maximum number of beams and pixels */
 #define MBF_ELMK2UNB_MAXBEAMS 126
 #define MBF_ELMK2UNB_COMMENT_LENGTH 200
@@ -171,3 +175,5 @@ struct mbf_elmk2unb_struct {
 	int beams_bath; /* number of beams stored */
 	struct mbf_elmk2unb_beam_struct beams[MBF_ELMK2UNB_MAXBEAMS];
 };
+
+#endif  /* MBF_ELMK2UNB_H_ */

--- a/src/mbio/mbf_em12darw.h
+++ b/src/mbio/mbf_em12darw.h
@@ -45,6 +45,9 @@
  *
  */
 
+#ifndef MBF_EM12DARW_H_
+#define MBF_EM12DARW_H_
+
 /* record length in bytes */
 #define MBF_EM12DARW_RECORD_LENGTH 1056
 
@@ -86,3 +89,5 @@ struct mbf_em12darw_struct {
 	short beamq[MBF_EM12DARW_BEAMS];
 	/* Beam Quality, unscaled */
 };
+
+#endif  /* MBF_EM12DARW_H_ */

--- a/src/mbio/mbf_em12ifrm.h
+++ b/src/mbio/mbf_em12ifrm.h
@@ -67,6 +67,9 @@
  *
  */
 
+#ifndef MBF_EM12IFRM_H_
+#define MBF_EM12IFRM_H_
+
 /* maximum number of beams and pixels */
 #define MBF_EM12IFRM_MAXBEAMS 81
 #define MBF_EM12IFRM_MAXRAWPIXELS 50 * MBF_EM12IFRM_MAXBEAMS
@@ -244,3 +247,5 @@ struct mbf_em12ifrm_struct {
 	/* the processed sidescan alongtrack distances
 	    in distance resolution units */
 };
+
+#endif  /* MBF_EM12IFRM_H_ */

--- a/src/mbio/mbf_gsfgenmb.h
+++ b/src/mbio/mbf_gsfgenmb.h
@@ -36,6 +36,9 @@
  *      reading and writing.
  */
 
+#ifndef MBF_GSFGENMB_H_
+#define MBF_GSFGENMB_H_
+
 #include "gsf.h"
 
 struct mbf_gsfgenmb_struct {
@@ -43,3 +46,5 @@ struct mbf_gsfgenmb_struct {
 	gsfDataID dataID;
 	gsfRecords records;
 };
+
+#endif  /* MBF_GSFGENMB_H_ */

--- a/src/mbio/mbf_hsatlraw.h
+++ b/src/mbio/mbf_hsatlraw.h
@@ -65,6 +65,9 @@
  *      which are passed in Hydrosweep records.
  */
 
+#ifndef MBF_HSATLRAW_H_
+#define MBF_HSATLRAW_H_
+
 /* maximum number of depth-velocity pairs */
 #define MBF_HSATLRAW_MAXVEL 30
 
@@ -176,3 +179,5 @@ struct mbf_hsatlraw_struct {
 	/* comment (LDEOCMNT) */
 	char comment[MBF_HSATLRAW_MAXLINE];
 };
+
+#endif  /* MBF_HSATLRAW_H_ */

--- a/src/mbio/mbf_hsldedmb.h
+++ b/src/mbio/mbf_hsldedmb.h
@@ -46,6 +46,9 @@
  * of the binary data structure used in the MBF_HSLDEDMB format.
  */
 
+#ifndef MBF_HSLDEDMB_H_
+#define MBF_HSLDEDMB_H_
+
 struct mbf_hsldedmb_data_struct {
 	unsigned int seconds;          /* seconds since 1/1/70 00:00:00 */
 	unsigned int microseconds;     /* microseconds */
@@ -72,3 +75,5 @@ struct mbf_hsldedmb_struct {
 	int kind;
 	struct mbf_hsldedmb_data_struct data;
 };
+
+#endif  /* MBF_HSLDEDMB_H_ */

--- a/src/mbio/mbf_hsldeoih.h
+++ b/src/mbio/mbf_hsldeoih.h
@@ -88,6 +88,9 @@
  *      using the record size values to check for bad kind values.
  */
 
+#ifndef MBF_HSLDEOIH_H_
+#define MBF_HSLDEOIH_H_
+
 /* maximum number of depth-velocity pairs */
 #define MBF_HSLDEOIH_MAXVEL 30
 
@@ -447,3 +450,5 @@ struct mbf_hsldeoih_comment_struct {
 	/* comment */
 	char comment[MBF_HSLDEOIH_MAXLINE];
 };
+
+#endif  /* MBF_HSLDEOIH_H_ */

--- a/src/mbio/mbf_hsmdaraw.h
+++ b/src/mbio/mbf_hsmdaraw.h
@@ -79,6 +79,9 @@
 
 /* HSMD defines */
 
+#ifndef MBF_HSMDARAW_H_
+#define MBF_HSMDARAW_H_
+
 /* maximum number of depth/sound speed data pairs allowed */
 #define MBF_HSMDARAW_MAXVEL 20
 
@@ -221,3 +224,5 @@ double mbf_hsmdaraw_beamangle[] = {0.000,  4.395,  8.740,  12.991, 17.095, 21.02
                                    37.562, 40.226, 42.698, 44.989, 47.115, 49.076, 50.900, 52.586, 54.152, 55.613,
                                    56.970, 58.233, 59.414, 60.518, 61.551, 62.518, 63.430, 65.028, 66.462, 67.742,
                                    68.901, 69.950, 70.900, 71.768, 72.565, 73.295, 73.965, 74.592, 75.168, 75.701};
+
+#endif  /* MBF_HSMDARAW_H_ */

--- a/src/mbio/mbf_hsmdldih.h
+++ b/src/mbio/mbf_hsmdldih.h
@@ -81,6 +81,9 @@
 
 /* HSMD defines */
 
+#ifndef MBF_HSMDLDIH_H_
+#define MBF_HSMDLDIH_H_
+
 /* maximum number of depth/sound speed data pairs allowed */
 #define MBF_HSMDLDIH_MAXVEL 20
 
@@ -223,3 +226,5 @@ double mbf_hsmdldih_beamangle[] = {0.000,  4.395,  8.740,  12.991, 17.095, 21.02
                                    37.562, 40.226, 42.698, 44.989, 47.115, 49.076, 50.900, 52.586, 54.152, 55.613,
                                    56.970, 58.233, 59.414, 60.518, 61.551, 62.518, 63.430, 65.028, 66.462, 67.742,
                                    68.901, 69.950, 70.900, 71.768, 72.565, 73.295, 73.965, 74.592, 75.168, 75.701};
+
+#endif  /* MBF_HSMDLDIH_H_ */

--- a/src/mbio/mbf_hsuricen.h
+++ b/src/mbio/mbf_hsuricen.h
@@ -44,6 +44,9 @@
  * of the binary data structure used in the MBF_HSURICEN format.
  */
 
+#ifndef MBF_HSURICE_H_
+#define MBF_HSURICE_H_
+
 struct mbf_hsuricen_data_struct {
 	short sec;           /* seconds x 100 */
 	short min;           /* minute of the day */
@@ -68,3 +71,5 @@ struct mbf_hsuricen_struct {
 	int kind;
 	struct mbf_hsuricen_data_struct data;
 };
+
+#endif  /* MBF_HSURICE_H_ */

--- a/src/mbio/mbf_hypc8101.h
+++ b/src/mbio/mbf_hypc8101.h
@@ -412,6 +412,9 @@
  *
  */
 
+#ifndef MBF_HYPC8101_H_
+#define MBF_HYPC8101_H_
+
 /* maximum number of beams and pixels */
 #define MBF_HYPC8101_MAXBEAMS 101
 #define MBF_HYPC8101_COMMENT_LENGTH 200
@@ -536,3 +539,5 @@ struct mbf_hypc8101_struct {
 	double angle0;
 	double angle_inc;
 };
+
+#endif  /* MBF_HYPC8101_H_ */

--- a/src/mbio/mbf_mbarirov.h
+++ b/src/mbio/mbf_mbarirov.h
@@ -31,6 +31,9 @@
  *
  */
 
+#ifndef MBF_MBARIRO_H_
+#define MBF_MBARIRO_H_
+
 #define MBF_MBARIROV_MAXLINE 256
 
 struct mbf_mbarirov_struct {
@@ -63,3 +66,5 @@ struct mbf_mbarirov_struct {
 	/* comment */
 	char comment[MBF_MBARIROV_MAXLINE];
 };
+
+#endif  /* MBF_MBARIRO_H_ */

--- a/src/mbio/mbf_mbarrov2.h
+++ b/src/mbio/mbf_mbarrov2.h
@@ -30,6 +30,9 @@
  *
  */
 
+#ifndef MBF_MBARROV2_H_
+#define MBF_MBARROV2_H_
+
 #define MBF_MBARROV2_MAXLINE 1024
 
 struct mbf_mbarrov2_struct {
@@ -63,3 +66,5 @@ struct mbf_mbarrov2_struct {
 	/* comment */
 	char comment[MBF_MBARROV2_MAXLINE];
 };
+
+#endif  /* MBF_MBARROV2_H_ */

--- a/src/mbio/mbf_mbpronav.h
+++ b/src/mbio/mbf_mbpronav.h
@@ -32,6 +32,9 @@
  *
  */
 
+#ifndef MBF_MBPRONAV_H_
+#define MBF_MBPRONAV_H_
+
 #define MBF_MBPRONAV_MAXLINE 256
 
 struct mbf_mbpronav_struct {
@@ -61,3 +64,5 @@ struct mbf_mbpronav_struct {
 	/* comment */
 	char comment[MBF_MBPRONAV_MAXLINE];
 };
+
+#endif  /* MBF_MBPRONAV_H_ */

--- a/src/mbio/mbf_mgd77dat.h
+++ b/src/mbio/mbf_mgd77dat.h
@@ -43,6 +43,9 @@
  *
  */
 
+#ifndef MBF_MGD77DAT_H_
+#define MBF_MGD77DAT_H_
+
 /* header and data record in bytes */
 #define MBF_MGD77DAT_HEADER_NUM 16
 #define MBF_MGD77DAT_DATA_LEN 120
@@ -165,3 +168,5 @@ struct mbf_mgd77dat_struct {
 	/* comment */
 	char comment[MBF_MGD77DAT_DATA_LEN];
 };
+
+#endif  /* MBF_MGD77DAT_H_ */

--- a/src/mbio/mbf_mr1aldeo.h
+++ b/src/mbio/mbf_mr1aldeo.h
@@ -39,6 +39,9 @@
  *      addition to the HIG MR1 post processing format.
  */
 
+#ifndef MBF_MR1ALDEO_H_
+#define MBF_MR1ALDEO_H_
+
 /* maximum number of bathymetry beams per side for MR1 */
 #define MBF_MR1ALDEO_BEAMS_SIDE 1500
 
@@ -118,3 +121,5 @@ struct mbf_mr1aldeo_struct {
 	/* comment */
 	char comment[MBF_MR1ALDEO_MAXLINE];
 };
+
+#endif  /* MBF_MR1ALDEO_H_ */

--- a/src/mbio/mbf_mr1bldeo.h
+++ b/src/mbio/mbf_mr1bldeo.h
@@ -40,6 +40,9 @@
  *      addition to the HIG MR1 post processing format.
  */
 
+#ifndef MBF_MR1BLDEO_H_
+#define MBF_MR1BLDEO_H_
+
 /* maximum number of bathymetry beams per side for MR1 */
 #define MBF_MR1BLDEO_BEAMS_SIDE 75
 
@@ -119,3 +122,5 @@ struct mbf_mr1bldeo_struct {
 	/* comment */
 	char comment[MBF_MR1BLDEO_MAXLINE];
 };
+
+#endif  /* MBF_MR1BLDEO_H_ */

--- a/src/mbio/mbf_mr1prhig.h
+++ b/src/mbio/mbf_mr1prhig.h
@@ -36,6 +36,9 @@
  *      which are passed in the MR1 post processing format.
  */
 
+#ifndef MBF_MR1PRHIG_H_
+#define MBF_MR1PRHIG_H_
+
 /* maximum number of bathymetry beams per side for MR1 */
 #define MBF_MR1PRHIG_BEAMS_SIDE 1500
 
@@ -110,3 +113,5 @@ struct mbf_mr1prhig_struct {
 	/* comment */
 	char comment[MBF_MR1PRHIG_MAXLINE];
 };
+
+#endif  /* MBF_MR1PRHIG_H_ */

--- a/src/mbio/mbf_mstiffss.h
+++ b/src/mbio/mbf_mstiffss.h
@@ -106,6 +106,9 @@
  *          285        Y2KTimeCorrelation#
  */
 
+#ifndef MBF_MSTIFFSS_H_
+#define MBF_MSTIFFSS_H_
+
 /* size of MSTIFFSS reading buffer */
 #define MBF_MSTIFFSS_BUFFERSIZE 1024
 
@@ -203,3 +206,5 @@ struct mbf_mstiffss_struct {
 	unsigned char ss[MBF_MSTIFFSS_PIXELS];
 	double ssacrosstrack[MBF_MSTIFFSS_PIXELS];
 };
+
+#endif /* MBF_MSTIFFSS_H_ */

--- a/src/mbio/mbf_oicgeoda.h
+++ b/src/mbio/mbf_oicgeoda.h
@@ -50,6 +50,9 @@
  *
  */
 
+#ifndef MBF_OICGEODA_H_
+#define MBF_OICGEODA_H_
+
 /* defines sizes of things */
 #define MBF_OICGEODA_HEADER_SIZE 248
 #define MBF_OICGEODA_MAX_CLIENT 252
@@ -181,3 +184,5 @@ struct mbf_oicgeoda_struct {
 	char client[MBF_OICGEODA_MAX_CLIENT];
 	struct mbf_oicgeoda_data_struct data;
 };
+
+#endif  /* MBF_OICGEODA_H_ */

--- a/src/mbio/mbf_oicmbari.h
+++ b/src/mbio/mbf_oicmbari.h
@@ -54,6 +54,9 @@
  *
  */
 
+#ifndef MBF_OICMBARI_H_
+#define MBF_OICMBARI_H_
+
 /* defines sizes of things */
 #define MBF_OICMBARI_HEADER_SIZE 276
 #define MBF_OICMBARI_MAX_CLIENT 252
@@ -186,3 +189,5 @@ struct mbf_oicmbari_struct {
 	char client[MBF_OICMBARI_MAX_CLIENT];
 	struct mbf_oicmbari_data_struct data;
 };
+
+#endif /* MBF_OICMBARI_H_ */

--- a/src/mbio/mbf_omghdcsj.h
+++ b/src/mbio/mbf_omghdcsj.h
@@ -53,6 +53,9 @@
  *
  */
 
+#ifndef MBF_OMGHDCSJ_H_
+#define MBF_OMGHDCSJ_H_
+
 /* defines sizes and maximums */
 #define MBF_OMGHDCSJ_SUMMARY_SIZE 96
 #define MBF_OMGHDCSJ_SUMMARY_V4EXTRA_SIZE 168
@@ -721,3 +724,5 @@ struct mbf_omghdcsj_struct {
 #define PROF_us_bs_current_beam_number 0x00000100
 #define PROF_uc_bs_sample_descriptor 0x00000200
 #define PROF_ui_snippet_sample_descriptor 0x00000400
+
+#endif /* MBF_OMGHDCSJ_H_ */

--- a/src/mbio/mbf_sb2100rw.h
+++ b/src/mbio/mbf_sb2100rw.h
@@ -48,6 +48,9 @@
  *      which are passed in SeaBeam 1000/2100 records.
  */
 
+#ifndef MBF_SB2100RW_H_
+#define MBF_SB2100RW_H_
+
 /* maximum number of depth-velocity pairs */
 #define MBF_SB2100RW_MAXVEL 30
 
@@ -177,3 +180,5 @@ struct mbf_sb2100rw_struct {
 	/* comment (TR) */
 	char comment[MBF_SB2100RW_MAXLINE];
 };
+
+#endif  /* MBF_SB2100RW_H_ */

--- a/src/mbio/mbf_sb2120xs.h
+++ b/src/mbio/mbf_sb2120xs.h
@@ -87,6 +87,9 @@
  *
  */
 
+#ifndef MBF_SB2120XS_H_
+#define MBF_SB2120XS_H_
+
 /* maximum number of beams and pixels */
 #define MBF_SB2120XS_MAXBEAMS 151
 #define MBF_SB2120XS_MAXPIXELS 2000
@@ -300,3 +303,5 @@ struct mbf_sb2120xs_struct {
 	int rawsize; /* size of unknown frame in bytes */
 	char raw[MBF_SB2120XS_BUFFER_SIZE];
 };
+
+#endif  /* MBF_SB2120XS_H_ */

--- a/src/mbio/mbf_sbifremr.h
+++ b/src/mbio/mbf_sbifremr.h
@@ -55,6 +55,9 @@
  * ascii comment record (kind = 2).
  */
 
+#ifndef MBF_SBIFREMR_H_
+#define MBF_SBIFREMR_H_
+
 /* maximum comment length in characters */
 #define MBF_SBIFREMR_MAXLINE 200
 
@@ -92,3 +95,5 @@ struct mbf_sbifremr_struct {
 	/* latitudes of beam values */
 	char comment[MBF_SBIFREMR_MAXLINE];
 };
+
+#endif  /* MBF_SBIFREMR_H_ */

--- a/src/mbio/mbf_sbsiocen.h
+++ b/src/mbio/mbf_sbsiocen.h
@@ -44,6 +44,9 @@
  * the binary data structure used in the MBF_SBSIOCEN format.
  */
 
+#ifndef MBF_SBSIOCEN_H_
+#define MBF_SBSIOCEN_H_
+
 struct mbf_sbsiocen_data_struct {
 	char flag[4];         /* comment flag (## flags comment record) */
 	short year;           /* year (4 digits) */
@@ -76,3 +79,5 @@ struct mbf_sbsiocen_struct {
 	int kind;
 	struct mbf_sbsiocen_data_struct data;
 };
+
+#endif  /* MBF_SBSIOCEN_H_ */

--- a/src/mbio/mbf_sbsiolsi.h
+++ b/src/mbio/mbf_sbsiolsi.h
@@ -47,6 +47,9 @@
  * of the binary data structure used in the MBF_SBSIOLSI format.
  */
 
+#ifndef MBF_SBSIOLSI_H_
+#define MBF_SBSIOLSI_H_
+
 struct mbf_sbsiolsi_data_struct {
 	short deph[19];       /* 16 depths from Sea Beam in meters
 	                  assuming 1500 m/s water velocity */
@@ -75,3 +78,5 @@ struct mbf_sbsiolsi_struct {
 	int kind;
 	struct mbf_sbsiolsi_data_struct data;
 };
+
+#endif  /* MBF_SBSIOLSI_H_ */

--- a/src/mbio/mbf_sbsiomrg.h
+++ b/src/mbio/mbf_sbsiomrg.h
@@ -47,6 +47,9 @@
  * of the binary data structure used in the MBF_SBSIOMRG format.
  */
 
+#ifndef MBF_SBSIOMRG_H_
+#define MBF_SBSIOMRG_H_
+
 /* size of data records */
 #define MBF_SBSIOMRG_RECORD_SIZE 100
 
@@ -83,3 +86,5 @@ struct mbf_sbsiomrg_struct {
 	int kind;
 	struct mbf_sbsiomrg_data_struct data;
 };
+
+#endif  /* MBF_SBSIOMRG_H_ */

--- a/src/mbio/mbf_sbsioswb.h
+++ b/src/mbio/mbf_sbsioswb.h
@@ -48,6 +48,9 @@
  * of the binary data structure used in the MBF_SBSIOSWB format.
  */
 
+#ifndef MBF_SBSIOSWB_H_
+#define MBF_SBSIOSWB_H_
+
 /* number of beams in pings */
 #define MB_BEAMS_SBSIOSWB 19
 
@@ -84,3 +87,5 @@ struct mbf_sbsioswb_struct {
 	struct mbf_sbsioswb_bath_struct bath_struct[MB_BEAMS_SBSIOSWB];
 	char comment[MBSYS_SB_MAXLINE];
 };
+
+#endif  /* MBF_SBSIOSWB_H_ */

--- a/src/mbio/mbf_sburicen.h
+++ b/src/mbio/mbf_sburicen.h
@@ -46,6 +46,9 @@
  * of the binary data structure used in the MBF_SBURICEN format.
  */
 
+#ifndef MBF_SBURICEN_H_
+#define MBF_SBURICEN_H_
+
 struct mbf_sburicen_data_struct {
 	short deph[19];       /* 16 depths from Sea Beam in meters
 	                  assuming 1500 m/s water velocity */
@@ -76,3 +79,5 @@ struct mbf_sburicen_struct {
 	int kind;
 	struct mbf_sburicen_data_struct data;
 };
+
+#endif  /* MBF_SBURICEN_H_ */

--- a/src/mbio/mbf_xtfr8101.h
+++ b/src/mbio/mbf_xtfr8101.h
@@ -28,6 +28,9 @@
  *
  */
 
+#ifndef MBF_XTFR8101_H_
+#define MBF_XTFR8101_H_
+
 /* maximum number of beams and pixels */
 #define MBF_XTFR8101_MAXBEAMS 240
 #define MBF_XTFR8101_MAXRAWPIXELS 8192
@@ -586,3 +589,5 @@ struct mbf_xtfr8101_struct {
 	/* comment */
 	char comment[MBF_XTFR8101_COMMENT_LENGTH];
 };
+
+#endif  /* MBF_XTFR8101_H_ */

--- a/src/mbio/mbsys_3datdepthlidar.h
+++ b/src/mbio/mbsys_3datdepthlidar.h
@@ -177,10 +177,10 @@
  *
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_3DATDEPTHLIDAR_H_
+#define MBSYS_3DATDEPTHLIDAR_H_
+
 #include "mb_define.h"
-#endif
 
 /* defines */
 #define MBF_3DDEPTHP_MAGICNUMBER 0x3D46        /* '=''F' */
@@ -356,3 +356,5 @@ int mbsys_3datdepthlidar_insert_svp(int verbose, void *mbio_ptr, void *store_ptr
 int mbsys_3datdepthlidar_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_3datdepthlidar_print_store(int verbose, void *store_ptr, int *error);
 int mbsys_3datdepthlidar_calculatebathymetry(int verbose, void *mbio_ptr, void *store_ptr, int *error);
+
+#endif  /* MBSYS_3DATDEPTHLIDAR_H_ */

--- a/src/mbio/mbsys_3ddwissl.h
+++ b/src/mbio/mbsys_3ddwissl.h
@@ -263,10 +263,10 @@
  *
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_3DDWISSL_H_
+#define MBSYS_3DDWISSL_H_
+
 #include "mb_define.h"
-#endif
 
 /* defines */
 #define MBF_3DWISSLR_MAGICNUMBER 0x3D08        /* '=', backspace */
@@ -613,3 +613,5 @@ int mbsys_3ddwissl_indextablefix(int verbose, void *mbio_ptr, int num_indextable
                                  void *indextable_ptr, int *error);
 int mbsys_3ddwissl_indextableapply(int verbose, void *mbio_ptr, int num_indextable,
                                    void *indextable_ptr, int n_file, int *error);
+
+#endif  /* MBSYS_3DDWISSL_H_ */

--- a/src/mbio/mbsys_atlas.h
+++ b/src/mbio/mbsys_atlas.h
@@ -74,10 +74,10 @@
  * 5) Time values are in Unix seconds (seconds since 1/1/1970 00:00:00
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_ATLAS_H_
+#define MBSYS_ATLAS_H_
+
 #include "mb_define.h"
-#endif
 
 /* sonar models */
 #define MBSYS_ATLAS_UNKNOWN 0
@@ -460,3 +460,5 @@ int mbsys_atlas_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int tim
                            int *error);
 int mbsys_atlas_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_atlas_ttcorr(int verbose, void *mbio_ptr, void *store_ptr, int *error);
+
+#endif  /* MBSYS_ATLAS_H_ */

--- a/src/mbio/mbsys_benthos.h
+++ b/src/mbio/mbsys_benthos.h
@@ -31,6 +31,9 @@
  *
  */
 
+#ifndef MBSYS_BENTHOS_H_
+#define MBSYS_BENTHOS_H_
+
 /* sonar types */
 #define MBSYS_BENTHOS_UNKNOWN 0
 #define MBSYS_BENTHOS_SIS1624 1624
@@ -158,3 +161,5 @@ int mbsys_benthos_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
 int mbsys_benthos_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_benthos_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int *error);
+
+#endif  /* MBSYS_BENTHOS_H_ */

--- a/src/mbio/mbsys_dsl.h
+++ b/src/mbio/mbsys_dsl.h
@@ -82,6 +82,9 @@
  *
  */
 
+#ifndef MBSYS_DSL_H_
+#define MBSYS_DSL_H_
+
 /* maximum number of beams and pixels */
 #define MBSYS_DSL_MAXBEAMS_SIDE 1024
 #define MBSYS_DSL_MAXBEAMS 2 * MBSYS_DSL_MAXBEAMS_SIDE
@@ -184,3 +187,5 @@ int mbsys_dsl_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 int mbsys_dsl_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_i[7], double time_d, double navlon, double navlat,
                          double speed, double heading, double draft, double roll, double pitch, double heave, int *error);
 int mbsys_dsl_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_DSL_H_ */

--- a/src/mbio/mbsys_elac.h
+++ b/src/mbio/mbsys_elac.h
@@ -55,6 +55,9 @@
  *
  */
 
+#ifndef MBSYS_ELAC_H_
+#define MBSYS_ELAC_H_
+
 /* sonar types */
 #define MBSYS_ELAC_UNKNOWN 0
 #define MBSYS_ELAC_BOTTOMCHART 1
@@ -238,3 +241,5 @@ int mbsys_elac_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *ki
                            int *error);
 int mbsys_elac_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error);
 int mbsys_elac_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_ELAC_H_ */

--- a/src/mbio/mbsys_elacmk2.h
+++ b/src/mbio/mbsys_elacmk2.h
@@ -53,6 +53,9 @@
  *
  */
 
+#ifndef MBSYS_ELACMK2_H_
+#define MBSYS_ELACMK2_H_
+
 /* sonar types */
 #define MBSYS_ELACMK2_UNKNOWN 0
 #define MBSYS_ELACMK2_BOTTOMCHART_MARKII 3
@@ -230,3 +233,5 @@ int mbsys_elacmk2_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
                               int *error);
 int mbsys_elacmk2_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error);
 int mbsys_elacmk2_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_ELACMK2_H_ */

--- a/src/mbio/mbsys_gsf.h
+++ b/src/mbio/mbsys_gsf.h
@@ -41,6 +41,9 @@
  *
  */
 
+#ifndef MBSYS_GSF_H_
+#define MBSYS_GSF_H_
+
 #include "gsf.h"
 #include "gsf_ft.h"
 #include "gsf_enc.h"
@@ -83,3 +86,5 @@ int mbsys_gsf_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 int mbsys_gsf_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error);
 int mbsys_gsf_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_gsf_setscalefactors(int verbose, int reset_all, gsfSwathBathyPing *mb_ping, int *error);
+
+#endif  /* MBSYS_GSF_H_ */

--- a/src/mbio/mbsys_hdcs.h
+++ b/src/mbio/mbsys_hdcs.h
@@ -53,6 +53,9 @@
  *
  */
 
+#ifndef MBSYS_HDCS_H_
+#define MBSYS_HDCS_H_
+
 /* defines sizes and maximums */
 #define MBSYS_HDCS_SUMMARY_SIZE 96
 #define MBSYS_HDCS_MAX_COMMENT 252
@@ -446,3 +449,5 @@ int mbsys_hdcs_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time
                           double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                           int *error);
 int mbsys_hdcs_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_HDCS_H_ */

--- a/src/mbio/mbsys_hs10.h
+++ b/src/mbio/mbsys_hs10.h
@@ -136,6 +136,9 @@
  *
  */
 
+#ifndef MBSYS_HS10_H_
+#define MBSYS_HS10_H_
+
 /* number of beams for Furuno HS-10 */
 #define MBSYS_HS10_BEAMS 45
 
@@ -199,3 +202,5 @@ int mbsys_hs10_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time
                           double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                           int *error);
 int mbsys_hs10_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_HS10_H_ */

--- a/src/mbio/mbsys_hsds.h
+++ b/src/mbio/mbsys_hsds.h
@@ -71,6 +71,9 @@
  *      which are passed in Hydrosweep records.
  */
 
+#ifndef MBSYS_HSDS_H_
+#define MBSYS_HSDS_H_
+
 /* maximum number of depth-velocity pairs */
 #define MBSYS_HSDS_MAXVEL 30
 
@@ -204,3 +207,5 @@ int mbsys_hsds_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *ki
                            int *error);
 int mbsys_hsds_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error);
 int mbsys_hsds_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_HSDS_H_ */

--- a/src/mbio/mbsys_hsmd.h
+++ b/src/mbio/mbsys_hsmd.h
@@ -83,6 +83,9 @@
  *      the data compatible with Atlas software.
  */
 
+#ifndef MBSYS_HSMD_H_
+#define MBSYS_HSMD_H_
+
 /* maximum number of depth-velocity pairs */
 #define MBSYS_HSMD_MAXVEL 20 /* As dimensioned in the Atlas code */
 
@@ -192,3 +195,5 @@ int mbsys_hsmd_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time
                           double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                           int *error);
 int mbsys_hsmd_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_HSMD_H_ */

--- a/src/mbio/mbsys_hysweep.h
+++ b/src/mbio/mbsys_hysweep.h
@@ -96,6 +96,9 @@
  *
  */
 
+#ifndef MBSYS_HYSWEEP_H_
+#define MBSYS_HYSWEEP_H_
+
 /* HYSWEEP record type */
 #define MBSYS_HYSWEEP_RECORDTYPE_NONE 0 /* No record */
 #define MBSYS_HYSWEEP_RECORDTYPE_DEV 1
@@ -881,3 +884,5 @@ int mbsys_hysweep_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
 int mbsys_hysweep_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_hysweep_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error);
+
+#endif  /* MBSYS_HYSWEEP_H_ */

--- a/src/mbio/mbsys_image83p.h
+++ b/src/mbio/mbsys_image83p.h
@@ -36,6 +36,9 @@
  *   4. Support for comment records is specific to MB-System.
  */
 
+#ifndef MBSYS_IMAGE83P_H_
+#define MBSYS_IMAGE83P_H_
+
 /* number of beams for imagex multibeam */
 #define MBSYS_IMAGE83P_BEAMS 480
 #define MBSYS_IMAGE83P_COMMENTLEN 248
@@ -114,3 +117,5 @@ int mbsys_image83p_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
                               double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                               int *error);
 int mbsys_image83p_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_IMAGE83P_H_ */

--- a/src/mbio/mbsys_jstar.h
+++ b/src/mbio/mbsys_jstar.h
@@ -34,6 +34,9 @@
  *            3. Trace data (2 bytes per sample)
  */
 
+#ifndef MBSYS_JSTAR_H_
+#define MBSYS_JSTAR_H_
+
 /* specify the maximum number of sidescan pixels that can be returned
     by mbsys_jstar_extract() */
 #define MBSYS_JSTAR_MESSAGE_SIZE 16
@@ -950,3 +953,5 @@ int mbsys_jstar_insert_segy(int verbose, void *mbio_ptr, void *store_ptr, int ki
 int mbsys_jstar_ctd(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nctd, double *time_d, double *conductivity,
                     double *temperature, double *depth, double *salinity, double *soundspeed, int *error);
 int mbsys_jstar_copyrecord(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_JSTAR_H_ */

--- a/src/mbio/mbsys_jstar2.h
+++ b/src/mbio/mbsys_jstar2.h
@@ -36,6 +36,9 @@
  *            3. Trace data (2 bytes per sample)
  */
 
+#ifndef MBSYS_JSTAR2_H_
+#define MBSYS_JSTAR2_H_
+
 /* specify the maximum number of sidescan pixels that can be returned
     by mbsys_jstar_extract() */
 #define MBSYS_JSTAR_MESSAGE_SIZE 16
@@ -945,3 +948,5 @@ int mbsys_jstar_insert_segy(int verbose, void *mbio_ptr, void *store_ptr, int ki
 int mbsys_jstar_ctd(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nctd, double *time_d, double *conductivity,
                     double *temperature, double *depth, double *salinity, double *soundspeed, int *error);
 int mbsys_jstar_copyrecord(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_JSTAR2_H_ */

--- a/src/mbio/mbsys_kmbes.h
+++ b/src/mbio/mbsys_kmbes.h
@@ -80,10 +80,10 @@
  *      XMS, // MB-System multibeam pseudosidescan derived from multibeam backscatter (MB-System only)
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_KMBES_H_
+#define MBSYS_KMBES_H_
+
 #include "mb_define.h"
-#endif
 
 /*---------------------------------------------------------------*/
 /* Datagram ID definitions */
@@ -1562,4 +1562,5 @@ int mbsys_kmbes_gains(int verbose, void *mbio_ptr, void *store_ptr,
 int mbsys_kmbes_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_kmbes_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error);
-/*---------------------------------------------------------------*/
+
+#endif  /* MBSYS_KMBES_H_ */

--- a/src/mbio/mbsys_ldeoih.h
+++ b/src/mbio/mbsys_ldeoih.h
@@ -36,6 +36,9 @@
  *      ascii comment record (kind = 0).
  */
 
+#ifndef MBSYS_LDEOIH_H_
+#define MBSYS_LDEOIH_H_
+
 /* maximum line length in characters */
 #define MBSYS_LDEOIH_MAXLINE 200
 
@@ -233,3 +236,5 @@ int mbsys_ldeoih_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
                             double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                             int *error);
 int mbsys_ldeoih_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_LDEOIH_H_ */

--- a/src/mbio/mbsys_mr1.h
+++ b/src/mbio/mbsys_mr1.h
@@ -42,6 +42,9 @@
  *      addition to the HIG MR1 post processing format.
  */
 
+#ifndef MBSYS_MR1_H_
+#define MBSYS_MR1_H_
+
 /* maximum number of bathymetry beams per side for MR1 */
 #define MBSYS_MR1_BEAMS_SIDE 1500
 
@@ -149,3 +152,5 @@ int mbsys_mr1_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 int mbsys_mr1_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_i[7], double time_d, double navlon, double navlat,
                          double speed, double heading, double draft, double roll, double pitch, double heave, int *error);
 int mbsys_mr1_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_MR1_H_ */

--- a/src/mbio/mbsys_mr1b.h
+++ b/src/mbio/mbsys_mr1b.h
@@ -44,6 +44,9 @@
  *      addition to the HIG MR1 post processing format.
  */
 
+#ifndef MBSYS_MR1B_H_
+#define MBSYS_MR1B_H_
+
 /* maximum number of bathymetry beams per side for MR1 */
 #define MBSYS_MR1B_BEAMS_SIDE 75
 
@@ -152,3 +155,5 @@ int mbsys_mr1b_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time
                           double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                           int *error);
 int mbsys_mr1b_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_MR1B_H_ */

--- a/src/mbio/mbsys_mr1v2001.h
+++ b/src/mbio/mbsys_mr1v2001.h
@@ -45,10 +45,10 @@
  *      data from the MR1, SCAMP, and WHOI DSL 120.
  */
 
-/* get MBBS library header file */
-#ifndef __MBBS__
+#ifndef MBSYS_MR1V2001_H_
+#define MBSYS_MR1V2001_H_
+
 #include "mbbs.h"
-#endif
 
 /* maximum number of bathymetry beams per side for MR1 */
 #define MBSYS_MR1V2001_BEAMS_SIDE 1500
@@ -115,3 +115,5 @@ int mbsys_mr1v2001_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
                               double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                               int *error);
 int mbsys_mr1v2001_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_MR1V2001_H_ */

--- a/src/mbio/mbsys_mstiff.h
+++ b/src/mbio/mbsys_mstiff.h
@@ -105,6 +105,9 @@
  *          285        Y2KTimeCorrelation
  */
 
+#ifndef MBSYS_MSTIFF_H_
+#define MBSYS_MSTIFF_H_
+
 /* number of sidescan pixels for Sea Scan sidescan sonars */
 #define MBSYS_MSTIFF_PIXELS 1024
 
@@ -158,3 +161,5 @@ int mbsys_mstiff_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
                             double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                             int *error);
 int mbsys_mstiff_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_MSTIFF_H_ */

--- a/src/mbio/mbsys_navnetcdf.h
+++ b/src/mbio/mbsys_navnetcdf.h
@@ -32,6 +32,9 @@
  *
  */
 
+#ifndef MBSYS_NAVNETCDF_H_
+#define MBSYS_NAVNETCDF_H_
+
 /* dimension lengths */
 #define MBSYS_NAVNETCDF_COMMENTLEN 256
 #define MBSYS_NAVNETCDF_ATTRIBUTELEN 64
@@ -362,3 +365,5 @@ int mbsys_navnetcdf_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, in
 int mbsys_navnetcdf_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity,
                                int *error);
 int mbsys_navnetcdf_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_NAVNETCDF_H_ */

--- a/src/mbio/mbsys_netcdf.h
+++ b/src/mbio/mbsys_netcdf.h
@@ -31,6 +31,9 @@
  *
  */
 
+#ifndef MBSYS_NETCDF_H_
+#define MBSYS_NETCDF_H_
+
 /* dimension lengths */
 #define MBSYS_NETCDF_COMMENTLEN 256
 #define MBSYS_NETCDF_ATTRIBUTELEN 64
@@ -1050,3 +1053,5 @@ int mbsys_netcdf_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *
                              int *error);
 int mbsys_netcdf_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error);
 int mbsys_netcdf_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_NETCDF_H_ */

--- a/src/mbio/mbsys_oic.h
+++ b/src/mbio/mbsys_oic.h
@@ -65,6 +65,9 @@
  *
  */
 
+#ifndef MBSYS_OIC_H_
+#define MBSYS_OIC_H_
+
 /* defines sizes of things */
 #define MBSYS_OIC_MAX_CLIENT 252
 #define MBSYS_OIC_MAX_COMMENT MBSYS_OIC_MAX_CLIENT
@@ -247,3 +250,5 @@ int mbsys_oic_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 int mbsys_oic_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_i[7], double time_d, double navlon, double navlat,
                          double speed, double heading, double draft, double roll, double pitch, double heave, int *error);
 int mbsys_oic_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_OIC_H_ */

--- a/src/mbio/mbsys_reson.h
+++ b/src/mbio/mbsys_reson.h
@@ -416,6 +416,9 @@
  *
  */
 
+#ifndef MBSYS_RESON_H_
+#define MBSYS_RESON_H_
+
 /* sonar types */
 #define MBSYS_RESON_UNKNOWN 0
 #define MBSYS_RESON_SEABAT9001 1
@@ -592,3 +595,5 @@ int mbsys_reson_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *k
                             int *error);
 int mbsys_reson_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error);
 int mbsys_reson_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_RESON_H_ */

--- a/src/mbio/mbsys_reson7k.h
+++ b/src/mbio/mbsys_reson7k.h
@@ -67,10 +67,10 @@
  *      records.
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_RESON7K_H_
+#define MBSYS_RESON7K_H_
+
 #include "mb_define.h"
-#endif
 
 /*---------------------------------------------------------------*/
 /* Record ID definitions */
@@ -2478,3 +2478,5 @@ int mbsys_reson7k_print_pitch(int verbose, s7kr_pitch *pitch, int *error);
 int mbsys_reson7k_print_soundvelocity(int verbose, s7kr_soundvelocity *soundvelocity, int *error);
 int mbsys_reson7k_print_absorptionloss(int verbose, s7kr_absorptionloss *absorptionloss, int *error);
 int mbsys_reson7k_print_spreadingloss(int verbose, s7kr_spreadingloss *spreadingloss, int *error);
+
+#endif  /* MBSYS_RESON7K_H_ */

--- a/src/mbio/mbsys_reson7k3.h
+++ b/src/mbio/mbsys_reson7k3.h
@@ -69,11 +69,11 @@
  *          Heading records?
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_RESON7K3_H_
+#define MBSYS_RESON7K3_H_
+
+#include <stdint.h>
 #include "mb_define.h"
-#include stdint.h
-#endif
 
 /*---------------------------------------------------------------*/
 /* Record ID definitions */
@@ -3533,3 +3533,5 @@ int mbsys_reson7k3_print_SystemLockStatus(int verbosee, s7k3_SystemLockStatus *S
 int mbsys_reson7k3_print_SoundVelocity(int verbosee, s7k3_SoundVelocity *SoundVelocity, int *error);
 int mbsys_reson7k3_print_AbsorptionLoss(int verbosee, s7k3_AbsorptionLoss *AbsorptionLoss, int *error);
 int mbsys_reson7k3_print_SpreadingLoss(int verbosee, s7k3_SpreadingLoss *SpreadingLoss, int *error);
+
+#endif  /*  MBSYS_RESON7K3_H_ */

--- a/src/mbio/mbsys_reson8k.h
+++ b/src/mbio/mbsys_reson8k.h
@@ -31,6 +31,9 @@
  *
  */
 
+#ifndef MBSYS_RESON8K_H_
+#define MBSYS_RESON8K_H_
+
 /* sonar types */
 #define MBSYS_RESON8K_UNKNOWN 0
 #define MBSYS_RESON8K_SEABAT9001 9001
@@ -224,3 +227,5 @@ int mbsys_reson8k_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
 int mbsys_reson8k_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_reson8k_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int *error);
+
+#endif  /* MBSYS_RESON8K_H_ */

--- a/src/mbio/mbsys_sb.h
+++ b/src/mbio/mbsys_sb.h
@@ -40,6 +40,9 @@
  *      which are passed in SeaBeam records.
  */
 
+#ifndef MBSYS_SB_H_
+#define MBSYS_SB_H_
+
 /* maximum line length in characters */
 #define MBSYS_SB_MAXLINE 200
 
@@ -110,3 +113,5 @@ int mbsys_sb_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 int mbsys_sb_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_i[7], double time_d, double navlon, double navlat,
                         double speed, double heading, double draft, double roll, double pitch, double heave, int *error);
 int mbsys_sb_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_SB_H_ */

--- a/src/mbio/mbsys_sb2000.h
+++ b/src/mbio/mbsys_sb2000.h
@@ -36,6 +36,9 @@
  *      which are passed in SeaBeam 2000 records.
  */
 
+#ifndef MBSYS_SB2000_H_
+#define MBSYS_SB2000_H_
+
 /* number of bathymetry beams for SeaBeam 2000 */
 #define MBSYS_SB2000_BEAMS 121
 
@@ -154,3 +157,5 @@ int mbsys_sb2000_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
                             double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                             int *error);
 int mbsys_sb2000_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_SB2000_H_ */

--- a/src/mbio/mbsys_sb2100.h
+++ b/src/mbio/mbsys_sb2100.h
@@ -168,6 +168,9 @@
  *
  */
 
+#ifndef MBSYS_SB2100_H_
+#define MBSYS_SB2100_H_
+
 /* maximum number of depth-velocity pairs */
 #define MBSYS_SB2100_MAXVEL 30
 
@@ -314,3 +317,5 @@ int mbsys_sb2100_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *
                              int *error);
 int mbsys_sb2100_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error);
 int mbsys_sb2100_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_SB2100_H_ */

--- a/src/mbio/mbsys_simrad.h
+++ b/src/mbio/mbsys_simrad.h
@@ -88,6 +88,9 @@
  *
  */
 
+#ifndef MBSYS_SIMRAD_H_
+#define MBSYS_SIMRAD_H_
+
 /* sonar types */
 #define MBSYS_SIMRAD_UNKNOWN 0
 #define MBSYS_SIMRAD_EM12S 1
@@ -751,3 +754,5 @@ int mbsys_simrad_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int ns
 int mbsys_simrad_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_simrad_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size, int swath_width_set,
                         double *swath_width, int pixel_int, int *error);
+
+#endif  /* MBSYS_SIMRAD_H_ */

--- a/src/mbio/mbsys_simrad2.h
+++ b/src/mbio/mbsys_simrad2.h
@@ -224,10 +224,10 @@
  *
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_SIMRAD2_H_
+#define MBSYS_SIMRAD2_H_
+
 #include "mb_define.h"
-#endif
 
 /* sonar models */
 #define MBSYS_SIMRAD2_UNKNOWN 0
@@ -1135,3 +1135,5 @@ int mbsys_simrad2_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
 int mbsys_simrad2_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_simrad2_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error);
+
+#endif  /* MBSYS_SIMRAD2_H_ */

--- a/src/mbio/mbsys_simrad3.h
+++ b/src/mbio/mbsys_simrad3.h
@@ -168,10 +168,11 @@
  *
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_SIMRAD3_H_
+#define MBSYS_SIMRAD3_H_
+
 #include "mb_define.h"
-#endif
+
 
 /* sonar models */
 #define MBSYS_SIMRAD3_UNKNOWN 0
@@ -1409,3 +1410,5 @@ int mbsys_simrad3_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
 int mbsys_simrad3_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_simrad3_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error);
+
+#endif  /* MBSYS_SIMRAD3_H_ */

--- a/src/mbio/mbsys_singlebeam.h
+++ b/src/mbio/mbsys_singlebeam.h
@@ -46,6 +46,9 @@
  *      mbsys_singlebeam_swathbounds().
  */
 
+#ifndef MBSYS_SINGLEBEAM_H_
+#define MBSYS_SINGLEBEAM_H_
+
 struct mbsys_singlebeam_struct {
 	/* type of data record */
 	int kind;
@@ -259,3 +262,5 @@ int mbsys_singlebeam_swathbounds(int verbose, void *mbio_ptr, void *store_ptr, i
                                  double *stbdlon, double *stbdlat, int *error);
 int mbsys_singlebeam_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_singlebeam_pressuredepth(int verbose, double pressure, double latitude, double *depth, int *error);
+
+#endif  /* MBSYS_SINGLEBEAM_H_ */

--- a/src/mbio/mbsys_stereopair.h
+++ b/src/mbio/mbsys_stereopair.h
@@ -114,10 +114,10 @@
  *              end identifiers
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_STEREOPAIR_H_
+#define MBSYS_STEREOPAIR_H_
+
 #include "mb_define.h"
-#endif
 
 /*---------------------------------------------------------------*/
 /* Record ID definitions (if needed for use in data reading and writing) */
@@ -275,4 +275,5 @@ int mbsys_stereopair_gains(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 //			double *sensor4, double *sensor5, double *sensor6,
 //			double *sensor7, double *sensor8, int *error);
 int mbsys_stereopair_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
-/*---------------------------------------------------------------*/
+
+#endif  /* MBSYS_STEREOPAIR_H_ */

--- a/src/mbio/mbsys_surf.h
+++ b/src/mbio/mbsys_surf.h
@@ -48,15 +48,11 @@
  *    SURF data
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
-#include "mb_define.h"
-#endif
+#ifndef MBSYS_SURF_H_
+#define MBSYS_SURF_H_
 
-/* include SAPI header file */
-#ifndef _SAPI
+#include "mb_define.h"
 #include "mb_sapi.h"
-#endif
 
 #define MBSYS_SURF_MAXBEAMS 1440
 #define MBSYS_SURF_MAXCVALUES 1024
@@ -146,3 +142,5 @@ int mbsys_surf_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *ki
                            int *error);
 int mbsys_surf_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error);
 int mbsys_surf_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_SURF_H_ */

--- a/src/mbio/mbsys_swathplus.h
+++ b/src/mbio/mbsys_swathplus.h
@@ -81,10 +81,11 @@
  *
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_SWATHPLUS_H_
+#define MBSYS_SWATHPLUS_H_
+
 #include "mb_define.h"
-#endif
+
 
 /*---------------------------------------------------------------
    Record ID definitions (if needed for use in data reading and writing) */
@@ -650,3 +651,5 @@ int swpls_pr_pos_offset(int verbose, FILE *fout, swpls_pos_offset *pos_offset, i
 int swpls_pr_imu_offset(int verbose, FILE *fout, swpls_imu_offset *imu_offset, int *error);
 int swpls_pr_txer_offset(int verbose, FILE *fout, swpls_txer_offset *txer_offset, int *error);
 int swpls_pr_wl_offset(int verbose, FILE *fout, swpls_wl_offset *wl_offset, int *error);
+
+#endif  /* MBSYS_SWATHPLUS_H_ */

--- a/src/mbio/mbsys_templatesystem.h
+++ b/src/mbio/mbsys_templatesystem.h
@@ -48,10 +48,10 @@
  *      profiler data supported by this data system */
 * /
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_TEMPLATESYSTEM_H_
+#define MBSYS_TEMPLATESYSTEM_H_
+
 #include "mb_define.h"
-#endif
 
 /*---------------------------------------------------------------*/
 /* Record ID definitions (if needed for use in data reading and writing) */
@@ -201,4 +201,5 @@ int mbsys_templatesystem_ttimes(int verbose, void *mbio_ptr, void *store_ptr, in
 //			double *sensor4, double *sensor5, double *sensor6,
 //			double *sensor7, double *sensor8, int *error);
 int mbsys_templatesystem_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
-/*---------------------------------------------------------------*/
+
+#endif  /* MBSYS_TEMPLATESYSTEM_H_ */

--- a/src/mbio/mbsys_wassp.h
+++ b/src/mbio/mbsys_wassp.h
@@ -91,10 +91,10 @@
  *
  */
 
-/* include mb_define.h */
-#ifndef MB_DEFINE_DEF
+#ifndef MBSYS_WASSP_H_
+#define MBSYS_WASSP_H_
+
 #include "mb_define.h"
-#endif
 
 /*---------------------------------------------------------------*/
 /* Record ID definitions (if needed for use in data reading and writing) */
@@ -722,4 +722,5 @@ int mbsys_wassp_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, d
 //			double *sensor4, double *sensor5, double *sensor6,
 //			double *sensor7, double *sensor8, int *error);
 int mbsys_wassp_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
-/*---------------------------------------------------------------*/
+
+#endif  /* MBSYS_WASSP_H_ */

--- a/src/mbio/mbsys_xse.h
+++ b/src/mbio/mbsys_xse.h
@@ -169,6 +169,9 @@
  *
  */
 
+#ifndef MBSYS_XSE_H_
+#define MBSYS_XSE_H_
+
 /* maximum number of beams and pixels */
 #define MBSYS_XSE_MAXBEAMS 630
 #define MBSYS_XSE_MAXPIXELS 32768
@@ -718,3 +721,5 @@ int mbsys_xse_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kin
                           int *error);
 int mbsys_xse_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error);
 int mbsys_xse_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
+
+#endif  /* MBSYS_XSE_H_ */


### PR DESCRIPTION
Use the pattern FILENAME_H_ for the define.  I skipped using a
filepath or package specific prefix as the files are pretty unique
with "MB" in front. The one exception what projection.h, which is too
generic a name to be safe to use.  This makes it easier to grep the
guards.

Removes some guards wrapped around `#include` lines that violate the
concept of Don't Repeat Yourself (DRY).

Fixed mbsys_reson7k3.h that had missing quotes on the include:

    #include stdint.h

See also:
- https://google.github.io/styleguide/cppguide.html#The__define_Guard
- https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rs-guards