### PR TITLE
mbr_mgd77: Use `&=` for status so that failures are not hidden.

### DIFF
--- a/src/mbio/mbr_mgd77dat.c
+++ b/src/mbio/mbr_mgd77dat.c
@@ -250,14 +250,11 @@ int mbr_alm_mgd77dat(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to mbio descriptor */
 	mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-	/* set initial status */
-	status = MB_SUCCESS;
-
 	/* allocate memory for data structure */
 	mb_io_ptr->structure_size = sizeof(struct mbf_mgd77dat_struct);
 	mb_io_ptr->data_structure_size = 0;
 	status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_singlebeam_struct), &mb_io_ptr->store_data, error);
+	status &= mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_singlebeam_struct), &mb_io_ptr->store_data, error);
 
 	/* get pointer to mbio descriptor */
 	mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
@@ -301,7 +298,7 @@ int mbr_dem_mgd77dat(int verbose, void *mbio_ptr, int *error) {
 
 	/* deallocate memory for data descriptor */
 	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->store_data, error);
+	status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->store_data, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {

--- a/src/mbio/mbr_mgd77tab.c
+++ b/src/mbio/mbr_mgd77tab.c
@@ -900,14 +900,11 @@ int mbr_alm_mgd77tab(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to mbio descriptor */
 	mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-	/* set initial status */
-	status = MB_SUCCESS;
-
 	/* allocate memory for data structure */
 	mb_io_ptr->structure_size = sizeof(struct mbf_mgd77tab_struct);
 	mb_io_ptr->data_structure_size = 0;
 	status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_singlebeam_struct), &mb_io_ptr->store_data, error);
+	status &= mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_singlebeam_struct), &mb_io_ptr->store_data, error);
 
 	/* get pointer to mbio descriptor */
 	mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
@@ -951,7 +948,7 @@ int mbr_dem_mgd77tab(int verbose, void *mbio_ptr, int *error) {
 
 	/* deallocate memory for data descriptor */
 	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->store_data, error);
+	status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->store_data, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {

--- a/src/mbio/mbr_mgd77txt.c
+++ b/src/mbio/mbr_mgd77txt.c
@@ -394,14 +394,11 @@ int mbr_alm_mgd77txt(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to mbio descriptor */
 	mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-	/* set initial status */
-	status = MB_SUCCESS;
-
 	/* allocate memory for data structure */
 	mb_io_ptr->structure_size = sizeof(struct mbf_mgd77txt_struct);
 	mb_io_ptr->data_structure_size = 0;
 	status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_singlebeam_struct), &mb_io_ptr->store_data, error);
+	status &= mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_singlebeam_struct), &mb_io_ptr->store_data, error);
 
 	/* get pointer to mbio descriptor */
 	mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
@@ -445,7 +442,7 @@ int mbr_dem_mgd77txt(int verbose, void *mbio_ptr, int *error) {
 
 	/* deallocate memory for data descriptor */
 	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->store_data, error);
+	status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->store_data, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {


### PR DESCRIPTION
Found with:

```bash
cppcheck --enable=all --std=c99 --force mb*77*.[ch] 2>&1 | grep "'status'"
```

```
[mbr_mgd77dat.c:254] -> [mbr_mgd77dat.c:259]: (style) Variable 'status' is reassigned a value before the old one has been used.
[mbr_mgd77dat.c:259] -> [mbr_mgd77dat.c:260]: (style) Variable 'status' is reassigned a value before the old one has been used.
[mbr_mgd77dat.c:303] -> [mbr_mgd77dat.c:304]: (style) Variable 'status' is reassigned a value before the old one has been used.
<SNIP>
```

There are likely many more occurrences of this issue.

Useful discussion here:

https://stackoverflow.com/questions/2488406/why-doesnt-c-have-or-for-booleans