### PR TITLE
Drop `-g` from travis builds.

### DIFF
--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-./configure --enable-test
+CFLAGS=-O2 ./configure --enable-test
 make -j 3
 make check


### PR DESCRIPTION
Debugging info in binaries is only going to slow down CI runs.

Looks like this reduces total time for a run by ~10%