### PR TITLE
mbr_*.c: Sort includes.

### DIFF
--- a/src/mbio/mbf_cbat8101.h
+++ b/src/mbio/mbf_cbat8101.h
@@ -413,6 +413,8 @@
 #ifndef MBF_CBAT8101_H_
 #define MBF_CBAT8101_H_
 
+#include "mbsys_reson.h"
+
 /* maximum number of beams and pixels */
 #define MBF_CBAT8101_MAXBEAMS 101
 #define MBF_CBAT8101_COMMENT_LENGTH 200

--- a/src/mbio/mbf_cbat9001.h
+++ b/src/mbio/mbf_cbat9001.h
@@ -81,6 +81,8 @@
 #ifndef MBF_CBAT9001_H_
 #define MBF_CBAT9001_H_
 
+#include "mbsys_reson.h"
+
 /* maximum number of beams and pixels */
 #define MBF_CBAT9001_MAXBEAMS 60
 #define MBF_CBAT9001_COMMENT_LENGTH 200

--- a/src/mbio/mbf_hsldeoih.h
+++ b/src/mbio/mbf_hsldeoih.h
@@ -90,6 +90,8 @@
 #ifndef MBF_HSLDEOIH_H_
 #define MBF_HSLDEOIH_H_
 
+#include "mbsys_hsds.h"
+
 /* maximum number of depth-velocity pairs */
 #define MBF_HSLDEOIH_MAXVEL 30
 

--- a/src/mbio/mbf_hsmdaraw.h
+++ b/src/mbio/mbf_hsmdaraw.h
@@ -82,6 +82,8 @@
 #ifndef MBF_HSMDARAW_H_
 #define MBF_HSMDARAW_H_
 
+#include "mbsys_hsmd.h"
+
 /* maximum number of depth/sound speed data pairs allowed */
 #define MBF_HSMDARAW_MAXVEL 20
 

--- a/src/mbio/mbf_hsmdldih.h
+++ b/src/mbio/mbf_hsmdldih.h
@@ -84,6 +84,8 @@
 #ifndef MBF_HSMDLDIH_H_
 #define MBF_HSMDLDIH_H_
 
+#include "mbsys_hsmd.h"
+
 /* maximum number of depth/sound speed data pairs allowed */
 #define MBF_HSMDLDIH_MAXVEL 20
 

--- a/src/mbio/mbf_hypc8101.h
+++ b/src/mbio/mbf_hypc8101.h
@@ -414,6 +414,8 @@
 #ifndef MBF_HYPC8101_H_
 #define MBF_HYPC8101_H_
 
+#include "mbsys_reson.h"
+
 /* maximum number of beams and pixels */
 #define MBF_HYPC8101_MAXBEAMS 101
 #define MBF_HYPC8101_COMMENT_LENGTH 200

--- a/src/mbio/mbf_omghdcsj.h
+++ b/src/mbio/mbf_omghdcsj.h
@@ -55,6 +55,8 @@
 #ifndef MBF_OMGHDCSJ_H_
 #define MBF_OMGHDCSJ_H_
 
+#include "mbsys_hdcs.h"
+
 /* defines sizes and maximums */
 #define MBF_OMGHDCSJ_SUMMARY_SIZE 96
 #define MBF_OMGHDCSJ_SUMMARY_V4EXTRA_SIZE 168

--- a/src/mbio/mbr_3ddepthp.c
+++ b/src/mbio/mbr_3ddepthp.c
@@ -24,30 +24,21 @@
  * Date:	December 27, 2013
  */
 
-/* standard include files */
-#include <stdio.h>
-#include <math.h>
-#include <string.h>
 #include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_3datdepthlidar.h"
 
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
-
-/* local defines */
 #define ZERO_ALL 0
 #define ZERO_SOME 1
 #define MBF_3DDEPTHP_BUFFER_SIZE MB_COMMENT_MAXLINE
 
-/* essential function prototypes */
 int mbr_register_3ddepthp(int verbose, void *mbio_ptr, int *error);
 int mbr_info_3ddepthp(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_3dwisslp.c
+++ b/src/mbio/mbr_3dwisslp.c
@@ -24,25 +24,17 @@
  * Date:  December 27, 2013
  */
 
-/* standard include files */
-#include <stdio.h>
-#include <math.h>
-#include <string.h>
 #include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_3ddwissl.h"
 
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
-
-/* essential function prototypes */
 int mbr_register_3dwisslp(int verbose, void *mbio_ptr, int *error);
 int mbr_info_3dwisslp(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_3dwisslr.c
+++ b/src/mbio/mbr_3dwisslr.c
@@ -24,26 +24,18 @@
  * Date:  December 27, 2013
  */
 
-/* standard include files */
+#include <math.h>
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
-#include <assert.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_3ddwissl.h"
 
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
-
-/* essential function prototypes */
 int mbr_register_3dwisslr(int verbose, void *mbio_ptr, int *error);
 int mbr_info_3dwisslr(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_asciixyz.c
+++ b/src/mbio/mbr_asciixyz.c
@@ -30,16 +30,14 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_singlebeam.h"
 
 /* get NaN detector */
@@ -58,7 +56,6 @@ extern int isnand(float x);
 #define check_dnan(x) ((x) != (x))
 #endif
 
-/* essential function prototypes */
 int mbr_register_asciixyz(int verbose, void *mbio_ptr, int *error);
 int mbr_info_asciixyz(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_bchrtunb.c
+++ b/src/mbio/mbr_bchrtunb.c
@@ -25,21 +25,17 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_elac.h"
-#include "mbf_bchrtunb.h"
-
-/* include for byte swapping */
+#include "mb_status.h"
 #include "mb_swap.h"
+#include "mbf_bchrtunb.h"
+#include "mbsys_elac.h"
 
 /* essential function prototypes */
 int mbr_register_bchrtunb(int verbose, void *mbio_ptr, int *error);

--- a/src/mbio/mbr_bchrxunb.c
+++ b/src/mbio/mbr_bchrxunb.c
@@ -26,23 +26,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_elac.h"
-#include "mbf_bchrxunb.h"
-
-/* include for byte swapping */
+#include "mb_status.h"
 #include "mb_swap.h"
+#include "mbf_bchrxunb.h"
+#include "mbsys_elac.h"
 
-/* essential function prototypes */
 int mbr_register_bchrxunb(int verbose, void *mbio_ptr, int *error);
 int mbr_info_bchrxunb(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_cbat8101.c
+++ b/src/mbio/mbr_cbat8101.c
@@ -26,23 +26,18 @@
  *
  */
 
-/* standard include files */
 #include <stdio.h>
 #include <math.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_reson.h"
-#include "mbf_cbat8101.h"
-
-/* include for byte swapping on little-endian machines */
+#include "mb_status.h"
 #include "mb_swap.h"
+#include "mbf_cbat8101.h"
+#include "mbsys_reson.h"
 
-/* essential function prototypes */
 int mbr_register_cbat8101(int verbose, void *mbio_ptr, int *error);
 int mbr_info_cbat8101(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_cbat9001.c
+++ b/src/mbio/mbr_cbat9001.c
@@ -25,23 +25,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_reson.h"
-#include "mbf_cbat9001.h"
-
-/* include for byte swapping on little-endian machines */
+#include "mb_status.h"
 #include "mb_swap.h"
+#include "mbf_cbat9001.h"
+#include "mbsys_reson.h"
 
-/* essential function prototypes */
 int mbr_register_cbat9001(int verbose, void *mbio_ptr, int *error);
 int mbr_info_cbat9001(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_dsl120pf.c
+++ b/src/mbio/mbr_dsl120pf.c
@@ -25,20 +25,17 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_dsl.h"
+#include "mb_status.h"
 #include "mbf_dsl120pf.h"
+#include "mbsys_dsl.h"
 
-/* essential function prototypes */
 int mbr_register_dsl120pf(int verbose, void *mbio_ptr, int *error);
 int mbr_info_dsl120pf(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_dsl120sf.c
+++ b/src/mbio/mbr_dsl120sf.c
@@ -26,18 +26,16 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_dsl.h"
+#include "mb_status.h"
 #include "mbf_dsl120sf.h"
+#include "mbsys_dsl.h"
 
 /* essential function prototypes */
 int mbr_register_dsl120sf(int verbose, void *mbio_ptr, int *error);

--- a/src/mbio/mbr_edgjstar.c
+++ b/src/mbio/mbr_edgjstar.c
@@ -28,21 +28,18 @@
 /* Debug flag */
 //#define MBF_EDGJSTAR_DEBUG 1
 
-/* standard include files */
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mb_swap.h"
 #include "mbsys_jstar.h"
 
-/* essential function prototypes */
 int mbr_register_edgjstar(int verbose, void *mbio_ptr, int *error);
 int mbr_info_edgjstar(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_elmk2unb.c
+++ b/src/mbio/mbr_elmk2unb.c
@@ -26,21 +26,17 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_elacmk2.h"
-#include "mbf_elmk2unb.h"
-
-/* include for byte swapping */
+#include "mb_status.h"
 #include "mb_swap.h"
+#include "mbf_elmk2unb.h"
+#include "mbsys_elacmk2.h"
 
 /* essential function prototypes */
 int mbr_register_elmk2unb(int verbose, void *mbio_ptr, int *error);

--- a/src/mbio/mbr_em12darw.c
+++ b/src/mbio/mbr_em12darw.c
@@ -25,23 +25,16 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbf_em12darw.h"
 #include "mbsys_simrad.h"
-
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
 
 /* essential function prototypes */
 int mbr_register_em12darw(int verbose, void *mbio_ptr, int *error);

--- a/src/mbio/mbr_em12ifrm.c
+++ b/src/mbio/mbr_em12ifrm.c
@@ -25,25 +25,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
-#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_simrad.h"
+#include "mb_status.h"
 #include "mbf_em12ifrm.h"
-
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
+#include "mbsys_simrad.h"
 
 /* define IFREMER EM12 Archive format record size */
 #define MBF_EM12IFRM_RECORD_SIZE 1032

--- a/src/mbio/mbr_em300mba.c
+++ b/src/mbio/mbr_em300mba.c
@@ -26,20 +26,16 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_simrad2.h"
-
-/* include for byte swapping */
+#include "mb_status.h"
 #include "mb_swap.h"
+#include "mbsys_simrad2.h"
 
 /* turn on debug statements here */
 // #define MBR_EM300MBA_DEBUG 1

--- a/src/mbio/mbr_em300raw.c
+++ b/src/mbio/mbr_em300raw.c
@@ -25,20 +25,16 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
+#include "mb_define.h"
 #include "mb_status.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_simrad2.h"
-
-/* include for byte swapping */
 #include "mb_swap.h"
+#include "mbsys_simrad2.h"
 
 /* turn on debug statements here */
 // #define MBR_EM300RAW_DEBUG 1

--- a/src/mbio/mbr_em710mba.c
+++ b/src/mbio/mbr_em710mba.c
@@ -26,20 +26,16 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mbsys_simrad3.h"
-
-/* include for byte swapping */
+#include "mb_status.h"
 #include "mb_swap.h"
+#include "mbsys_simrad3.h"
 
 /* get NaN detector */
 #if defined(isnanf)

--- a/src/mbio/mbr_em710raw.c
+++ b/src/mbio/mbr_em710raw.c
@@ -26,20 +26,16 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mbsys_simrad3.h"
-
-/* include for byte swapping */
+#include "mb_status.h"
 #include "mb_swap.h"
+#include "mbsys_simrad3.h"
 
 /* get NaN detector */
 #if defined(isnanf)

--- a/src/mbio/mbr_emoldraw.c
+++ b/src/mbio/mbr_emoldraw.c
@@ -26,25 +26,20 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_simrad.h"
-
-/* include for byte swapping */
+#include "mb_status.h"
 #include "mb_swap.h"
+#include "mbsys_simrad.h"
 
 /* turn on debug statements here */
 /*#define MBR_EMOLDRAW_DEBUG 1*/
 
-/* essential function prototypes */
 int mbr_register_emoldraw(int verbose, void *mbio_ptr, int *error);
 int mbr_info_emoldraw(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_gsfgenmb.c
+++ b/src/mbio/mbr_gsfgenmb.c
@@ -25,24 +25,21 @@
  *
  */
 
-/* standard include files */
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbf_gsfgenmb.h"
 #include "mbsys_gsf.h"
 
 /* GSF error value */
 extern int gsfError;
 
-/* essential function prototypes */
 int mbr_register_gsfgenmb(int verbose, void *mbio_ptr, int *error);
 int mbr_info_gsfgenmb(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hir2rnav.c
+++ b/src/mbio/mbr_hir2rnav.c
@@ -26,19 +26,16 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_singlebeam.h"
 
-/* essential function prototypes */
 int mbr_register_hir2rnav(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hir2rnav(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hs10jams.c
+++ b/src/mbio/mbr_hs10jams.c
@@ -141,19 +141,16 @@
 #define MBF_HS10JAMS_MAXLINE 800
 #define MBF_HS10JAMS_LENGTH 717
 
-/* standard include files */
 #include <stdio.h>
 #include <math.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_hs10.h"
 
-/* essential function prototypes */
 int mbr_register_hs10jams(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hs10jams(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hsds2lam.c
+++ b/src/mbio/mbr_hsds2lam.c
@@ -26,22 +26,19 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
 #include "mb_define.h"
-#include "mb_status.h"
 #include "mb_format.h"
 #include "mb_io.h"
+#include "mb_status.h"
 #include "mbsys_atlas.h"
 
 /* turn on debug statements here */
 /* #define MBR_HSDS2LAM_DEBUG 1 */
 
-/* essential function prototypes */
 int mbr_register_hsds2lam(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hsds2lam(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hsds2raw.c
+++ b/src/mbio/mbr_hsds2raw.c
@@ -27,22 +27,19 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
 #include "mb_define.h"
-#include "mb_status.h"
 #include "mb_format.h"
 #include "mb_io.h"
+#include "mb_status.h"
 #include "mbsys_atlas.h"
 
 /* turn on debug statements here */
 /* #define MBR_HSDS2RAW_DEBUG 1 */
 
-/* essential function prototypes */
 int mbr_register_hsds2raw(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hsds2raw(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hsldedmb.c
+++ b/src/mbio/mbr_hsldedmb.c
@@ -25,29 +25,22 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_hsds.h"
+#include "mb_status.h"
+#include "mb_swap.h"
 #include "mbf_hsldedmb.h"
+#include "mbsys_hsds.h"
 
 /* time conversion constants */
 #define MININYEAR 525600.0
 #define MININDAY 1440.0
 
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
-
-/* essential function prototypes */
 int mbr_register_hsldedmb(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hsldedmb(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hsldeoih.c
+++ b/src/mbio/mbr_hsldeoih.c
@@ -25,29 +25,22 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_hsds.h"
-#include "mbf_hsldeoih.h"
-
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
+#include "mb_status.h"
 #include "mb_swap.h"
-#endif
+#include "mbf_hsldeoih.h"
+#include "mbsys_hsds.h"
 
 /* local defines */
 #define ZERO_ALL 0
 #define ZERO_SOME 1
 
-/* essential function prototypes */
 int mbr_register_hsldeoih(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hsldeoih(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hsmdaraw.c
+++ b/src/mbio/mbr_hsmdaraw.c
@@ -27,20 +27,17 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
 #include "mb_define.h"
-#include "mb_status.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mbsys_hsmd.h"
+#include "mb_status.h"
 #include "mbf_hsmdaraw.h"
+#include "mbsys_hsmd.h"
 
-/* essential function prototypes */
 int mbr_register_hsmdaraw(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hsmdaraw(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hsmdldih.c
+++ b/src/mbio/mbr_hsmdldih.c
@@ -23,25 +23,19 @@
  *
  * Author:	David W. Caress
  * Date:	September 26, 1995
- *
- *
- *
  */
 
-/* standard include files */
 #include <stdio.h>
 #include <math.h>
 #include <string.h>
 
-/* mbio include files */
 #include "mb_define.h"
-#include "mb_status.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mbsys_hsmd.h"
+#include "mb_status.h"
 #include "mbf_hsmdldih.h"
+#include "mbsys_hsmd.h"
 
-/* essential function prototypes */
 int mbr_register_hsmdldih(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hsmdldih(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hsunknwn.c
+++ b/src/mbio/mbr_hsunknwn.c
@@ -60,22 +60,19 @@
  * end of the first line, after the center water depth.
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_hsds.h"
 
 #define LINE1SIZE 87
 #define LINE2SIZE 415
 
-/* essential function prototypes */
 int mbr_register_hsunknwn(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hsunknwn(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hsuricen.c
+++ b/src/mbio/mbr_hsuricen.c
@@ -25,25 +25,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_hsds.h"
-#include "mbf_hsuricen.h"
-
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
 #include "mb_swap.h"
-#endif
+#include "mb_status.h"
+#include "mbf_hsuricen.h"
+#include "mbsys_hsds.h"
 
-/* essential function prototypes */
 int mbr_register_hsuricen(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hsuricen(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hsurivax.c
+++ b/src/mbio/mbr_hsurivax.c
@@ -26,29 +26,20 @@
  *
  * Author:	D. W. Caress
  * Date:	February 2, 1993
- *
- *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_hsds.h"
-#include "mbf_hsuricen.h"
-
-/* include for byte swapping on little-endian machines */
-#ifndef BYTESWAPPED
+#include "mb_status.h"
 #include "mb_swap.h"
-#endif
+#include "mbf_hsuricen.h"
+#include "mbsys_hsds.h"
 
-/* essential function prototypes */
 int mbr_register_hsurivax(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hsurivax(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hydrob93.c
+++ b/src/mbio/mbr_hydrob93.c
@@ -28,22 +28,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_singlebeam.h"
 
-/* local defines */
 #define MBF_HYDROB93_RECORD_LENGTH 14
 
-/* essential function prototypes */
 int mbr_register_hydrob93(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hydrob93(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_hypc8101.c
+++ b/src/mbio/mbr_hypc8101.c
@@ -22,24 +22,19 @@
  *
  * Author:	D. W. Caress
  * Date:	December 10, 1998
- *
- *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_reson.h"
+#include "mb_status.h"
 #include "mbf_hypc8101.h"
+#include "mbsys_reson.h"
 
-/* essential function prototypes */
 int mbr_register_hypc8101(int verbose, void *mbio_ptr, int *error);
 int mbr_info_hypc8101(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_image83p.c
+++ b/src/mbio/mbr_image83p.c
@@ -36,16 +36,14 @@
  *   3. Comment records are supported - this is specific to MB-System.
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_image83p.h"
 
 /* time conversion constants */
@@ -54,12 +52,6 @@
 
 #define MBF_IMAGE83P_BUFFER_SIZE 2176
 
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
-
-/* essential function prototypes */
 int mbr_register_image83p(int verbose, void *mbio_ptr, int *error);
 int mbr_info_image83p(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_imagemba.c
+++ b/src/mbio/mbr_imagemba.c
@@ -35,16 +35,14 @@
  *   3. Comment records are supported.
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_image83p.h"
 
 /* time conversion constants */
@@ -53,11 +51,6 @@
 
 #define MBF_IMAGEMBA_BUFFER_SIZE 7456
 #define MBF_IMAGEMBA_BEAM_SIZE 15
-
-/* include for byte swapping */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
 
 /* essential function prototypes */
 int mbr_register_imagemba(int verbose, void *mbio_ptr, int *error);

--- a/src/mbio/mbr_kemkmall.c
+++ b/src/mbio/mbr_kemkmall.c
@@ -25,27 +25,21 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
+#include <assert.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <assert.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_kmbes.h"
-
-/* include for byte swapping */
-#include "mb_swap.h"
 
 /* turn on debug statements here */
 //#define MBR_KEMKMALL_DEBUG 1
 
-/* essential function prototypes */
 int mbr_register_kemkmall(int verbose, void *mbio_ptr, int *error);
 int mbr_info_kemkmall(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
            char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_l3xseraw.c
+++ b/src/mbio/mbr_l3xseraw.c
@@ -27,20 +27,15 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_xse.h"
-
-/* include for byte swapping */
-#include "mb_swap.h"
 
 /* #define MB_DEBUG 1 */
 /* #define MB_DEBUG2 1 */
@@ -52,7 +47,6 @@
 #define SWAPFLAG MB_NO
 #endif
 
-/* essential function prototypes */
 int mbr_register_l3xseraw(int verbose, void *mbio_ptr, int *error);
 int mbr_info_l3xseraw(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_mbarirov.c
+++ b/src/mbio/mbr_mbarirov.c
@@ -26,20 +26,17 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_singlebeam.h"
+#include "mb_status.h"
 #include "mbf_mbarirov.h"
+#include "mbsys_singlebeam.h"
 
-/* essential function prototypes */
 int mbr_register_mbarirov(int verbose, void *mbio_ptr, int *error);
 int mbr_info_mbarirov(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_mbarrov2.c
+++ b/src/mbio/mbr_mbarrov2.c
@@ -22,24 +22,19 @@
  *
  * Author:	D. W. Caress
  * Date:	May 20, 1999
- *
- *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_singlebeam.h"
+#include "mb_status.h"
 #include "mbf_mbarrov2.h"
+#include "mbsys_singlebeam.h"
 
-/* essential function prototypes */
 int mbr_register_mbarrov2(int verbose, void *mbio_ptr, int *error);
 int mbr_info_mbarrov2(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_mbldeoih.c
+++ b/src/mbio/mbr_mbldeoih.c
@@ -75,24 +75,17 @@
  * are documented in the mbsys_ldeoih.h file.
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
+#include "mb_swap.h"
 #include "mbsys_ldeoih.h"
 
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
-
-/* essential function prototypes */
 int mbr_register_mbldeoih(int verbose, void *mbio_ptr, int *error);
 int mbr_info_mbldeoih(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_mbnetcdf.c
+++ b/src/mbio/mbr_mbnetcdf.c
@@ -22,27 +22,22 @@
  *
  * Author:	D. W. Caress
  * Date:	January 25, 2002
- *
- *
  */
 
-/* standard include files */
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
 #include <time.h>
-#include <netcdf.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include <netcdf.h>
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
 #include "mb_process.h"
+#include "mb_status.h"
 #include "mbsys_netcdf.h"
 
-/* essential function prototypes */
 int mbr_register_mbnetcdf(int verbose, void *mbio_ptr, int *error);
 int mbr_info_mbnetcdf(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_mbpronav.c
+++ b/src/mbio/mbr_mbpronav.c
@@ -25,20 +25,17 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_singlebeam.h"
+#include "mb_status.h"
 #include "mbf_mbpronav.h"
+#include "mbsys_singlebeam.h"
 
-/* essential function prototypes */
 int mbr_register_mbpronav(int verbose, void *mbio_ptr, int *error);
 int mbr_info_mbpronav(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_mgd77dat.c
+++ b/src/mbio/mbr_mgd77dat.c
@@ -22,24 +22,19 @@
  *
  * Author:	D. W. Caress
  * Date:	May 18, 1999
- *
- *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_singlebeam.h"
+#include "mb_status.h"
 #include "mbf_mgd77dat.h"
+#include "mbsys_singlebeam.h"
 
-/* essential function prototypes */
 int mbr_register_mgd77dat(int verbose, void *mbio_ptr, int *error);
 int mbr_info_mgd77dat(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_mgd77tab.c
+++ b/src/mbio/mbr_mgd77tab.c
@@ -25,16 +25,14 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_singlebeam.h"
 
 /*

--- a/src/mbio/mbr_mr1aldeo.c
+++ b/src/mbio/mbr_mr1aldeo.c
@@ -25,21 +25,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 
-/* mbio include files */
 #include "mb_define.h"
-#include "mb_status.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mbsys_mr1.h"
+#include "mb_status.h"
 #include "mbf_mr1aldeo.h"
+#include "mbsys_mr1.h"
 
-/* essential function prototypes */
 int mbr_register_mr1aldeo(int verbose, void *mbio_ptr, int *error);
 int mbr_info_mr1aldeo(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_mr1bldeo.c
+++ b/src/mbio/mbr_mr1bldeo.c
@@ -25,21 +25,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 
-/* mbio include files */
 #include "mb_define.h"
-#include "mb_status.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mbsys_mr1b.h"
+#include "mb_status.h"
 #include "mbf_mr1bldeo.h"
+#include "mbsys_mr1b.h"
 
-/* essential function prototypes */
 int mbr_register_mr1bldeo(int verbose, void *mbio_ptr, int *error);
 int mbr_info_mr1bldeo(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_mr1prhig.c
+++ b/src/mbio/mbr_mr1prhig.c
@@ -25,21 +25,17 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 
-/* mbio include files */
 #include "mb_define.h"
-#include "mb_status.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mbsys_mr1.h"
+#include "mb_status.h"
 #include "mbf_mr1prhig.h"
-
-/* essential function prototypes */
+#include "mbsys_mr1.h"
 
 int mbr_register_mr1prhig(int verbose, void *mbio_ptr, int *error);
 int mbr_info_mr1prhig(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,

--- a/src/mbio/mbr_mr1prvr2.c
+++ b/src/mbio/mbr_mr1prvr2.c
@@ -22,26 +22,21 @@
  *
  * Author:	D. W. Caress
  * Date:	March 6, 2003
- *
- *
  */
 
-/* standard include files */
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
 #include <time.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbbs.h"
 #include "mbsys_mr1v2001.h"
 
-/* essential function prototypes */
 int mbr_register_mr1prvr2(int verbose, void *mbio_ptr, int *error);
 int mbr_info_mr1prvr2(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_mstiffss.c
+++ b/src/mbio/mbr_mstiffss.c
@@ -25,20 +25,17 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_mstiff.h"
+#include "mb_status.h"
 #include "mbf_mstiffss.h"
+#include "mbsys_mstiff.h"
 
-/* essential function prototypes */
 int mbr_register_mstiffss(int verbose, void *mbio_ptr, int *error);
 int mbr_info_mstiffss(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_nvnetcdf.c
+++ b/src/mbio/mbr_nvnetcdf.c
@@ -27,22 +27,19 @@
  */
 /* #define MBNETCDF_DEBUG 1 */
 
-/* standard include files */
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
 #include <time.h>
-#include <netcdf.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include <netcdf.h>
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_navnetcdf.h"
 
-/* essential function prototypes */
 int mbr_register_nvnetcdf(int verbose, void *mbio_ptr, int *error);
 int mbr_info_nvnetcdf(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_oicgeoda.c
+++ b/src/mbio/mbr_oicgeoda.c
@@ -26,26 +26,19 @@
  *
  */
 
-/* standard include files */
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
+#include "mb_swap.h"
 #include "mbf_oicgeoda.h"
 #include "mbsys_oic.h"
 
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
-
-/* essential function prototypes */
 int mbr_register_oicgeoda(int verbose, void *mbio_ptr, int *error);
 int mbr_info_oicgeoda(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_oicmbari.c
+++ b/src/mbio/mbr_oicmbari.c
@@ -26,26 +26,19 @@
  *
  */
 
-/* standard include files */
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
+#include "mb_swap.h"
 #include "mbf_oicmbari.h"
 #include "mbsys_oic.h"
 
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
-
-/* essential function prototypes */
 int mbr_register_oicmbari(int verbose, void *mbio_ptr, int *error);
 int mbr_info_oicmbari(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_omghdcsj.c
+++ b/src/mbio/mbr_omghdcsj.c
@@ -26,26 +26,19 @@
  *
  */
 
-/* standard include files */
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_hdcs.h"
-#include "mbf_omghdcsj.h"
-
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
+#include "mb_status.h"
 #include "mb_swap.h"
-#endif
+#include "mbf_omghdcsj.h"
+#include "mbsys_hdcs.h"
 
-/* essential function prototypes */
 int mbr_register_omghdcsj(int verbose, void *mbio_ptr, int *error);
 int mbr_info_omghdcsj(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_photgram.c
+++ b/src/mbio/mbr_photgram.c
@@ -116,25 +116,19 @@
  *              end identifiers
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_stereopair.h"
-
-/* include for byte swapping */
-#include "mb_swap.h"
 
 /* turn on debug statements here */
 /* #define MBR_PHOTGRAM_DEBUG 1 */
 
-/* essential function prototypes */
 int mbr_register_photgram(int verbose, void *mbio_ptr, int *error);
 int mbr_info_photgram(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_reson7kr.c
+++ b/src/mbio/mbr_reson7kr.c
@@ -25,27 +25,22 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_reson7k.h"
-
-/* include for byte swapping */
+#include "mb_status.h"
 #include "mb_swap.h"
+#include "mbsys_reson7k.h"
 
 /* turn on debug statements here */
 //#define MBR_RESON7KR_DEBUG 1
 //#define MBR_RESON7KR_DEBUG2 1
 //#define MBR_RESON7KR_DEBUG3 1
 
-/* essential function prototypes */
 int mbr_register_reson7kr(int verbose, void *mbio_ptr, int *error);
 int mbr_info_reson7kr(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_samesurf.c
+++ b/src/mbio/mbr_samesurf.c
@@ -26,20 +26,17 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "../surf/mb_sapi.h"
+#include "mb_status.h"
 #include "mbsys_surf.h"
+#include "../surf/mb_sapi.h"
 
-/* essential function prototypes */
 int mbr_register_samesurf(int verbose, void *mbio_ptr, int *error);
 int mbr_info_samesurf(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_sb2000sb.c
+++ b/src/mbio/mbr_sb2000sb.c
@@ -51,24 +51,16 @@
  * ascii comment record (kind = 2).
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_sb2000.h"
 
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
-
-/* essential function prototypes */
 int mbr_register_sb2000sb(int verbose, void *mbio_ptr, int *error);
 int mbr_info_sb2000sb(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_sb2000ss.c
+++ b/src/mbio/mbr_sb2000ss.c
@@ -51,24 +51,16 @@
  * ascii comment record (kind = 2).
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_sb2000.h"
 
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
-
-/* essential function prototypes */
 int mbr_register_sb2000ss(int verbose, void *mbio_ptr, int *error);
 int mbr_info_sb2000ss(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_sb2100bi.c
+++ b/src/mbio/mbr_sb2100bi.c
@@ -36,16 +36,14 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_sb2100.h"
 
 /* define id's for the different types of raw records */
@@ -68,7 +66,6 @@ char *mbf_sb2100bi_labels[] = {"NONE    ", "SB21BIFH", "SB21BITR", "SB21BIPR", "
 /* define end of record label */
 char mbf_sb2100bi_eor[2] = {'\r', '\n'};
 
-/* essential function prototypes */
 int mbr_register_sb2100b1(int verbose, void *mbio_ptr, int *error);
 int mbr_info_sb2100b1(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_sb2100rw.c
+++ b/src/mbio/mbr_sb2100rw.c
@@ -25,25 +25,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_sb2100.h"
-#include "mbf_sb2100rw.h"
-
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
+#include "mb_status.h"
 #include "mb_swap.h"
-#endif
+#include "mbf_sb2100rw.h"
+#include "mbsys_sb2100.h"
 
-/* essential function prototypes */
 int mbr_register_sb2100rw(int verbose, void *mbio_ptr, int *error);
 int mbr_info_sb2100rw(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_sbifremr.c
+++ b/src/mbio/mbr_sbifremr.c
@@ -27,23 +27,20 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_sb.h"
+#include "mb_status.h"
 #include "mbf_sbifremr.h"
+#include "mbsys_sb.h"
 
 /* angle spacing for SeaBeam Classic */
 #define ANGLE_SPACING 3.75
 
-/* essential function prototypes */
 int mbr_register_sbifremr(int verbose, void *mbio_ptr, int *error);
 int mbr_info_sbifremr(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_sbsiocen.c
+++ b/src/mbio/mbr_sbsiocen.c
@@ -25,25 +25,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_sb.h"
-#include "mbf_sbsiocen.h"
-
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
+#include "mb_status.h"
 #include "mb_swap.h"
-#endif
+#include "mbf_sbsiocen.h"
+#include "mbsys_sb.h"
 
-/* essential function prototypes */
 int mbr_register_sbsiocen(int verbose, void *mbio_ptr, int *error);
 int mbr_info_sbsiocen(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_sbsiolsi.c
+++ b/src/mbio/mbr_sbsiolsi.c
@@ -25,25 +25,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_sb.h"
-#include "mbf_sbsiolsi.h"
-
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
+#include "mb_status.h"
 #include "mb_swap.h"
-#endif
+#include "mbf_sbsiolsi.h"
+#include "mbsys_sb.h"
 
-/* essential function prototypes */
 int mbr_register_sbsiolsi(int verbose, void *mbio_ptr, int *error);
 int mbr_info_sbsiolsi(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_sbsiomrg.c
+++ b/src/mbio/mbr_sbsiomrg.c
@@ -25,25 +25,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_sb.h"
-#include "mbf_sbsiomrg.h"
-
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
+#include "mb_status.h"
 #include "mb_swap.h"
-#endif
+#include "mbf_sbsiomrg.h"
+#include "mbsys_sb.h"
 
-/* essential function prototypes */
 int mbr_register_sbsiomrg(int verbose, void *mbio_ptr, int *error);
 int mbr_info_sbsiomrg(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_sbsioswb.c
+++ b/src/mbio/mbr_sbsioswb.c
@@ -22,29 +22,20 @@
  *
  * Author:	D. W. Caress
  * Date:	February 2, 1993
- *
- *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
+#include "mb_swap.h"
 #include "mbsys_sb.h"
 #include "mbf_sbsioswb.h"
 
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
-#include "mb_swap.h"
-#endif
-
-/* essential function prototypes */
 int mbr_register_sbsioswb(int verbose, void *mbio_ptr, int *error);
 int mbr_info_sbsioswb(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_sburicen.c
+++ b/src/mbio/mbr_sburicen.c
@@ -25,25 +25,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_sb.h"
-#include "mbf_sburicen.h"
-
-/* include for byte swapping on little-endian machines */
-#ifdef BYTESWAPPED
+#include "mb_status.h"
 #include "mb_swap.h"
-#endif
+#include "mbf_sburicen.h"
+#include "mbsys_sb.h"
 
-/* essential function prototypes */
 int mbr_register_sburicen(int verbose, void *mbio_ptr, int *error);
 int mbr_info_sburicen(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_sburivax.c
+++ b/src/mbio/mbr_sburivax.c
@@ -29,25 +29,18 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_sb.h"
-#include "mbf_sburicen.h"
-
-/* include for byte swapping on little-endian machines */
-#ifndef BYTESWAPPED
+#include "mb_status.h"
 #include "mb_swap.h"
-#endif
+#include "mbf_sburicen.h"
+#include "mbsys_sb.h"
 
-/* essential function prototypes */
 int mbr_register_sburivax(int verbose, void *mbio_ptr, int *error);
 int mbr_info_sburivax(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_segysegy.c
+++ b/src/mbio/mbr_segysegy.c
@@ -22,24 +22,19 @@
  *
  * Author:	D. W. Caress
  * Date:	October 27, 2006
-
- *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_singlebeam.h"
 #include "mb_segy.h"
+#include "mb_status.h"
+#include "mbsys_singlebeam.h"
 
-/* essential function prototypes */
 int mbr_register_segysegy(int verbose, void *mbio_ptr, int *error);
 int mbr_info_segysegy(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_swplssxi.c
+++ b/src/mbio/mbr_swplssxi.c
@@ -23,30 +23,22 @@
  *
  * Author:	David Finlayson and D. W. Caress
  * Date:	February 26, 2013
- *
- *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 
-/* mbio include files */
-#include "mb_status.h"
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
+#include "mb_status.h"
 #include "mbsys_swathplus.h"
-
-/* include for byte swapping */
-#include "mb_swap.h"
 
 /* turn on debug statements here */
 // #define MBF_SWPLSSXI_DEBUG 1
 
-/* essential function prototypes */
 int mbr_register_swplssxi(int verbose, void *mbio_ptr, int *error);
 int mbr_info_swplssxi(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_swplssxp.c
+++ b/src/mbio/mbr_swplssxp.c
@@ -26,27 +26,21 @@
  *
  */
 
-/* standard include files */
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
 #include <time.h>
 
-/* mbio include files */
-#include "mb_status.h"
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
+#include "mb_status.h"
 #include "mbsys_swathplus.h"
-
-/* include for byte swapping */
-#include "mb_swap.h"
 
 /* turn on debug statements here */
 // #define MBF_SWPLSSXP_DEBUG 1
 
-/* essential function prototypes */
 int mbr_register_swplssxp(int verbose, void *mbio_ptr, int *error);
 int mbr_info_swplssxp(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_tempform.c
+++ b/src/mbio/mbr_tempform.c
@@ -25,25 +25,20 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
+/* #include "mb_swap.h" */
 #include "mbsys_templatesystem.h"
-
-/* include for byte swapping */
-#include "mb_swap.h"
 
 /* turn on debug statements here */
 /* #define MBR_TEMPFORM_DEBUG 1 */
 
-/* essential function prototypes */
 int mbr_register_tempform(int verbose, void *mbio_ptr, int *error);
 int mbr_info_tempform(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_wasspenl.c
+++ b/src/mbio/mbr_wasspenl.c
@@ -25,25 +25,20 @@
  *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_wassp.h"
-
-/* include for byte swapping */
+#include "mb_status.h"
 #include "mb_swap.h"
+#include "mbsys_wassp.h"
 
 /* turn on debug statements here */
 /* #define MBR_WASSPENLDEBUG 1 */
 
-/* essential function prototypes */
 int mbr_register_wasspenl(int verbose, void *mbio_ptr, int *error);
 int mbr_info_wasspenl(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbr_xtfb1624.c
+++ b/src/mbio/mbr_xtfb1624.c
@@ -25,20 +25,16 @@
  *
  * Author:	D. W. Caress
  * Date:	2 May 2012 (when the code was brought into the MB-System archive as a read-only i/o module)
- *
- *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
-#include "mb_status.h"
+#include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
+#include "mb_status.h"
 #include "mbsys_benthos.h"
 
 /* turn on debug statements here */

--- a/src/mbio/mbr_xtfr8101.c
+++ b/src/mbio/mbr_xtfr8101.c
@@ -22,27 +22,22 @@
  *
  * Author:	D. W. Caress
  * Date:	August 26, 2001
- *
- *
  */
 
-/* standard include files */
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 
-/* mbio include files */
+#include "mb_define.h"
 #include "mb_status.h"
 #include "mb_format.h"
 #include "mb_io.h"
-#include "mb_define.h"
-#include "mbsys_reson8k.h"
 #include "mbf_xtfr8101.h"
+#include "mbsys_reson8k.h"
 
 /* turn on debug statements here */
 /* #define MBR_XTFR8101_DEBUG 1 */
 
-/* essential function prototypes */
 int mbr_register_xtfr8101(int verbose, void *mbio_ptr, int *error);
 int mbr_info_xtfr8101(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,
                       char *system_name, char *format_description, int *numfile, int *filetype, int *variable_beams,

--- a/src/mbio/mbsys_swathplus.c
+++ b/src/mbio/mbsys_swathplus.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "mb_define.h"
 #include "mb_format.h"


### PR DESCRIPTION
Also:
- remove some unused includes of mb_swap.h
- remove `#ifdef BYTESWAPPED` around include of mb_swap.
  If those are needed, put them in the header