### PR TITLE
mbr_mgd77: Comment out `shift` increment that is not used.

### DIFF
--- a/src/mbio/mbr_mgd77dat.c
+++ b/src/mbio/mbr_mgd77dat.c
@@ -868,7 +868,7 @@ int mbr_mgd77dat_rd_data(int verbose, void *mbio_ptr, int *error) {
 
 		/* get nav quality */
 		mb_get_int(&data->nav_quality, &line[shift], 1);
-		shift += 1;
+		/* shift += 1; */
 	}
 
 	/* print output debug statements */
@@ -1032,7 +1032,7 @@ int mbr_mgd77dat_wr_data(int verbose, void *mbio_ptr, void *data_ptr, int *error
 
 		/* get nav quality */
 		sprintf(&line[shift], "%1.1d", data->nav_quality);
-		shift += 1;
+		/* shift += 1; */
 	}
 
 	write_len = fwrite(line, 1, MBF_MGD77DAT_DATA_LEN, mb_io_ptr->mbfp);

--- a/src/mbio/mbr_mgd77tab.c
+++ b/src/mbio/mbr_mgd77tab.c
@@ -2028,7 +2028,7 @@ int mbr_mgd77tab_wr_data(int verbose, void *mbio_ptr, void *data_ptr, int *error
 		line[shift] = '\n';
 		shift++;
 		line[shift] = '\0';
-		shift++;
+		/* shift++; */
 	}
 
 	if ((write_status = fputs(line, mb_io_ptr->mbfp)) > 0) {

--- a/src/mbio/mbr_mgd77txt.c
+++ b/src/mbio/mbr_mgd77txt.c
@@ -973,7 +973,7 @@ int mbr_mgd77txt_rd_data(int verbose, void *mbio_ptr, int *error) {
 
 		/* get nav quality */
 		mb_get_int(&data->nav_quality, &line[shift], 1);
-		shift += 1;
+		/* shift += 1; */
 	}
 
 	/* print output debug statements */


### PR DESCRIPTION
Found with:

```bash
    cppcheck --enable=all --std=c99 --force mbr_mgd77*.c 2>&1 | grep "'shift'"
```

```
    [mbr_mgd77dat.c:871]: (style) Variable 'shift' is assigned a value that is never used.
    [mbr_mgd77dat.c:1035]: (style) Variable 'shift' is assigned a value that is never used.
    [mbr_mgd77tab.c:2031]: (style) Variable 'shift' is modified but its new value is never used.
    [mbr_mgd77txt.c:976]: (style) Variable 'shift' is assigned a value that is never used.
```

Where:

```bash
cppcheck --version
Cppcheck 1.83
```