### PR TITLE
mbio: `#define`s -> `static const`

### DIFF
--- a/src/mbio/mb_esf.c
+++ b/src/mbio/mb_esf.c
@@ -1,6 +1,6 @@
 /*--------------------------------------------------------------------
  *    The MB-system:	mb_esf.c	4/10/2003
-  *
+ *
  *    Copyright (c) 2003-2019 by
  *    David W. Caress (caress@mbari.org)
  *      Monterey Bay Aquarium Research Institute
@@ -918,7 +918,7 @@ int mb_esf_close(int verbose, struct mb_esf_struct *esf, int *error) {
  */
 
 #define NATURAL
-#define THRESHOLD 16 /* Best choice for natural merge cut-off. */
+static const int THRESHOLD = 16; /* Best choice for natural merge cut-off. */
 
 /* #define NATURAL to get hybrid natural merge.
  * (The default is pairwise merging.)

--- a/src/mbio/mb_rt.c
+++ b/src/mbio/mb_rt.c
@@ -34,23 +34,23 @@
 #include "mb_define.h"
 
 /* raytracing defines */
-#define MB_RT_GRADIENT_TOLERANCE 0.00001
-#define MB_RT_LAYER_HOMOGENEOUS 0
-#define MB_RT_LAYER_GRADIENT 1
-#define MB_RT_ERROR 0
-#define MB_RT_DOWN 1
-#define MB_RT_UP 2
-#define MB_RT_DOWN_TURN 3
-#define MB_RT_UP_TURN 4
-#define MB_RT_OUT_BOTTOM 5
-#define MB_RT_OUT_TOP 6
-#define MB_RT_NUMBER_SEGMENTS 5
-#define MB_RT_PLOT_MODE_OFF 0
-#define MB_RT_PLOT_MODE_ON 1
-#define MB_RT_PLOT_MODE_TABLE 2
-#define MB_SSV_NO_USE 0
-#define MB_SSV_CORRECT 1
-#define MB_SSV_INCORRECT 2
+static double MB_RT_GRADIENT_TOLERANCE = 0.00001;
+static const int MB_RT_LAYER_HOMOGENEOUS = 0;;
+static const int MB_RT_LAYER_GRADIENT = 1;
+static const int MB_RT_ERROR = 0;
+static const int MB_RT_DOWN = 1;
+static const int MB_RT_UP = 2;
+static const int MB_RT_DOWN_TURN = 3;
+static const int MB_RT_UP_TURN = 4;
+static const int MB_RT_OUT_BOTTOM = 5;
+static const int MB_RT_OUT_TOP = 6;
+static const int MB_RT_NUMBER_SEGMENTS = 5;
+static const int MB_RT_PLOT_MODE_OFF = 0;
+static const int MB_RT_PLOT_MODE_ON = 1;
+static const int MB_RT_PLOT_MODE_TABLE = 2;
+/* static const int MB_SSV_NO_USE = 0; */
+static const int MB_SSV_CORRECT = 1;
+static const int MB_SSV_INCORRECT = 2;
 
 /* velocity model structure */
 struct velocity_model {

--- a/src/mbio/mbr_3ddepthp.c
+++ b/src/mbio/mbr_3ddepthp.c
@@ -35,8 +35,6 @@
 #include "mb_status.h"
 #include "mbsys_3datdepthlidar.h"
 
-#define ZERO_ALL 0
-#define ZERO_SOME 1
 #define MBF_3DDEPTHP_BUFFER_SIZE MB_COMMENT_MAXLINE
 
 int mbr_3ddepthp_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *error);

--- a/src/mbio/mbr_em12ifrm.c
+++ b/src/mbio/mbr_em12ifrm.c
@@ -40,8 +40,8 @@
 
 /* define IFREMER EM12 Archive format record size */
 #define MBF_EM12IFRM_RECORD_SIZE 1032
-#define MBF_EM12IFRM_SSHEADER_SIZE 42
-#define MBF_EM12IFRM_SSBEAMHEADER_SIZE 6
+static const size_t MBF_EM12IFRM_SSHEADER_SIZE = 42;
+static const size_t MBF_EM12IFRM_SSBEAMHEADER_SIZE = 6;
 
 int mbr_zero_em12ifrm(int verbose, char *data_ptr, int *error);
 int mbr_em12ifrm_rd_data(int verbose, void *mbio_ptr, int *error);

--- a/src/mbio/mbr_em710mba.c
+++ b/src/mbio/mbr_em710mba.c
@@ -53,11 +53,6 @@ extern int isnanf(float x);
 #define check_fnan(x) ((x) != (x))
 #endif
 
-/* set precision of iterative raytracing depth & distance matching */
-#define MBR_EM710MBA_BATH_RECALC_PRECISION 0.0001
-#define MBR_EM710MBA_BATH_RECALC_NCALCMAX 50
-#define MBR_EM710MBA_BATH_RECALC_ANGLEMODE 0
-
 /* control method of estimating range and angles for bathymetry recalculation
     - by default the code solves for the angles and heave offsets that come
       close to matching the original reported bathymetry by raytracing through

--- a/src/mbio/mbr_em710raw.c
+++ b/src/mbio/mbr_em710raw.c
@@ -53,11 +53,6 @@ extern int isnanf(float x);
 #define check_fnan(x) ((x) != (x))
 #endif
 
-/* set precision of iterative raytracing depth & distance matching */
-#define MBR_EM710RAW_BATH_RECALC_PRECISION 0.0001
-#define MBR_EM710RAW_BATH_RECALC_NCALCMAX 50
-#define MBR_EM710RAW_BATH_RECALC_ANGLEMODE 0
-
 /* control method of estimating range and angles for bathymetry recalculation
     - by default the code solves for the angles and heave offsets that come
       close to matching the original reported bathymetry by raytracing through

--- a/src/mbio/mbr_hs10jams.c
+++ b/src/mbio/mbr_hs10jams.c
@@ -138,9 +138,6 @@
  *
  */
 
-#define MBF_HS10JAMS_MAXLINE 800
-#define MBF_HS10JAMS_LENGTH 717
-
 #include <stdio.h>
 #include <math.h>
 #include <string.h>
@@ -150,6 +147,9 @@
 #include "mb_io.h"
 #include "mb_status.h"
 #include "mbsys_hs10.h"
+
+#define MBF_HS10JAMS_MAXLINE 800
+static const size_t MBF_HS10JAMS_LENGTH = 717;
 
 /*--------------------------------------------------------------------*/
 int mbr_info_hs10jams(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,

--- a/src/mbio/mbr_hsatlraw.c
+++ b/src/mbio/mbr_hsatlraw.c
@@ -37,9 +37,8 @@
 #include "mb_status.h"
 #include "mbsys_hsds.h"
 
-/* local defines */
-#define ZERO_ALL 0
-#define ZERO_SOME 1
+static const int ZERO_ALL = 0;
+static const int ZERO_SOME = 1;
 
 /*--------------------------------------------------------------------*/
 int mbr_register_hsatlraw(int verbose, void *mbio_ptr, int *error) {

--- a/src/mbio/mbr_hsunknwn.c
+++ b/src/mbio/mbr_hsunknwn.c
@@ -70,8 +70,8 @@
 #include "mb_status.h"
 #include "mbsys_hsds.h"
 
-#define LINE1SIZE 87
-#define LINE2SIZE 415
+static const size_t LINE1SIZE = 87;
+static const size_t LINE2SIZE = 415;
 
 /*--------------------------------------------------------------------*/
 int mbr_info_hsunknwn(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,

--- a/src/mbio/mbr_imagemba.c
+++ b/src/mbio/mbr_imagemba.c
@@ -46,7 +46,7 @@
 #include "mbsys_image83p.h"
 
 #define MBF_IMAGEMBA_BUFFER_SIZE 7456
-#define MBF_IMAGEMBA_BEAM_SIZE 15
+static const int MBF_IMAGEMBA_BEAM_SIZE = 15;
 
 /*--------------------------------------------------------------------*/
 int mbr_info_imagemba(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,

--- a/src/mbio/mbr_mbldeoih.c
+++ b/src/mbio/mbr_mbldeoih.c
@@ -87,18 +87,18 @@
 #include "mbsys_ldeoih.h"
 
 /* define header sizes */
-#define MBF_MBLDEOIH_V1HEADERSIZE 38
-#define MBF_MBLDEOIH_V2HEADERSIZE 44
-#define MBF_MBLDEOIH_V3HEADERSIZE 48
-#define MBF_MBLDEOIH_V4HEADERSIZE 90
+static const int MBF_MBLDEOIH_V1HEADERSIZE = 38;
+static const int MBF_MBLDEOIH_V2HEADERSIZE = 44;
+static const int MBF_MBLDEOIH_V3HEADERSIZE = 48;
+static const int MBF_MBLDEOIH_V4HEADERSIZE = 90;
 #define MBF_MBLDEOIH_V5HEADERSIZE 98
-#define MBF_MBLDEOIH_ID_COMMENT1 8995  /* ## */
-#define MBF_MBLDEOIH_ID_COMMENT2 25443 /* cc */
-#define MBF_MBLDEOIH_ID_DATA1 25700    /* dd */
-#define MBF_MBLDEOIH_ID_DATA2 28270    /* nn */
-#define MBF_MBLDEOIH_ID_DATA3 17476    /* DD */
-#define MBF_MBLDEOIH_ID_DATA4 22068    /* V4 big endian, 13398 little endian*/
-#define MBF_MBLDEOIH_ID_DATA5 22069    /* V5 bin endian, 13654 little endian */
+static const int MBF_MBLDEOIH_ID_COMMENT1 = 8995;  /* ## */
+static const int MBF_MBLDEOIH_ID_COMMENT2 = 25443; /* cc */
+static const int MBF_MBLDEOIH_ID_DATA1 = 25700;    /* dd */
+static const int MBF_MBLDEOIH_ID_DATA2 = 28270;    /* nn */
+static const int MBF_MBLDEOIH_ID_DATA3 = 17476;    /* DD */
+static const int MBF_MBLDEOIH_ID_DATA4 = 22068;    /* V4 big endian, 13398 little endian*/
+static const int MBF_MBLDEOIH_ID_DATA5 = 22069;    /* V5 bin endian, 13654 little endian */
 
 /*--------------------------------------------------------------------*/
 int mbr_info_mbldeoih(int verbose, int *system, int *beams_bath_max, int *beams_amp_max, int *pixels_ss_max, char *format_name,

--- a/src/mbio/mbr_mgd77tab.c
+++ b/src/mbio/mbr_mgd77tab.c
@@ -520,7 +520,6 @@
 
 /* header and data record in bytes */
 #define MBF_MGD77TAB_HEADER_FIELDS 58
-#define MBF_MGD77TAB_DATA_FIELDS 26
 
 struct mbf_mgd77tab_struct {
 	/* type of data record */

--- a/src/mbio/mbr_mgd77txt.c
+++ b/src/mbio/mbr_mgd77txt.c
@@ -57,8 +57,8 @@
  */
 
 /* header and data record in bytes */
-#define MBF_MGD77TXT_HEADER_NUM 16
-#define MBF_MGD77TXT_DATA_LEN 128
+static const int  MBF_MGD77TXT_HEADER_NUM = 16;
+static const int MBF_MGD77TXT_DATA_LEN = 128;
 
 struct mbf_mgd77txt_struct {
 	/* type of data record */

--- a/src/mbio/mbr_sb2100bi.c
+++ b/src/mbio/mbr_sb2100bi.c
@@ -47,24 +47,24 @@
 #include "mbsys_sb2100.h"
 
 /* define id's for the different types of raw records */
-#define MBF_SB2100BI_RECORDS 6
-#define MBF_SB2100BI_NONE 0
-#define MBF_SB2100BI_FH 1
-#define MBF_SB2100BI_TR 2
-#define MBF_SB2100BI_PR 3
-#define MBF_SB2100BI_DH 4
-#define MBF_SB2100BI_BR 5
-#define MBF_SB2100BI_SR 6
+static const int MBF_SB2100BI_RECORDS = 6;
+static const int MBF_SB2100BI_NONE = 0;
+static const int MBF_SB2100BI_FH = 1;
+static const int MBF_SB2100BI_TR = 2;
+static const int MBF_SB2100BI_PR = 3;
+static const int MBF_SB2100BI_DH = 4;
+static const int MBF_SB2100BI_BR = 5;
+static const int MBF_SB2100BI_SR = 6;
 char *mbf_sb2100bi_labels[] = {"NONE    ", "SB21BIFH", "SB21BITR", "SB21BIPR", "SB21BIDH", "SB21BIBR", "SB21BISR"};
 
-#define MBF_SB2100BI_PR_WRITE_LEN 284
-#define MBF_SB2100BI_DH_WRITE_LEN 80
-#define MBF_SB2100BI_BR_WRITE_LEN 32
-#define MBF_SB2100BI_SR_WRITE_LEN 4
-#define MBF_SB2100BI_LABEL_LEN 8
+static const int MBF_SB2100BI_PR_WRITE_LEN = 284;
+static const int MBF_SB2100BI_DH_WRITE_LEN = 80;
+static const int MBF_SB2100BI_BR_WRITE_LEN = 32;
+static const int MBF_SB2100BI_SR_WRITE_LEN = 4;
+static const int MBF_SB2100BI_LABEL_LEN = 8;
 
 /* define end of record label */
-char mbf_sb2100bi_eor[2] = {'\r', '\n'};
+static const char mbf_sb2100bi_eor[2] = {'\r', '\n'};
 
 int mbr_zero_sb2100bi(int verbose, char *store_ptr, int *error);
 int mbr_sb2100bi_rd_data(int verbose, void *mbio_ptr, char *store_ptr, int *error);
@@ -83,7 +83,7 @@ int mbr_sb2100bi_wr_br(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *stor
 int mbr_sb2100bi_wr_sr(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *store, int *error);
 
 /* text for ascii file header */
-char *mbf_sb2100bi_file_header_text_1 = {"\
+static const char *mbf_sb2100bi_file_header_text_1 = {"\
 \nSeaBeam 2100 multibeam sonar binary data format\n\
 MB-System formats 42 and 43\n\
 Format specification 1.2 defined March 20, 1997\n\
@@ -230,7 +230,7 @@ Record End                      03338           2       298     unsigned short\n
 \n\
 "};
 
-char *mbf_sb2100bi_file_header_text_2 = {"\
+static const char *mbf_sb2100bi_file_header_text_2 = {"\
 Sonar Data Header Record (96 bytes - navigation and sonar parameters):\n\
 ----------------------------------------------------------------------------\n\
 Item            Units           Valid           # of    Byte    Coding\n\
@@ -379,7 +379,7 @@ Record End                      03338           2       varies  unsigned short\n
 "};
 
 /* read & write buffer */
-char buffer[4 * MBSYS_SB2100_PIXELS];
+static char buffer[4 * MBSYS_SB2100_PIXELS];
 
 
 /*--------------------------------------------------------------------*/

--- a/src/mbio/mbr_sbifremr.c
+++ b/src/mbio/mbr_sbifremr.c
@@ -38,9 +38,6 @@
 #include "mbf_sbifremr.h"
 #include "mbsys_sb.h"
 
-/* angle spacing for SeaBeam Classic */
-#define ANGLE_SPACING 3.75
-
 int mbr_sbifremr_rd_data(int verbose, void *mbio_ptr, int *error);
 int mbr_sbifremr_wr_data(int verbose, void *mbio_ptr, int *error);
 

--- a/src/mbio/mbr_xtfb1624.c
+++ b/src/mbio/mbr_xtfb1624.c
@@ -41,34 +41,34 @@
 /* #define MBR_XTFB1624_DEBUG 1 */
 
 /* maximum number of beams and pixels */
-#define MBF_XTFB1624_MAXBEAMS 1
+// #define MBF_XTFB1624_MAXBEAMS 1
 #define MBF_XTFB1624_MAXRAWPIXELS 15360
 #define MBF_XTFB1624_COMMENT_LENGTH 200
 #define MBF_XTFB1624_MAXLINE 16384
-#define MBF_XTFB1624_FILEHEADERLEN 1024
-#define XTF_MAGIC_NUMBER 0xFACE
-#define XTF_DATA_SIDESCAN 0
-#define XTF_DATA_ANNOTATION 1
-#define XTF_DATA_BATHYMETRY 2
-#define XTF_DATA_ATTITUDE 3
-#define XTF_DATA_POSITION 100
-#define XTF_HEADER_SONAR 0              // sidescan and subbottom
-#define XTF_HEADER_NOTES 1              // notes - text annotation
-#define XTF_HEADER_BATHY 2              // bathymetry (Seabat, Odom)
-#define XTF_HEADER_ATTITUDE 3           // TSS or MRU attitude (pitch, roll, heave, yaw)
-#define XTF_HEADER_FORWARD 4            // forward-look sonar (polar display)
-#define XTF_HEADER_ELAC 5               // Elac multibeam
-#define XTF_HEADER_RAW_SERIAL 6         // Raw data from serial port
-#define XTF_HEADER_EMBED_HEAD 7         // Embedded header structure
-#define XTF_HEADER_HIDDEN_SONAR 8       // hidden (non-displayable) ping
-#define XTF_HEADER_SEAVIEW_ANGLES 9     // Bathymetry (angles) for Seaview
-#define XTF_HEADER_SEAVIEW_DEPTHS 10    // Bathymetry from Seaview data (depths)
-#define XTF_HEADER_HIGHSPEED_SENSOR 11  // used by Klein (Cliff Chase) 0=roll, 1=yaw
-#define XTF_HEADER_ECHOSTRENGTH 12      // Elac EchoStrength (10 values)
-#define XTF_HEADER_GEOREC 13            // Used to store mosaic params
-#define XTF_HEADER_K5000_BATHYMETRY 14  // Bathymetry data from the Klein 5000
-#define XTF_HEADER_HIGHSPEED_SENSOR2 15 // High speed sensor from Klein 5000
-#define XTF_HEADER_RAW_CUSTOM 199       // Raw Custom Header
+static const size_t MBF_XTFB1624_FILEHEADERLEN = 1024;
+// #define XTF_MAGIC_NUMBER 0xFACE
+static const mb_u_char XTF_DATA_SIDESCAN = 0;
+// #define XTF_DATA_ANNOTATION 1
+// #define XTF_DATA_BATHYMETRY 2
+static const mb_u_char XTF_DATA_ATTITUDE = 3;
+// #define XTF_DATA_POSITION 100
+// #define XTF_HEADER_SONAR 0              // sidescan and subbottom
+// #define XTF_HEADER_NOTES 1              // notes - text annotation
+// #define XTF_HEADER_BATHY 2              // bathymetry (Seabat, Odom)
+// #define XTF_HEADER_ATTITUDE 3           // TSS or MRU attitude (pitch, roll, heave, yaw)
+// #define XTF_HEADER_FORWARD 4            // forward-look sonar (polar display)
+// #define XTF_HEADER_ELAC 5               // Elac multibeam
+// #define XTF_HEADER_RAW_SERIAL 6         // Raw data from serial port
+// #define XTF_HEADER_EMBED_HEAD 7         // Embedded header structure
+// #define XTF_HEADER_HIDDEN_SONAR 8       // hidden (non-displayable) ping
+// #define XTF_HEADER_SEAVIEW_ANGLES 9     // Bathymetry (angles) for Seaview
+// #define XTF_HEADER_SEAVIEW_DEPTHS 10    // Bathymetry from Seaview data (depths)
+// #define XTF_HEADER_HIGHSPEED_SENSOR 11  // used by Klein (Cliff Chase) 0=roll, 1=yaw
+// #define XTF_HEADER_ECHOSTRENGTH 12      // Elac EchoStrength (10 values)
+// #define XTF_HEADER_GEOREC 13            // Used to store mosaic params
+// #define XTF_HEADER_K5000_BATHYMETRY 14  // Bathymetry data from the Klein 5000
+// #define XTF_HEADER_HIGHSPEED_SENSOR2 15 // High speed sensor from Klein 5000
+// #define XTF_HEADER_RAW_CUSTOM 199       // Raw Custom Header
 
 struct mbf_xtfb1624_xtfchaninfo {
 	char TypeOfChannel;


### PR DESCRIPTION
Allows the compiler to do better type checking and debuggers to see
the symbolic names rather than just literals.

Also removed some unused defines.