### PR TITLE
mbio: Remove some of the unused variable warnings

### DIFF
--- a/src/mbio/mb_absorption.c
+++ b/src/mbio/mb_absorption.c
@@ -487,8 +487,6 @@ int mb_seabird_soundspeed(int verbose, int algorithm, double salinity,
 						  double *soundspeed, int *error) {
 	char *function_name = "mb_seabird_soundspeed";
 	int status = MB_SUCCESS;
-	double R, RT, RP, temp, sum1, sum2, result, val;
-	int i;
 
 	/* print input debug statements */
 	if (verbose >= 2) {

--- a/src/mbio/mb_read_init.c
+++ b/src/mbio/mb_read_init.c
@@ -676,15 +676,11 @@ int mb_input_init(int verbose, char *file, int format,
 	struct mb_io_struct *mb_io_ptr;
 	int status_save;
 	int error_save;
-	int sapi_status;
-	char *lastslash;
-	char path[MB_PATH_MAXLINE], name[MB_PATH_MAXLINE];
+	char path[MB_PATH_MAXLINE];
 	char prjfile[MB_PATH_MAXLINE];
 	char projection_id[MB_NAME_LENGTH];
 	int proj_status;
 	FILE *pfp;
-	struct stat file_status;
-	int fstat;
 	int nscan;
 	int i;
 	char *stdin_string = "stdin";

--- a/src/mbio/mbr_3dwisslp.c
+++ b/src/mbio/mbr_3dwisslp.c
@@ -440,13 +440,11 @@ int mbr_3dwisslp_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
   size_t read_len;
   size_t index;
   unsigned short magic_number = 0;
-  unsigned int *newscancheck, newscancheckvalue;
-  int time_i[7];
   int done;
-  int i, ipulse, isounding, ivalidpulse, ivalidsounding;
+  int ipulse, isounding, ivalidpulse, ivalidsounding;
   int skip;
   int valid_id;
-    unsigned short ushort_val;
+  unsigned short ushort_val;
 
   /* print input debug statements */
   if (verbose >= 2) {
@@ -879,11 +877,10 @@ int mbr_3dwisslp_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
   struct mbsys_3ddwissl_pulse_struct *pulse;
   struct mbsys_3ddwissl_calibration_struct *calibration;
   int *file_header_readwritten;
-    char *buffer;
+  char *buffer;
   size_t write_len;
   size_t index;
-    long file_pos;
-  int i, ipulse, isounding;
+  int ipulse, isounding;
 
   /* print input debug statements */
   if (verbose >= 2) {

--- a/src/mbio/mbr_3dwisslr.c
+++ b/src/mbio/mbr_3dwisslr.c
@@ -257,7 +257,7 @@ int mbr_alm_3dwisslr(int verbose, void *mbio_ptr, int *error) {
   int status = MB_SUCCESS;
   struct mb_io_struct *mb_io_ptr;
   int *file_header_readwritten;
-    int *file_indexed;
+  int *file_indexed;
 
   /* print input debug statements */
   if (verbose >= 2) {
@@ -358,7 +358,7 @@ int mbr_rt_3dwisslr(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
   struct mb_io_struct *mb_io_ptr;
   struct mbsys_3ddwissl_struct *store;
-    int *file_indexed;
+  int *file_indexed;
 
   /* print input debug statements */
   if (verbose >= 2) {
@@ -460,22 +460,20 @@ int mbr_3dwisslr_index_data(int verbose, void *mbio_ptr, void *store_ptr, int *e
   int status = MB_SUCCESS;
   struct mb_io_struct *mb_io_ptr;
   struct mbsys_3ddwissl_struct *store;
-    int *file_indexed;
-  int *file_header_readwritten;
+  int *file_indexed;
   char *buffer = NULL;
   size_t read_len;
   size_t index;
   unsigned short magic_number = 0;
   int time_i[7];
-    double time_d;
+  double time_d;
   int done;
   int i;
-    int record_num_heada = 0;
-    int record_num_headb = 0;
-    int record_num_comment = 0;
+  int record_num_heada = 0;
+  int record_num_headb = 0;
+  int record_num_comment = 0;
   int skip;
   int valid_id;
-    double A_dt, B_dt, last_A_time_d, last_B_time_d;
 
   /* print input debug statements */
   if (verbose >= 2) {
@@ -603,7 +601,7 @@ int mbr_3dwisslr_index_data(int verbose, void *mbio_ptr, void *store_ptr, int *e
     while (done == MB_NO) {
     /* read and check two bytes until a valid record_id is found */
     read_len = (size_t)sizeof(short);
-        buffer = mb_io_ptr->raw_data;
+    buffer = mb_io_ptr->raw_data;
     valid_id = MB_NO;
     skip = 0;
     status = mb_fileio_get(verbose, mbio_ptr, (void *)buffer, &read_len, error);
@@ -836,7 +834,7 @@ int mbr_3dwisslr_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
   size_t read_len;
   size_t index;
   int time_i[7];
-    int time_j[5];
+  int time_j[5];
   int found;
   int i, ipulse, isounding;
   int irecord;
@@ -1215,8 +1213,7 @@ int mbr_3dwisslr_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
   char *buffer = NULL;
   size_t write_len;
   size_t index;
-    long file_pos;
-  int i, ipulse, isounding;
+  int ipulse, isounding;
 
   /* print input debug statements */
   if (verbose >= 2) {
@@ -1574,8 +1571,6 @@ int mbr_3dwisslr_fixtimestamps(int verbose, void *mbio_ptr,
   int status = MB_SUCCESS;
   struct mb_io_struct *mb_io_ptr;
   struct mbsys_3ddwissl_struct *store;
-    double time_d;
-  int time_i[7], time_j[5];
 
   /* print input debug statements */
   if (verbose >= 2) {

--- a/src/mbio/mbr_em300mba.c
+++ b/src/mbio/mbr_em300mba.c
@@ -2553,8 +2553,6 @@ int mbr_em300mba_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 	char line[EM2_EXTRAPARAMETERS_HEADER_SIZE];
 	short short_val;
 	size_t read_len;
-	int index;
-	int i, j;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -6203,8 +6201,7 @@ int mbr_em300mba_wr_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 	int write_size;
 	unsigned short checksum;
 	mb_u_char *uchar_ptr;
-  int index;
-	int i, j;
+	int j;
 
 	/* print input debug statements */
 	if (verbose >= 2) {

--- a/src/mbio/mbr_em300raw.c
+++ b/src/mbio/mbr_em300raw.c
@@ -2703,8 +2703,6 @@ int mbr_em300raw_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 	char line[EM2_EXTRAPARAMETERS_HEADER_SIZE];
 	short short_val;
 	size_t read_len;
-	int index;
-	int i, j;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -6376,8 +6374,7 @@ int mbr_em300raw_wr_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 	int write_size;
 	unsigned short checksum;
 	mb_u_char *uchar_ptr;
-  int index;
-	int i, j;
+	int j;
 
 	/* print input debug statements */
 	if (verbose >= 2) {

--- a/src/mbio/mbr_kemkmall.c
+++ b/src/mbio/mbr_kemkmall.c
@@ -414,12 +414,11 @@ int mbr_dem_kemkmall(int verbose, void *mbio_ptr, int *error) {
 int mbr_rt_kemkmall(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   char *function_name = "mbr_rt_kemkmall";
   int status = MB_SUCCESS;
-  int interp_status;
   int interp_error = MB_ERROR_NO_ERROR;
   struct mb_io_struct *mb_io_ptr = NULL;
   struct mbsys_kmbes_struct *store = NULL;
   int *file_indexed = NULL;
-	double *pixel_size, *swath_width;
+  double *pixel_size, *swath_width;
 
   /* print input debug statements */
   if (verbose >= 2) {

--- a/src/mbio/mbr_reson7k3.c
+++ b/src/mbio/mbr_reson7k3.c
@@ -548,7 +548,6 @@ int mbr_dem_reson7k3(int verbose, void *mbio_ptr, int *error) {
 int mbr_rt_reson7k3(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   char *function_name = "mbr_rt_reson7k3";
   int status = MB_SUCCESS;
-  int interp_status;
   int interp_error = MB_ERROR_NO_ERROR;
   struct mb_io_struct *mb_io_ptr;
   struct mbsys_reson7k3_struct *store;
@@ -796,9 +795,7 @@ int mbr_reson7k3_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
   int *nbadrec;
   int skip;
   int ping_record;
-  int time_j[5], time_i[7];
-  double time_d;
-  int nscan;
+  int time_j[5];
   int done;
   size_t read_len;
   int i;
@@ -2302,7 +2299,6 @@ int mbr_reson7k3_chk_pingnumber(int verbose, int recordid, char *buffer, int *pi
 int mbr_reson7k3_rd_header(int verbose, char *buffer, int *index, s7k3_header *header, int *error) {
   char *function_name = "mbr_reson7k3_rd_header";
   int status = MB_SUCCESS;
-  int i;
 
   /* print input debug statements */
   if (verbose >= 2) {
@@ -5072,7 +5068,6 @@ int mbr_reson7k3_rd_Bathymetry(int verbose, char *buffer, void *store_ptr, int *
   s7k3_Bathymetry *Bathymetry;
   int index;
   int time_j[5];
-  double acrosstrackmax, alongtrackmax;
   int i;
 
   /* print input debug statements */
@@ -10037,7 +10032,6 @@ int mbr_reson7k3_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 int mbr_reson7k3_wr_header(int verbose, char *buffer, int *index, s7k3_header *header, int *error) {
   char *function_name = "mbr_reson7k3_wr_header";
   int status = MB_SUCCESS;
-  int i;
 
   /* print input debug statements */
   if (verbose >= 2) {
@@ -15240,7 +15234,7 @@ int mbr_reson7k3_wr_RawDetection(int verbose, int *bufferalloc, char **bufferptr
   unsigned int checksum;
   int index;
   char *buffer;
-  int i, j;
+  int i;
 
   /* print input debug statements */
   if (verbose >= 2) {

--- a/src/mbio/mbsys_3ddwissl.c
+++ b/src/mbio/mbsys_3ddwissl.c
@@ -452,7 +452,7 @@ int mbsys_3ddwissl_preprocess(int verbose,     /* in: verbosity level set on com
 	double headingx, headingy;
 	int interp_status = MB_SUCCESS;
 	int interp_error = MB_ERROR_NO_ERROR;
-	int i, ipulse, isounding;
+	int i, ipulse;
 	int jnav = 0;
 	int jsensordepth = 0;
 	int jheading = 0;
@@ -1411,7 +1411,7 @@ int mbsys_3ddwissl_extract_altitude(
 	struct mbsys_3ddwissl_struct *store;
 	struct mbsys_3ddwissl_pulse_struct *pulse;
 	struct mbsys_3ddwissl_sounding_struct *sounding;
-	int i, ipulse, isounding;
+	int ipulse, isounding;
 	double rmin, r;
 
 	/* check for non-null data */
@@ -1725,9 +1725,7 @@ int mbsys_3ddwissl_insert_nav(int verbose, void *mbio_ptr, /* in: verbosity leve
 	int status = MB_SUCCESS;
 	struct mb_io_struct *mb_io_ptr;
 	struct mbsys_3ddwissl_struct *store;
-	struct mbsys_3ddwissl_pulse_struct *pulse;
 	double dlon, dlat, dheading, dsensordepth, droll, dpitch;
-	int ipulse, isounding;
 
 	/* check for non-null data */
 	assert(mbio_ptr != NULL);
@@ -2017,8 +2015,7 @@ int mbsys_3ddwissl_print_store(int verbose,     /* in: verbosity level set on co
 	char *debug_str = "dbg2  ";
 	char *nodebug_str = "  ";
 	char *first;
-	int npulses;
-	int i, ipulse, isounding;
+	int ipulse, isounding;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -2801,14 +2798,11 @@ int mbsys_3ddwissl_indextableapply(int verbose, void *mbio_ptr, int num_indextab
 	char *function_name = "mbsys_3ddwissl_indextableapply";
 	int status = MB_SUCCESS;
 	struct mb_io_struct *mb_io_ptr;
-    struct mb_io_indextable_struct *indextable;
-    double time_d;
-    double nearest_minute_time_d;
-	int time_i[7], time_j[5];
-    int giindex, iindex;
-    int giindex_a_begin, giindex_a_end;
-    int giindex_b_begin, giindex_b_end;
-    int i;
+        struct mb_io_indextable_struct *indextable;
+        int giindex, iindex;
+        int giindex_a_begin, giindex_a_end;
+        int giindex_b_begin, giindex_b_end;
+        int i;
 
 	/* print input debug statements */
 	if (verbose >= 2) {

--- a/src/mbio/mbsys_kmbes.c
+++ b/src/mbio/mbsys_kmbes.c
@@ -980,9 +980,6 @@ int mbsys_kmbes_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
   struct mbsys_kmbes_struct *store = NULL;
   struct mbsys_kmbes_mwc *mwc = NULL;
   struct mbsys_kmbes_mrz *mrz = NULL;
-  double heave_use, roll, pitch;
-  double alpha, beta, theta, phi;
-  int soundings_count;
   int numSoundings = 0;
   int imrz;
   int i;
@@ -1294,8 +1291,6 @@ int mbsys_kmbes_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, d
   struct mbsys_kmbes_struct *store = NULL;
   struct mbsys_kmbes_mrz *mrz = NULL;
   int numSoundings = 0;
-  int imrz;
-  int i;
 
   /* print input debug statements */
   if (verbose >= 2) {
@@ -1379,10 +1374,7 @@ int mbsys_kmbes_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, i
   struct mbsys_kmbes_struct *store = NULL;
   struct mbsys_kmbes_mwc *mwc = NULL;
   struct mbsys_kmbes_mrz *mrz = NULL;
-  double heave, roll, pitch;
-  double xtrackmin;
-  int altitude_found;
-  int i;
+
 
   /* print input debug statements */
   if (verbose >= 2) {
@@ -2314,22 +2306,13 @@ int mbsys_kmbes_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_s
   int ss_cnt[MBSYS_KMBES_MAX_PIXELS];
   double ssacrosstrack[MBSYS_KMBES_MAX_PIXELS];
   double ssalongtrack[MBSYS_KMBES_MAX_PIXELS];
-  short *beam_ss;
   int nbathsort;
   double bathsort[MBSYS_KMBES_MAX_PIXELS];
   int nsoundings, nsamples;
   double median_altitude;
-  double depthoffset;
-  double reflscale;
   double pixel_size_calc;
-  double pixel_size_max_swath;
-  double sample_size_m, sample_size_m_use;
+  double sample_size_m;
   int pixel_int_use;
-  double angle, xtrackss;
-  double range, beam_foot, beamwidth, sint;
-  int time_i[7];
-  double bath_time_d, ss_time_d;
-  int ss_ok;
   int first, last, k1, kc, k2;
   double dx1, dx2, dx, xx;
   int imrz;


### PR DESCRIPTION
Used:

```bash
cppcheck --enable=style *.c 2>&1 | grep -i unused
```

Skipped mbsys_reson7k3.c as it is under development.  e.g. https://github.com/dwcaress/MB-System/commit/24e7ef8ecdf66a938bb1a13367bb75a727d2c31e

    [mbsys_reson7k3.c:51]: (style) Unused variable: i
    [mbsys_reson7k3.c:124]: (style) Unused variable: time
    [mbsys_reson7k3.c:125]: (style) Unused variable: header
    [mbsys_reson7k3.c:126]: (style) Unused variable: ReferencePoint
    [mbsys_reson7k3.c:127]: (style) Unused variable: UncalibratedSensorOffset
    [mbsys_reson7k3.c:128]: (style) Unused variable: CalibratedSensorOffset
    [mbsys_reson7k3.c:129]: (style) Unused variable: Position
    <SNIP>

And there are quite a few:

```bash
cppcheck --enable=style mbsys_reson7k3.c 2>&1 | grep -i unused | wc -l
117
```
