### PR TITLE
Update mbformat.1 man page for -W and mbformat -H for -K and -W.

### DIFF
--- a/src/man/man1/mbformat.1
+++ b/src/man/man1/mbformat.1
@@ -6,7 +6,8 @@ supported by the \fBMBIO\fP library.
 .SH VERSION
 Version 5.0
 
-.SH SYNOPSIS\fBmbformat\fP [\fB \-F\fP\fIformat\fP \fB\-I\fP\fIfile\fP \fB\-L \-K \-V \-H\fP]
+.SH SYNOPSIS
+\fBmbformat\fP [\fB \-F\fP\fIformat\fP \fB\-I\fP\fIfile\fP \fB\-L \-K \-V \-W \-H\fP]
 
 .SH DESCRIPTION
 \fBmbformat\fP is a utility which identifies the swath sonar data formats
@@ -77,6 +78,9 @@ so that only the \fBMBIO\fP format id numbers are listed.
 Normally, \fBmbformat\fP only prints out format descriptions.  If the
 \fB\-V\fP flag is given, then \fBmbformat\fP works in a "verbose" mode and
 also outputs the program version being used.
+.TP
+.B \-W
+Output the list of formats as HTML.
 
 .SH EXAMPLES
 Suppose one wishes to identify the swath sonar data format associated

--- a/src/utilities/mbformat.c
+++ b/src/utilities/mbformat.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
 	char program_name[] = "MBFORMAT";
 	char help_message[] = "MBFORMAT is an utility which identifies the swath data formats \nassociated with MBIO format id's.  "
 	                      "If no format id is specified, \nMBFORMAT lists all of the currently supported formats.";
-	char usage_message[] = "mbformat [-Fformat -Ifile -L -W -V -H]";
+	char usage_message[] = "mbformat [-Fformat -Ifile -L -K -V -W -H]";
 
 	/* parsing variables */
 	extern char *optarg;


### PR DESCRIPTION
Also corrects the SYNOPSIS so that it doesn't run into the following `mbformat`.

Fixes #126.