### PR TITLE
Prepare for hydrosweep testing

### DIFF
--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -620,7 +620,7 @@ int mb_rt(int verbose, void *modelptr, double source_depth, double source_angle,
           double *travel_time, int *ray_stat, int *error);
 
 #ifdef __cplusplus
-} /* extern "C" */
+}  /* extern "C" */
 #endif
 
 #endif  /* MB_DEFINE_H_ */

--- a/src/mbio/mbr_hysweep1.c
+++ b/src/mbio/mbr_hysweep1.c
@@ -27,19 +27,16 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
-#include <math.h>
-#include <string.h>
-
-/* mbio include files */
-#include "mb_status.h"
-#include "mb_format.h"
-#include "mb_io.h"
-#include "mb_define.h"
 #include "mbsys_hysweep.h"
 
-/* include for byte swapping */
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "mb_define.h"
+#include "mb_format.h"
+#include "mb_io.h"
+#include "mb_status.h"
 #include "mb_swap.h"
 
 /* local defines */

--- a/src/mbio/mbsys_hysweep.c
+++ b/src/mbio/mbsys_hysweep.c
@@ -23,18 +23,17 @@
  *
  */
 
-/* standard include files */
+#include "mbsys_hysweep.h"
+
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_hysweep.h"
+#include "mb_status.h"
 
 /* turn on debug statements here */
 /* #define MSYS_HYSWEEP_DEBUG 1 */

--- a/src/mbio/mbsys_hysweep.h
+++ b/src/mbio/mbsys_hysweep.h
@@ -99,6 +99,8 @@
 #ifndef MBSYS_HYSWEEP_H_
 #define MBSYS_HYSWEEP_H_
 
+#include "mb_define.h"
+
 /* HYSWEEP record type */
 #define MBSYS_HYSWEEP_RECORDTYPE_NONE 0 /* No record */
 #define MBSYS_HYSWEEP_RECORDTYPE_DEV 1

--- a/src/mbio/mbsys_hysweep.h
+++ b/src/mbio/mbsys_hysweep.h
@@ -852,6 +852,10 @@ struct mbsys_hysweep_struct {
 	char COM_comment[MB_COMMENT_MAXLINE]; /* comment string */
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* system specific function prototypes */
 int mbsys_hysweep_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error);
 int mbsys_hysweep_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error);
@@ -886,5 +890,10 @@ int mbsys_hysweep_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
 int mbsys_hysweep_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error);
 int mbsys_hysweep_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
 
 #endif  /* MBSYS_HYSWEEP_H_ */


### PR DESCRIPTION
- Add extern C to mbsys_hysweep.h
- Do some of what include what you use would do:
    - Make headers better at standing alone:
        Add `#include "mb_define.h"` to mbsys_hysweep.h
    - Put `#include "mbsys_hysweep.h"` first
    - Sort includes
    - Remove redundant comments