### PR TITLE
Autoconf cpp testing: Add --enable-test to configure of travis-ci test run

### DIFF
--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-./configure
+./configure --enable-test
 make -j 3
 make check


### PR DESCRIPTION
This goes with the workaround for macosx failing to detect X11 and PROJ 6: https://github.com/dwcaress/MB-System/commit/e9b12d03d78c21959c2393c0d3a41c4196b87e42

The workaround adds complexity that it would be nice to get rid of.
The eventual solutions are one or more of:

1) Fix the detections of X11 and PROJ >=0 to work with C++
2) Set the language to C only for the tests that require it.

e.g.

```m4
AC_LANG_PUSH([C])
# Perform some tests using C.
# ...
AC_LANG_POP([C])
```

See: https://www.gnu.org/software/autoconf/manual/autoconf-2.65/html_node/Language-Choice.html