### PR TITLE
mbr_dsl120pf.c ... mbr_em300raw.c: Localize status variable.

### DIFF
--- a/src/mbio/mbr_dsl120pf.c
+++ b/src/mbio/mbr_dsl120pf.c
@@ -43,7 +43,6 @@ int mbr_info_dsl120pf(int verbose, int *system, int *beams_bath_max, int *beams_
                       int *heading_source, int *attitude_source, int *svp_source, double *beamwidth_xtrack,
                       double *beamwidth_ltrack, int *error) {
 	char *function_name = "mbr_info_dsl120pf";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -53,7 +52,6 @@ int mbr_info_dsl120pf(int verbose, int *system, int *beams_bath_max, int *beams_
 	}
 
 	/* set format info parameters */
-	status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 	*system = MB_SYS_DSL;
 	*beams_bath_max = 2048;
@@ -79,6 +77,8 @@ int mbr_info_dsl120pf(int verbose, int *system, int *beams_bath_max, int *beams_
 	*svp_source = MB_DATA_NONE;
 	*beamwidth_xtrack = 0.0;
 	*beamwidth_ltrack = 0.0;
+
+	const int status = MB_SUCCESS;
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -114,7 +114,6 @@ int mbr_info_dsl120pf(int verbose, int *system, int *beams_bath_max, int *beams_
 /*--------------------------------------------------------------------*/
 int mbr_zero_dsl120pf(int verbose, char *data_ptr, int *error) {
 	char *function_name = "mbr_zero_dsl120pf";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 
 	/* print input debug statements */
@@ -195,7 +194,7 @@ int mbr_zero_dsl120pf(int verbose, char *data_ptr, int *error) {
 	}
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 
 	/* print output debug statements */
@@ -212,7 +211,6 @@ int mbr_zero_dsl120pf(int verbose, char *data_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_alm_dsl120pf(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_alm_dsl120pf";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 	char *tag_ptr;
 
@@ -227,14 +225,11 @@ int mbr_alm_dsl120pf(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to mbio descriptor */
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-	/* set initial status */
-	status = MB_SUCCESS;
-
 	/* allocate memory for data structure */
 	mb_io_ptr->structure_size = sizeof(struct mbf_dsl120pf_struct);
 	mb_io_ptr->data_structure_size = 0;
-	status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
-	status = mbsys_dsl_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	int status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
+	status &= mbsys_dsl_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* initialize everything to zeros */
 	mbr_zero_dsl120pf(verbose, mb_io_ptr->raw_data, error);
@@ -281,7 +276,6 @@ int mbr_alm_dsl120pf(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dem_dsl120pf(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_dem_dsl120pf";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -295,8 +289,8 @@ int mbr_dem_dsl120pf(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* deallocate memory for data descriptor */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
-	status = mbsys_dsl_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	int status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
+	status &= mbsys_dsl_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -312,7 +306,6 @@ int mbr_dem_dsl120pf(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dsl120pf_rd_header(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120pf_rd_header";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 	char *data_ptr;
 	char buffer[124];
@@ -336,7 +329,7 @@ int mbr_dsl120pf_rd_header(int verbose, void *mbio_ptr, FILE *mbfp, int *error) 
 	data_ptr = (char *)data;
 
 	/* read header */
-	status = fread(buffer, 1, 124, mbfp);
+	int status = fread(buffer, 1, 124, mbfp);
 	if (status == 124) {
 		status = MB_SUCCESS;
 		*error = MB_ERROR_NO_ERROR;
@@ -467,7 +460,6 @@ int mbr_dsl120pf_rd_header(int verbose, void *mbio_ptr, FILE *mbfp, int *error) 
 /*--------------------------------------------------------------------*/
 int mbr_dsl120pf_rd_dataheader(int verbose, void *mbio_ptr, FILE *mbfp, char *type, int *len, int *hdr_len, int *error) {
 	char *function_name = "mbr_dsl120pf_rd_dataheader";
-	int status = MB_SUCCESS;
 	char buffer[12];
 	int index;
 
@@ -481,7 +473,7 @@ int mbr_dsl120pf_rd_dataheader(int verbose, void *mbio_ptr, FILE *mbfp, char *ty
 	}
 
 	/* read header */
-	status = fread(buffer, 1, 12, mbfp);
+	int status = fread(buffer, 1, 12, mbfp);
 	if (status == 12) {
 		status = MB_SUCCESS;
 		*error = MB_ERROR_NO_ERROR;
@@ -518,7 +510,6 @@ int mbr_dsl120pf_rd_dataheader(int verbose, void *mbio_ptr, FILE *mbfp, char *ty
 /*--------------------------------------------------------------------*/
 int mbr_dsl120pf_rd_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120pf_rd_bath";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 	int read_bytes;
 	char *data_ptr;
@@ -542,7 +533,7 @@ int mbr_dsl120pf_rd_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 
 	/* read bath record */
 	read_bytes = data->bat_len - 12;
-	status = fread(buffer, 1, read_bytes, mbfp);
+	int status = fread(buffer, 1, read_bytes, mbfp);
 	if (status == read_bytes) {
 		status = MB_SUCCESS;
 		*error = MB_ERROR_NO_ERROR;
@@ -605,7 +596,6 @@ int mbr_dsl120pf_rd_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dsl120pf_rd_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120pf_rd_amp";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 	int read_bytes;
 	char *data_ptr;
@@ -629,7 +619,7 @@ int mbr_dsl120pf_rd_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 
 	/* read amp record */
 	read_bytes = data->amp_len - 12;
-	status = fread(buffer, 1, read_bytes, mbfp);
+	int status = fread(buffer, 1, read_bytes, mbfp);
 	if (status == read_bytes) {
 		status = MB_SUCCESS;
 		*error = MB_ERROR_NO_ERROR;
@@ -695,7 +685,6 @@ int mbr_dsl120pf_rd_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dsl120pf_rd_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120pf_rd_comment";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 	int read_bytes;
 	char *data_ptr;
@@ -718,7 +707,7 @@ int mbr_dsl120pf_rd_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 
 	/* read comment record */
 	read_bytes = 80;
-	status = fread(buffer, 1, read_bytes, mbfp);
+	int status = fread(buffer, 1, read_bytes, mbfp);
 	if (status == read_bytes) {
 		status = MB_SUCCESS;
 		*error = MB_ERROR_NO_ERROR;
@@ -754,7 +743,6 @@ int mbr_dsl120pf_rd_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_dsl120pf_rd_data(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_dsl120pf_rd_data";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 	char *data_ptr;
 	char tag[5];
@@ -777,6 +765,8 @@ int mbr_dsl120pf_rd_data(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to raw data structure */
 	data = (struct mbf_dsl120pf_struct *)mb_io_ptr->raw_data;
 	data_ptr = (char *)data;
+
+	int status = MB_SUCCESS;
 
 	/* read first file */
 	if (mb_io_ptr->mbfp != NULL) {
@@ -920,7 +910,6 @@ int mbr_dsl120pf_rd_data(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_rt_dsl120pf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_rt_dsl120pf";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 	struct mbsys_dsl_struct *store;
 
@@ -939,7 +928,7 @@ int mbr_rt_dsl120pf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	store = (struct mbsys_dsl_struct *)store_ptr;
 
 	/* read next data from file */
-	status = mbr_dsl120pf_rd_data(verbose, mbio_ptr, error);
+	const int status = mbr_dsl120pf_rd_data(verbose, mbio_ptr, error);
 
 	/* set error and kind in mb_io_ptr */
 	mb_io_ptr->new_error = *error;
@@ -1022,7 +1011,6 @@ int mbr_rt_dsl120pf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dsl120pf_wr_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120pf_wr_bath";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 	char *data_ptr;
 	char buffer[10000];
@@ -1045,7 +1033,7 @@ int mbr_dsl120pf_wr_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	data_ptr = (char *)data;
 
 	/* print debug statements */
-	if (verbose >= 5 && status == MB_SUCCESS) {
+	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5       rec_type:         %d\n", data->rec_type);
 		fprintf(stderr, "dbg5       rec_len:          %d\n", data->rec_len);
@@ -1183,7 +1171,7 @@ int mbr_dsl120pf_wr_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	}
 
 	/* write the record */
-	status = fwrite(buffer, 1, data->rec_len, mbfp);
+	int status = fwrite(buffer, 1, data->rec_len, mbfp);
 	if (status != data->rec_len) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -1205,7 +1193,6 @@ int mbr_dsl120pf_wr_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dsl120pf_wr_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120pf_wr_amp";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 	char *data_ptr;
 	char buffer[10000];
@@ -1228,7 +1215,7 @@ int mbr_dsl120pf_wr_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	data_ptr = (char *)data;
 
 	/* print debug statements */
-	if (verbose >= 5 && status == MB_SUCCESS) {
+	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5       rec_type:         %d\n", data->rec_type);
 		fprintf(stderr, "dbg5       rec_len:          %d\n", data->rec_len);
@@ -1369,7 +1356,7 @@ int mbr_dsl120pf_wr_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	}
 
 	/* write the record */
-	status = fwrite(buffer, 1, data->rec_len, mbfp);
+	int status = fwrite(buffer, 1, data->rec_len, mbfp);
 	if (status != data->rec_len) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -1391,7 +1378,6 @@ int mbr_dsl120pf_wr_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dsl120pf_wr_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120pf_wr_comment";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 	char *data_ptr;
 	char buffer[10000];
@@ -1414,7 +1400,7 @@ int mbr_dsl120pf_wr_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 	data_ptr = (char *)data;
 
 	/* print debug statements */
-	if (verbose >= 5 && status == MB_SUCCESS) {
+	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
 	}
@@ -1501,7 +1487,7 @@ int mbr_dsl120pf_wr_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 	index++;
 
 	/* write the record */
-	status = fwrite(buffer, 1, data->rec_len, mbfp);
+	int status = fwrite(buffer, 1, data->rec_len, mbfp);
 	if (status != data->rec_len) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -1523,7 +1509,6 @@ int mbr_dsl120pf_wr_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_dsl120pf_wr_data(int verbose, void *mbio_ptr, char *data_ptr, int *error) {
 	char *function_name = "mbr_dsl120pf_wr_data";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 
 	/* print input debug statements */
@@ -1540,6 +1525,8 @@ int mbr_dsl120pf_wr_data(int verbose, void *mbio_ptr, char *data_ptr, int *error
 
 	/* get pointer to raw data structure */
 	data = (struct mbf_dsl120pf_struct *)data_ptr;
+
+	int status = MB_SUCCESS;
 
 	if (data->kind == MB_DATA_COMMENT) {
 		status = mbr_dsl120pf_wr_comment(verbose, mbio_ptr, mb_io_ptr->mbfp, error);
@@ -1577,7 +1564,6 @@ int mbr_dsl120pf_wr_data(int verbose, void *mbio_ptr, char *data_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbr_wt_dsl120pf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_wt_dsl120pf";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120pf_struct *data;
 	struct mbsys_dsl_struct *store;
 	char *data_ptr;
@@ -1663,7 +1649,7 @@ int mbr_wt_dsl120pf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	}
 
 	/* write next data to file */
-	status = mbr_dsl120pf_wr_data(verbose, mbio_ptr, data_ptr, error);
+	const int status = mbr_dsl120pf_wr_data(verbose, mbio_ptr, data_ptr, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -1680,7 +1666,6 @@ int mbr_wt_dsl120pf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_register_dsl120pf(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_register_dsl120pf";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -1693,7 +1678,7 @@ int mbr_register_dsl120pf(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* set format info parameters */
-	status = mbr_info_dsl120pf(
+	const int status = mbr_info_dsl120pf(
 	    verbose, &mb_io_ptr->system, &mb_io_ptr->beams_bath_max, &mb_io_ptr->beams_amp_max, &mb_io_ptr->pixels_ss_max,
 	    mb_io_ptr->format_name, mb_io_ptr->system_name, mb_io_ptr->format_description, &mb_io_ptr->numfile, &mb_io_ptr->filetype,
 	    &mb_io_ptr->variable_beams, &mb_io_ptr->traveltime, &mb_io_ptr->beam_flagging, &mb_io_ptr->platform_source,

--- a/src/mbio/mbr_dsl120sf.c
+++ b/src/mbio/mbr_dsl120sf.c
@@ -44,7 +44,6 @@ int mbr_info_dsl120sf(int verbose, int *system, int *beams_bath_max, int *beams_
                       int *heading_source, int *attitude_source, int *svp_source, double *beamwidth_xtrack,
                       double *beamwidth_ltrack, int *error) {
 	char *function_name = "mbr_info_dsl120sf";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -54,7 +53,6 @@ int mbr_info_dsl120sf(int verbose, int *system, int *beams_bath_max, int *beams_
 	}
 
 	/* set format info parameters */
-	status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 	*system = MB_SYS_DSL;
 	*beams_bath_max = 2048;
@@ -79,6 +77,8 @@ int mbr_info_dsl120sf(int verbose, int *system, int *beams_bath_max, int *beams_
 	*svp_source = MB_DATA_NONE;
 	*beamwidth_xtrack = 0.0;
 	*beamwidth_ltrack = 0.0;
+
+	const int status = MB_SUCCESS;
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -114,7 +114,6 @@ int mbr_info_dsl120sf(int verbose, int *system, int *beams_bath_max, int *beams_
 /*--------------------------------------------------------------------*/
 int mbr_zero_dsl120sf(int verbose, char *data_ptr, int *error) {
 	char *function_name = "mbr_zero_dsl120sf";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 
 	/* print input debug statements */
@@ -195,7 +194,7 @@ int mbr_zero_dsl120sf(int verbose, char *data_ptr, int *error) {
 	}
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 
 	/* print output debug statements */
@@ -212,7 +211,6 @@ int mbr_zero_dsl120sf(int verbose, char *data_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_alm_dsl120sf(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_alm_dsl120sf";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 
 	/* print input debug statements */
@@ -226,14 +224,11 @@ int mbr_alm_dsl120sf(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to mbio descriptor */
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-	/* set initial status */
-	status = MB_SUCCESS;
-
 	/* allocate memory for data structure */
 	mb_io_ptr->structure_size = sizeof(struct mbf_dsl120sf_struct);
 	mb_io_ptr->data_structure_size = 0;
-	status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
-	status = mbsys_dsl_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	int status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
+	status &= mbsys_dsl_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* initialize everything to zeros */
 	mbr_zero_dsl120sf(verbose, mb_io_ptr->raw_data, error);
@@ -255,7 +250,6 @@ int mbr_alm_dsl120sf(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dem_dsl120sf(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_dem_dsl120sf";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -269,8 +263,8 @@ int mbr_dem_dsl120sf(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* deallocate memory for data descriptor */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
-	status = mbsys_dsl_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	int status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
+	status &= mbsys_dsl_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -286,7 +280,6 @@ int mbr_dem_dsl120sf(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dsl120sf_rd_header(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120sf_rd_header";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 	char *data_ptr;
 	char buffer[124];
@@ -308,7 +301,7 @@ int mbr_dsl120sf_rd_header(int verbose, void *mbio_ptr, FILE *mbfp, int *error) 
 	data_ptr = (char *)data;
 
 	/* read header */
-	status = fread(buffer, 1, 124, mbfp);
+	int status = fread(buffer, 1, 124, mbfp);
 	if (status == 124) {
 		status = MB_SUCCESS;
 		*error = MB_ERROR_NO_ERROR;
@@ -435,7 +428,6 @@ int mbr_dsl120sf_rd_header(int verbose, void *mbio_ptr, FILE *mbfp, int *error) 
 /*--------------------------------------------------------------------*/
 int mbr_dsl120sf_rd_dataheader(int verbose, void *mbio_ptr, FILE *mbfp, char *type, int *len, int *hdr_len, int *error) {
 	char *function_name = "mbr_dsl120sf_rd_dataheader";
-	int status = MB_SUCCESS;
 	char buffer[12];
 	int index;
 
@@ -449,7 +441,7 @@ int mbr_dsl120sf_rd_dataheader(int verbose, void *mbio_ptr, FILE *mbfp, char *ty
 	}
 
 	/* read header */
-	status = fread(buffer, 1, 12, mbfp);
+	int status = fread(buffer, 1, 12, mbfp);
 	if (status == 12) {
 		status = MB_SUCCESS;
 		*error = MB_ERROR_NO_ERROR;
@@ -486,7 +478,6 @@ int mbr_dsl120sf_rd_dataheader(int verbose, void *mbio_ptr, FILE *mbfp, char *ty
 /*--------------------------------------------------------------------*/
 int mbr_dsl120sf_rd_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120sf_rd_bath";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 	int read_bytes;
 	char *data_ptr;
@@ -510,7 +501,7 @@ int mbr_dsl120sf_rd_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 
 	/* read bath record */
 	read_bytes = data->bat_len - 12;
-	status = fread(buffer, 1, read_bytes, mbfp);
+	int status = fread(buffer, 1, read_bytes, mbfp);
 	if (status == read_bytes) {
 		status = MB_SUCCESS;
 		*error = MB_ERROR_NO_ERROR;
@@ -573,7 +564,6 @@ int mbr_dsl120sf_rd_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dsl120sf_rd_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120sf_rd_amp";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 	int read_bytes;
 	char *data_ptr;
@@ -597,7 +587,7 @@ int mbr_dsl120sf_rd_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 
 	/* read amp record */
 	read_bytes = data->amp_len - 12;
-	status = fread(buffer, 1, read_bytes, mbfp);
+	int status = fread(buffer, 1, read_bytes, mbfp);
 	if (status == read_bytes) {
 		status = MB_SUCCESS;
 		*error = MB_ERROR_NO_ERROR;
@@ -663,7 +653,6 @@ int mbr_dsl120sf_rd_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dsl120sf_rd_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120sf_rd_comment";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 	int read_bytes;
 	char *data_ptr;
@@ -686,7 +675,7 @@ int mbr_dsl120sf_rd_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 
 	/* read comment record */
 	read_bytes = 80;
-	status = fread(buffer, 1, read_bytes, mbfp);
+	int status = fread(buffer, 1, read_bytes, mbfp);
 	if (status == read_bytes) {
 		status = MB_SUCCESS;
 		*error = MB_ERROR_NO_ERROR;
@@ -722,7 +711,6 @@ int mbr_dsl120sf_rd_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_dsl120sf_rd_data(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_dsl120sf_rd_data";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 	char *data_ptr;
 	char tag[5];
@@ -745,6 +733,8 @@ int mbr_dsl120sf_rd_data(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to raw data structure */
 	data = (struct mbf_dsl120sf_struct *)mb_io_ptr->raw_data;
 	data_ptr = (char *)data;
+
+	int status = MB_SUCCESS;
 
 	/* read data */
 	if (mb_io_ptr->mbfp != NULL) {
@@ -824,7 +814,6 @@ int mbr_dsl120sf_rd_data(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_rt_dsl120sf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_rt_dsl120sf";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 	struct mbsys_dsl_struct *store;
 
@@ -843,7 +832,7 @@ int mbr_rt_dsl120sf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	store = (struct mbsys_dsl_struct *)store_ptr;
 
 	/* read next data from file */
-	status = mbr_dsl120sf_rd_data(verbose, mbio_ptr, error);
+	const int status = mbr_dsl120sf_rd_data(verbose, mbio_ptr, error);
 
 	/* set error and kind in mb_io_ptr */
 	mb_io_ptr->new_error = *error;
@@ -926,7 +915,6 @@ int mbr_rt_dsl120sf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dsl120sf_wr_bathamp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120sf_wr_bathamp";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 	char *data_ptr;
 	char buffer[17000];
@@ -949,7 +937,7 @@ int mbr_dsl120sf_wr_bathamp(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 	data_ptr = (char *)data;
 
 	/* print debug statements */
-	if (verbose >= 5 && status == MB_SUCCESS) {
+	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5       rec_type:         %d\n", data->rec_type);
 		fprintf(stderr, "dbg5       rec_len:          %d\n", data->rec_len);
@@ -1131,7 +1119,7 @@ int mbr_dsl120sf_wr_bathamp(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 	}
 
 	/* write the record */
-	status = fwrite(buffer, 1, data->rec_len, mbfp);
+	int status = fwrite(buffer, 1, data->rec_len, mbfp);
 	if (status != data->rec_len) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -1153,7 +1141,6 @@ int mbr_dsl120sf_wr_bathamp(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_dsl120sf_wr_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	char *function_name = "mbr_dsl120sf_wr_comment";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 	char *data_ptr;
 	char buffer[10000];
@@ -1176,7 +1163,7 @@ int mbr_dsl120sf_wr_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 	data_ptr = (char *)data;
 
 	/* print debug statements */
-	if (verbose >= 5 && status == MB_SUCCESS) {
+	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
 	}
@@ -1262,7 +1249,7 @@ int mbr_dsl120sf_wr_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 	index++;
 
 	/* write the record */
-	status = fwrite(buffer, 1, data->rec_len, mbfp);
+	int status = fwrite(buffer, 1, data->rec_len, mbfp);
 	if (status != data->rec_len) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -1286,7 +1273,6 @@ int mbr_dsl120sf_wr_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_dsl120sf_wr_data(int verbose, void *mbio_ptr, char *data_ptr, int *error) {
 	char *function_name = "mbr_dsl120sf_wr_data";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 
 	/* print input debug statements */
@@ -1303,6 +1289,8 @@ int mbr_dsl120sf_wr_data(int verbose, void *mbio_ptr, char *data_ptr, int *error
 
 	/* get pointer to raw data structure */
 	data = (struct mbf_dsl120sf_struct *)data_ptr;
+
+	int status = MB_SUCCESS;
 
 	if (data->kind == MB_DATA_COMMENT) {
 		status = mbr_dsl120sf_wr_comment(verbose, mbio_ptr, mb_io_ptr->mbfp, error);
@@ -1335,7 +1323,6 @@ int mbr_dsl120sf_wr_data(int verbose, void *mbio_ptr, char *data_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbr_wt_dsl120sf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_wt_dsl120sf";
-	int status = MB_SUCCESS;
 	struct mbf_dsl120sf_struct *data;
 	struct mbsys_dsl_struct *store;
 	char *data_ptr;
@@ -1421,7 +1408,7 @@ int mbr_wt_dsl120sf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	}
 
 	/* write next data to file */
-	status = mbr_dsl120sf_wr_data(verbose, mbio_ptr, data_ptr, error);
+	const int status = mbr_dsl120sf_wr_data(verbose, mbio_ptr, data_ptr, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -1438,7 +1425,6 @@ int mbr_wt_dsl120sf(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_register_dsl120sf(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_register_dsl120sf";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -1451,7 +1437,7 @@ int mbr_register_dsl120sf(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* set format info parameters */
-	status = mbr_info_dsl120sf(
+	const int status = mbr_info_dsl120sf(
 	    verbose, &mb_io_ptr->system, &mb_io_ptr->beams_bath_max, &mb_io_ptr->beams_amp_max, &mb_io_ptr->pixels_ss_max,
 	    mb_io_ptr->format_name, mb_io_ptr->system_name, mb_io_ptr->format_description, &mb_io_ptr->numfile, &mb_io_ptr->filetype,
 	    &mb_io_ptr->variable_beams, &mb_io_ptr->traveltime, &mb_io_ptr->beam_flagging, &mb_io_ptr->platform_source,

--- a/src/mbio/mbr_edgjstar.c
+++ b/src/mbio/mbr_edgjstar.c
@@ -47,7 +47,6 @@ int mbr_info_edgjstar(int verbose, int *system, int *beams_bath_max, int *beams_
                       int *heading_source, int *attitude_source, int *svp_source, double *beamwidth_xtrack,
                       double *beamwidth_ltrack, int *error) {
 	char *function_name = "mbr_info_edgjstar";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -57,7 +56,6 @@ int mbr_info_edgjstar(int verbose, int *system, int *beams_bath_max, int *beams_
 	}
 
 	/* set format info parameters */
-	status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 	*system = MB_SYS_JSTAR;
 	*beams_bath_max = 1;
@@ -83,6 +81,8 @@ int mbr_info_edgjstar(int verbose, int *system, int *beams_bath_max, int *beams_
 	*svp_source = MB_DATA_NONE;
 	*beamwidth_xtrack = 0.0;
 	*beamwidth_ltrack = 0.0;
+
+	const int status = MB_SUCCESS;
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -123,7 +123,6 @@ int mbr_info_edgjstr2(int verbose, int *system, int *beams_bath_max, int *beams_
                       int *heading_source, int *attitude_source, int *svp_source, double *beamwidth_xtrack,
                       double *beamwidth_ltrack, int *error) {
 	char *function_name = "mbr_info_edgjstr2";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -133,7 +132,6 @@ int mbr_info_edgjstr2(int verbose, int *system, int *beams_bath_max, int *beams_
 	}
 
 	/* set format info parameters */
-	status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 	*system = MB_SYS_JSTAR;
 	*beams_bath_max = 1;
@@ -159,6 +157,8 @@ int mbr_info_edgjstr2(int verbose, int *system, int *beams_bath_max, int *beams_
 	*svp_source = MB_DATA_NONE;
 	*beamwidth_xtrack = 0.0;
 	*beamwidth_ltrack = 0.0;
+
+	const int status = MB_SUCCESS;
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -194,7 +194,6 @@ int mbr_info_edgjstr2(int verbose, int *system, int *beams_bath_max, int *beams_
 /*--------------------------------------------------------------------*/
 int mbr_alm_edgjstar(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_alm_edgjstar";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -207,12 +206,11 @@ int mbr_alm_edgjstar(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to mbio descriptor */
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-	/* set initial status */
-	status = MB_SUCCESS;
-
 	/* allocate memory for data structure */
 	mb_io_ptr->structure_size = 0;
 	mbsys_jstar_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+
+	const int status = MB_SUCCESS;
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -228,7 +226,6 @@ int mbr_alm_edgjstar(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dem_edgjstar(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_dem_edgjstar";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -242,7 +239,7 @@ int mbr_dem_edgjstar(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* deallocate memory for data structure */
-	status = mbsys_jstar_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	const int status = mbsys_jstar_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -258,7 +255,6 @@ int mbr_dem_edgjstar(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_rt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_rt_edgjstar";
-	int status = MB_SUCCESS;
 	struct mbsys_jstar_message_struct message;
 	struct mbsys_jstar_struct *store;
 	struct mbsys_jstar_channel_struct *sbp;
@@ -318,6 +314,8 @@ int mbr_rt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	store->ssstbd.pingNum = -1;
 	store->ssport.message.subsystem = -1;
 	store->ssstbd.message.subsystem = -1;
+
+	int status = MB_SUCCESS;
 
 	/* loop over reading data until a full record of some sort is read */
 	done = MB_NO;
@@ -2315,7 +2313,6 @@ int mbr_rt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_wt_edgjstar";
-	int status = MB_SUCCESS;
 	struct mbsys_jstar_struct *store;
 	struct mbsys_jstar_channel_struct *sbp;
 	struct mbsys_jstar_channel_struct *ss;
@@ -2347,7 +2344,7 @@ int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	store = (struct mbsys_jstar_struct *)store_ptr;
 
 	/* print debug statements */
-	if (status == MB_SUCCESS && verbose >= 5 && store->kind == MB_DATA_COMMENT) {
+	if (verbose >= 5 && store->kind == MB_DATA_COMMENT) {
 		fprintf(stderr, "\ndbg5  New comment to be written by MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5  Subsystem ID:\n");
 		fprintf(stderr, "dbg5       subsystem:        %d ", store->subsystem);
@@ -2373,7 +2370,7 @@ int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 
 		fprintf(stderr, "dbg5     comment:                     %s\n", store->comment.comment);
 	}
-	else if (status == MB_SUCCESS && verbose >= 5 && store->kind == MB_DATA_SUBBOTTOM_SUBBOTTOM) {
+	else if (verbose >= 5 && store->kind == MB_DATA_SUBBOTTOM_SUBBOTTOM) {
 		sbp = (struct mbsys_jstar_channel_struct *)&(store->sbp);
 		fprintf(stderr, "\ndbg5  New subbottom data record to be written by MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5  Subsystem ID:\n");
@@ -2474,7 +2471,7 @@ int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 				fprintf(stderr, "dbg5     Channel[%d]: %10d\n", i, sbp->trace[i]);
 		}
 	}
-	else if (status == MB_SUCCESS && verbose >= 5 && (store->kind == MB_DATA_DATA || store->kind == MB_DATA_SIDESCAN2)) {
+	else if (verbose >= 5 && (store->kind == MB_DATA_DATA || store->kind == MB_DATA_SIDESCAN2)) {
 		fprintf(stderr, "\ndbg5  New sidescan data record to be written by MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5  Subsystem ID:\n");
 		fprintf(stderr, "dbg5       subsystem:        %d ", store->subsystem);
@@ -2677,7 +2674,7 @@ int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 				fprintf(stderr, "dbg5     Channel 1[%d]: %10d\n", i, ss->trace[i]);
 		}
 	}
-	else if (status == MB_SUCCESS && verbose >= 5 && store->kind == MB_DATA_ATTITUDE) {
+	else if (verbose >= 5 && store->kind == MB_DATA_ATTITUDE) {
 		fprintf(stderr, "\ndbg5  New roll pitch data record to be written by MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5  Subsystem ID:\n");
 		fprintf(stderr, "dbg5       subsystem:        %d ", store->subsystem);
@@ -2720,7 +2717,7 @@ int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "dbg5     datavalidflags:              %d\n", pitchroll->datavalidflags);
 		fprintf(stderr, "dbg5     reserve2:                    %d\n", pitchroll->reserve2);
 	}
-	else if (status == MB_SUCCESS && verbose >= 5 && store->kind == MB_DATA_DVL) {
+	else if (verbose >= 5 && store->kind == MB_DATA_DVL) {
 		fprintf(stderr, "\ndbg5  New dvl data record to be written by MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5  Subsystem ID:\n");
 		fprintf(stderr, "dbg5       subsystem:        %d ", store->subsystem);
@@ -2769,7 +2766,7 @@ int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		for (int i = 0; i < 7; i++)
 			fprintf(stderr, "dbg5     reserve2[%d]:                %d\n", i, dvl->reserve2[i]);
 	}
-	else if (status == MB_SUCCESS && verbose >= 5 && store->kind == MB_DATA_CTD) {
+	else if (verbose >= 5 && store->kind == MB_DATA_CTD) {
 		pressure = (struct mbsys_jstar_pressure_struct *)&(store->pressure);
 		fprintf(stderr, "\ndbg5  New pressure data record to be written by MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5     start_marker:                %d\n", pressure->message.start_marker);
@@ -2797,7 +2794,7 @@ int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		for (int i = 0; i < 10; i++)
 			fprintf(stderr, "dbg5     reserve2[%2d]:                 %d\n", i, pressure->reserve2[i]);
 	}
-	else if (status == MB_SUCCESS && verbose >= 5 &&
+	else if (verbose >= 5 &&
 	         (store->kind == MB_DATA_NMEA_RMC || store->kind == MB_DATA_NMEA_DBT || store->kind == MB_DATA_NMEA_DPT)) {
 		nmea = (struct mbsys_jstar_nmea_struct *)&(store->nmea);
 		fprintf(stderr, "\ndbg5  New NMEA data record to be written by MBIO function <%s>\n", function_name);
@@ -2820,7 +2817,7 @@ int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "dbg5     reserve[2]:                  %d\n", nmea->reserve[2]);
 		fprintf(stderr, "dbg5     nmea:                        %s\n", nmea->nmea);
 	}
-	else if (status == MB_SUCCESS && verbose >= 5 && (store->kind == MB_DATA_HEADER)) {
+	else if (verbose >= 5 && (store->kind == MB_DATA_HEADER)) {
 		sysinfo = (struct mbsys_jstar_sysinfo_struct *)&(store->sysinfo);
 		fprintf(stderr, "\ndbg5  New sysinfo data record to be written by MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5     start_marker:                %d\n", sysinfo->message.start_marker);
@@ -2842,6 +2839,8 @@ int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "dbg5     sysinfosize:                 %d\n", sysinfo->sysinfosize);
 		fprintf(stderr, "dbg5     sysinfo:                     \n%s\n", sysinfo->sysinfo);
 	}
+
+	int status = MB_SUCCESS;
 
 	/* write out comment */
 	if (store->kind == MB_DATA_COMMENT) {
@@ -3927,7 +3926,6 @@ int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_register_edgjstar(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_register_edgjstar";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -3940,7 +3938,7 @@ int mbr_register_edgjstar(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* set format info parameters */
-	status = mbr_info_edgjstar(
+	const int status = mbr_info_edgjstar(
 	    verbose, &mb_io_ptr->system, &mb_io_ptr->beams_bath_max, &mb_io_ptr->beams_amp_max, &mb_io_ptr->pixels_ss_max,
 	    mb_io_ptr->format_name, mb_io_ptr->system_name, mb_io_ptr->format_description, &mb_io_ptr->numfile, &mb_io_ptr->filetype,
 	    &mb_io_ptr->variable_beams, &mb_io_ptr->traveltime, &mb_io_ptr->beam_flagging, &mb_io_ptr->platform_source,

--- a/src/mbio/mbr_elmk2unb.c
+++ b/src/mbio/mbr_elmk2unb.c
@@ -45,7 +45,6 @@ int mbr_info_elmk2unb(int verbose, int *system, int *beams_bath_max, int *beams_
                       int *heading_source, int *attitude_source, int *svp_source, double *beamwidth_xtrack,
                       double *beamwidth_ltrack, int *error) {
 	char *function_name = "mbr_info_elmk2unb";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -55,7 +54,6 @@ int mbr_info_elmk2unb(int verbose, int *system, int *beams_bath_max, int *beams_
 	}
 
 	/* set format info parameters */
-	status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 	*system = MB_SYS_ELACMK2;
 	*beams_bath_max = 126;
@@ -81,6 +79,8 @@ int mbr_info_elmk2unb(int verbose, int *system, int *beams_bath_max, int *beams_
 	*svp_source = MB_DATA_VELOCITY_PROFILE;
 	*beamwidth_xtrack = 3.0;
 	*beamwidth_ltrack = 3.0;
+
+	const int status = MB_SUCCESS;
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -116,7 +116,6 @@ int mbr_info_elmk2unb(int verbose, int *system, int *beams_bath_max, int *beams_
 /*--------------------------------------------------------------------*/
 int mbr_zero_elmk2unb(int verbose, void *data_ptr, int *error) {
 	char *function_name = "mbr_zero_elmk2unb";
-	int status = MB_SUCCESS;
 	struct mbf_elmk2unb_struct *data;
 
 	/* print input debug statements */
@@ -243,7 +242,7 @@ int mbr_zero_elmk2unb(int verbose, void *data_ptr, int *error) {
 	}
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 
 	/* print output debug statements */
@@ -260,7 +259,6 @@ int mbr_zero_elmk2unb(int verbose, void *data_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_alm_elmk2unb(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_alm_elmk2unb";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -273,13 +271,10 @@ int mbr_alm_elmk2unb(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to mbio descriptor */
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-	/* set initial status */
-	status = MB_SUCCESS;
-
 	/* allocate memory for data structure */
 	mb_io_ptr->structure_size = sizeof(struct mbf_elmk2unb_struct);
 	mb_io_ptr->data_structure_size = 0;
-	status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
 	mbsys_elacmk2_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* initialize everything to zeros */
@@ -299,7 +294,6 @@ int mbr_alm_elmk2unb(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dem_elmk2unb(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_dem_elmk2unb";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -313,8 +307,8 @@ int mbr_dem_elmk2unb(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* deallocate memory for data descriptor */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->store_data, error);
+	int status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
+	status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->store_data, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -330,7 +324,6 @@ int mbr_dem_elmk2unb(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_rd_comment(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct *data, int *error) {
 	char *function_name = "mbr_elmk2unb_rd_comment";
-	int status = MB_SUCCESS;
 	char line[ELACMK2_COMMENT_SIZE + 3];
 
 	/* print input debug statements */
@@ -343,7 +336,7 @@ int mbr_elmk2unb_rd_comment(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct 
 	}
 
 	/* read record into char array */
-	status = fread(line, 1, ELACMK2_COMMENT_SIZE + 3, mbfp);
+	int status = fread(line, 1, ELACMK2_COMMENT_SIZE + 3, mbfp);
 	if (status == ELACMK2_COMMENT_SIZE + 3)
 		status = MB_SUCCESS;
 	else {
@@ -377,7 +370,6 @@ int mbr_elmk2unb_rd_comment(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct 
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_rd_parameter(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct *data, int *error) {
 	char *function_name = "mbr_elmk2unb_rd_parameter";
-	int status = MB_SUCCESS;
 	char line[ELACMK2_PARAMETER_SIZE + 3];
 	short int *short_ptr;
 
@@ -391,7 +383,7 @@ int mbr_elmk2unb_rd_parameter(int verbose, FILE *mbfp, struct mbf_elmk2unb_struc
 	}
 
 	/* read record into char array */
-	status = fread(line, 1, ELACMK2_PARAMETER_SIZE + 3, mbfp);
+	int status = fread(line, 1, ELACMK2_PARAMETER_SIZE + 3, mbfp);
 	if (status == ELACMK2_PARAMETER_SIZE + 3)
 		status = MB_SUCCESS;
 	else {
@@ -557,7 +549,6 @@ int mbr_elmk2unb_rd_parameter(int verbose, FILE *mbfp, struct mbf_elmk2unb_struc
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_rd_pos(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct *data, int *error) {
 	char *function_name = "mbr_elmk2unb_rd_pos";
-	int status = MB_SUCCESS;
 	char line[ELACMK2_POS_SIZE + 3];
 	short int *short_ptr;
 	int *int_ptr;
@@ -572,7 +563,7 @@ int mbr_elmk2unb_rd_pos(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct *dat
 	}
 
 	/* read record into char array */
-	status = fread(line, 1, ELACMK2_POS_SIZE + 3, mbfp);
+	int status = fread(line, 1, ELACMK2_POS_SIZE + 3, mbfp);
 	if (status == ELACMK2_POS_SIZE + 3)
 		status = MB_SUCCESS;
 	else {
@@ -674,7 +665,6 @@ int mbr_elmk2unb_rd_pos(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct *dat
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_rd_svp(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct *data, int *error) {
 	char *function_name = "mbr_elmk2unb_rd_svp";
-	int status = MB_SUCCESS;
 	char line[ELACMK2_SVP_SIZE + 3];
 	short int *short_ptr;
 	short int *short_ptr2;
@@ -690,7 +680,7 @@ int mbr_elmk2unb_rd_svp(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct *dat
 	}
 
 	/* read record into char array */
-	status = fread(line, 1, ELACMK2_SVP_SIZE + 3, mbfp);
+	int status = fread(line, 1, ELACMK2_SVP_SIZE + 3, mbfp);
 	if (status == ELACMK2_SVP_SIZE + 3)
 		status = MB_SUCCESS;
 	else {
@@ -768,7 +758,6 @@ int mbr_elmk2unb_rd_svp(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct *dat
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_rd_bathgen(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct *data, int *error) {
 	char *function_name = "mbr_elmk2unb_rd_bathgen";
-	int status = MB_SUCCESS;
 	char line[ELACMK2_COMMENT_SIZE];
 	short int *short_ptr;
 	int *int_ptr;
@@ -783,7 +772,7 @@ int mbr_elmk2unb_rd_bathgen(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct 
 	}
 
 	/* read record into char array */
-	status = fread(line, 1, ELACMK2_BATHGEN_HDR_SIZE, mbfp);
+	int status = fread(line, 1, ELACMK2_BATHGEN_HDR_SIZE, mbfp);
 	if (status == ELACMK2_BATHGEN_HDR_SIZE)
 		status = MB_SUCCESS;
 	else {
@@ -964,7 +953,6 @@ int mbr_elmk2unb_rd_bathgen(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct 
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_rd_data(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_elmk2unb_rd_data";
-	int status = MB_SUCCESS;
 	struct mbf_elmk2unb_struct *data;
 	char *data_ptr;
 	FILE *mbfp;
@@ -991,6 +979,7 @@ int mbr_elmk2unb_rd_data(int verbose, void *mbio_ptr, int *error) {
 	/* set file position */
 	mb_io_ptr->file_pos = mb_io_ptr->file_bytes;
 
+	int status = MB_SUCCESS;
 	done = MB_NO;
 	type = (short int *)label;
 	*error = MB_ERROR_NO_ERROR;
@@ -1077,7 +1066,6 @@ int mbr_elmk2unb_rd_data(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_rt_elmk2unb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_rt_elmk2unb";
-	int status = MB_SUCCESS;
 	struct mbf_elmk2unb_struct *data;
 	struct mbsys_elacmk2_struct *store;
 	int time_i[7];
@@ -1099,7 +1087,7 @@ int mbr_rt_elmk2unb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	store = (struct mbsys_elacmk2_struct *)store_ptr;
 
 	/* read next data from file */
-	status = mbr_elmk2unb_rd_data(verbose, mbio_ptr, error);
+	const int status = mbr_elmk2unb_rd_data(verbose, mbio_ptr, error);
 
 	/* set error and kind in mb_io_ptr */
 	mb_io_ptr->new_error = *error;
@@ -1275,7 +1263,6 @@ int mbr_rt_elmk2unb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_wr_comment(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	char *function_name = "mbr_elmk2unb_wr_comment";
-	int status = MB_SUCCESS;
 	struct mbf_elmk2unb_struct *data;
 	char line[ELACMK2_COMMENT_SIZE + 3];
 	short int label;
@@ -1304,7 +1291,7 @@ int mbr_elmk2unb_wr_comment(int verbose, FILE *mbfp, void *data_ptr, int *error)
 #ifdef BYTESWAPPED
 	label = (short)mb_swap_short(label);
 #endif
-	status = fwrite(&label, 1, 2, mbfp);
+	int status = fwrite(&label, 1, 2, mbfp);
 	if (status != 2) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -1352,7 +1339,6 @@ int mbr_elmk2unb_wr_comment(int verbose, FILE *mbfp, void *data_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_wr_parameter(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	char *function_name = "mbr_elmk2unb_wr_parameter";
-	int status = MB_SUCCESS;
 	struct mbf_elmk2unb_struct *data;
 	char line[ELACMK2_PARAMETER_SIZE + 3];
 	short int label;
@@ -1411,7 +1397,7 @@ int mbr_elmk2unb_wr_parameter(int verbose, FILE *mbfp, void *data_ptr, int *erro
 #ifdef BYTESWAPPED
 	label = (short)mb_swap_short(label);
 #endif
-	status = fwrite(&label, 1, 2, mbfp);
+	int status = fwrite(&label, 1, 2, mbfp);
 	if (status != 2) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -1555,7 +1541,6 @@ int mbr_elmk2unb_wr_parameter(int verbose, FILE *mbfp, void *data_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_wr_pos(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	char *function_name = "mbr_elmk2unb_wr_pos";
-	int status = MB_SUCCESS;
 	struct mbf_elmk2unb_struct *data;
 	char line[ELACMK2_POS_SIZE + 3];
 	short int label;
@@ -1603,7 +1588,7 @@ int mbr_elmk2unb_wr_pos(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 #ifdef BYTESWAPPED
 	label = (short)mb_swap_short(label);
 #endif
-	status = fwrite(&label, 1, 2, mbfp);
+	int status = fwrite(&label, 1, 2, mbfp);
 	if (status != 2) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -1691,7 +1676,6 @@ int mbr_elmk2unb_wr_pos(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_wr_svp(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	char *function_name = "mbr_elmk2unb_wr_svp";
-	int status = MB_SUCCESS;
 	struct mbf_elmk2unb_struct *data;
 	char line[ELACMK2_SVP_SIZE + 3];
 	short int label;
@@ -1734,7 +1718,7 @@ int mbr_elmk2unb_wr_svp(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 #ifdef BYTESWAPPED
 	label = (short)mb_swap_short(label);
 #endif
-	status = fwrite(&label, 1, 2, mbfp);
+	int status = fwrite(&label, 1, 2, mbfp);
 	if (status != 2) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -1811,7 +1795,6 @@ int mbr_elmk2unb_wr_svp(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_wr_bathgen(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	char *function_name = "mbr_elmk2unb_wr_bathgen";
-	int status = MB_SUCCESS;
 	struct mbf_elmk2unb_struct *data;
 	char line[ELACMK2_COMMENT_SIZE];
 	short int label;
@@ -1872,7 +1855,7 @@ int mbr_elmk2unb_wr_bathgen(int verbose, FILE *mbfp, void *data_ptr, int *error)
 #ifdef BYTESWAPPED
 	label = (short)mb_swap_short(label);
 #endif
-	status = fwrite(&label, 1, 2, mbfp);
+	int status = fwrite(&label, 1, 2, mbfp);
 	if (status != 2) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -2031,7 +2014,6 @@ int mbr_elmk2unb_wr_bathgen(int verbose, FILE *mbfp, void *data_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_elmk2unb_wr_data(int verbose, void *mbio_ptr, void *data_ptr, int *error) {
 	char *function_name = "mbr_elmk2unb_wr_data";
-	int status = MB_SUCCESS;
 	struct mbf_elmk2unb_struct *data;
 	FILE *mbfp;
 
@@ -2050,6 +2032,8 @@ int mbr_elmk2unb_wr_data(int verbose, void *mbio_ptr, void *data_ptr, int *error
 	/* get pointer to raw data structure */
 	data = (struct mbf_elmk2unb_struct *)data_ptr;
 	mbfp = mb_io_ptr->mbfp;
+
+	int status = MB_SUCCESS;
 
 	if (data->kind == MB_DATA_COMMENT) {
 		status = mbr_elmk2unb_wr_comment(verbose, mbfp, data, error);
@@ -2091,7 +2075,6 @@ int mbr_elmk2unb_wr_data(int verbose, void *mbio_ptr, void *data_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbr_wt_elmk2unb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_wt_elmk2unb";
-	int status = MB_SUCCESS;
 	struct mbf_elmk2unb_struct *data;
 	char *data_ptr;
 	struct mbsys_elacmk2_struct *store;
@@ -2224,7 +2207,7 @@ int mbr_wt_elmk2unb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	}
 
 	/* write next data to file */
-	status = mbr_elmk2unb_wr_data(verbose, mbio_ptr, data_ptr, error);
+	const int status = mbr_elmk2unb_wr_data(verbose, mbio_ptr, data_ptr, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -2241,7 +2224,6 @@ int mbr_wt_elmk2unb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_register_elmk2unb(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_register_elmk2unb";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -2254,7 +2236,7 @@ int mbr_register_elmk2unb(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* set format info parameters */
-	status = mbr_info_elmk2unb(
+	const int status = mbr_info_elmk2unb(
 	    verbose, &mb_io_ptr->system, &mb_io_ptr->beams_bath_max, &mb_io_ptr->beams_amp_max, &mb_io_ptr->pixels_ss_max,
 	    mb_io_ptr->format_name, mb_io_ptr->system_name, mb_io_ptr->format_description, &mb_io_ptr->numfile, &mb_io_ptr->filetype,
 	    &mb_io_ptr->variable_beams, &mb_io_ptr->traveltime, &mb_io_ptr->beam_flagging, &mb_io_ptr->platform_source,

--- a/src/mbio/mbr_em12darw.c
+++ b/src/mbio/mbr_em12darw.c
@@ -43,7 +43,6 @@ int mbr_info_em12darw(int verbose, int *system, int *beams_bath_max, int *beams_
                       int *heading_source, int *attitude_source, int *svp_source, double *beamwidth_xtrack,
                       double *beamwidth_ltrack, int *error) {
 	char *function_name = "mbr_info_em12darw";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -53,7 +52,6 @@ int mbr_info_em12darw(int verbose, int *system, int *beams_bath_max, int *beams_
 	}
 
 	/* set format info parameters */
-	status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 	*system = MB_SYS_SIMRAD;
 	*beams_bath_max = MBF_EM12DARW_BEAMS;
@@ -78,6 +76,8 @@ int mbr_info_em12darw(int verbose, int *system, int *beams_bath_max, int *beams_
 	*svp_source = MB_DATA_NONE;
 	*beamwidth_xtrack = 2.0;
 	*beamwidth_ltrack = 2.0;
+
+	const int status = MB_SUCCESS;
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -113,7 +113,6 @@ int mbr_info_em12darw(int verbose, int *system, int *beams_bath_max, int *beams_
 /*--------------------------------------------------------------------*/
 int mbr_zero_em12darw(int verbose, char *data_ptr, int *error) {
 	char *function_name = "mbr_zero_em12darw";
-	int status = MB_SUCCESS;
 	struct mbf_em12darw_struct *data;
 
 	/* print input debug statements */
@@ -169,7 +168,7 @@ int mbr_zero_em12darw(int verbose, char *data_ptr, int *error) {
 	}
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 
 	/* print output debug statements */
@@ -186,7 +185,6 @@ int mbr_zero_em12darw(int verbose, char *data_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_alm_em12darw(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_alm_em12darw";
-	int status = MB_SUCCESS;
 	struct mbf_em12darw_struct *data;
 	char *data_ptr;
 
@@ -201,13 +199,10 @@ int mbr_alm_em12darw(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to mbio descriptor */
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-	/* set initial status */
-	status = MB_SUCCESS;
-
 	/* allocate memory for data structure */
 	mb_io_ptr->structure_size = sizeof(struct mbf_em12darw_struct);
-	status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
-	status = mbsys_simrad_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	int status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
+	status &= mbsys_simrad_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* get pointer to mbio descriptor */
 	mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
@@ -231,7 +226,6 @@ int mbr_alm_em12darw(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dem_em12darw(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_dem_em12darw";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 
 	/* print input debug statements */
@@ -247,8 +241,8 @@ int mbr_dem_em12darw(int verbose, void *mbio_ptr, int *error) {
 	store = (struct mbsys_simrad_struct *)mb_io_ptr->store_data;
 
 	/* deallocate memory for data descriptor */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
-	status = mbsys_simrad_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	int status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
+	status &= mbsys_simrad_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -264,7 +258,6 @@ int mbr_dem_em12darw(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_rt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_rt_em12darw";
-	int status = MB_SUCCESS;
 	struct mbf_em12darw_struct *data;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
@@ -294,6 +287,8 @@ int mbr_rt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 
 	/* set file position */
 	mb_io_ptr->file_pos = mb_io_ptr->file_bytes;
+
+	int status = MB_SUCCESS;
 
 	/* read next record from file */
 	if ((status = fread(line, 1, MBF_EM12DARW_RECORD_LENGTH, mb_io_ptr->mbfp)) == MBF_EM12DARW_RECORD_LENGTH) {
@@ -553,7 +548,6 @@ int mbr_rt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_wt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_wt_em12darw";
-	int status = MB_SUCCESS;
 	struct mbf_em12darw_struct *data;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
@@ -586,7 +580,6 @@ int mbr_wt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "\ndbg5  Status at beginning of MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5       store->kind:    %d\n", store->kind);
 		fprintf(stderr, "dbg5       error:          %d\n", *error);
-		fprintf(stderr, "dbg5       status:         %d\n", status);
 	}
 
 	/*  translate values from em12 data storage structure */
@@ -668,16 +661,14 @@ int mbr_wt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5       store->kind:       %d\n", store->kind);
 		fprintf(stderr, "dbg5       error:             %d\n", *error);
-		fprintf(stderr, "dbg5       status:            %d\n", status);
 	}
 
 	/* print debug statements */
-	if (verbose >= 4 && status == MB_SUCCESS) {
+	if (verbose >= 4) {
 		fprintf(stderr, "\ndbg4  Data to be written by MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg4  Status values:\n");
 		fprintf(stderr, "dbg4       store->kind:%d\n", store->kind);
 		fprintf(stderr, "dbg4       error:      %d\n", *error);
-		fprintf(stderr, "dbg4       status:     %d\n", status);
 		if (store->kind == MB_DATA_DATA) {
 			fprintf(stderr, "dbg4  Survey values:\n");
 			fprintf(stderr, "dbg4       year:       %d\n", data->year);
@@ -710,7 +701,7 @@ int mbr_wt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	}
 
 	/* deal with comment */
-	if (status == MB_SUCCESS && store->kind == MB_DATA_COMMENT) {
+	if (store->kind == MB_DATA_COMMENT) {
 		index = 0;
 		for (int i = 0; i < MBF_EM12DARW_RECORD_LENGTH; i++)
 			line[i] = 0;
@@ -720,7 +711,7 @@ int mbr_wt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	}
 
 	/* deal with data */
-	else if (status == MB_SUCCESS && store->kind == MB_DATA_DATA) {
+	else if (store->kind == MB_DATA_DATA) {
 		index = 0;
 		mb_put_binary_short(MB_NO, data->func, &line[0]);
 		index += 2;
@@ -788,6 +779,8 @@ int mbr_wt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 	}
 
+	int status = MB_SUCCESS;
+
 	/* write next record to file */
 	if (store->kind == MB_DATA_DATA || store->kind == MB_DATA_COMMENT) {
 		if ((status = fwrite(line, 1, MBF_EM12DARW_RECORD_LENGTH, mb_io_ptr->mbfp)) == MBF_EM12DARW_RECORD_LENGTH) {
@@ -821,7 +814,6 @@ int mbr_wt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_register_em12darw(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_register_em12darw";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -834,7 +826,7 @@ int mbr_register_em12darw(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* set format info parameters */
-	status = mbr_info_em12darw(
+	const int status = mbr_info_em12darw(
 	    verbose, &mb_io_ptr->system, &mb_io_ptr->beams_bath_max, &mb_io_ptr->beams_amp_max, &mb_io_ptr->pixels_ss_max,
 	    mb_io_ptr->format_name, mb_io_ptr->system_name, mb_io_ptr->format_description, &mb_io_ptr->numfile, &mb_io_ptr->filetype,
 	    &mb_io_ptr->variable_beams, &mb_io_ptr->traveltime, &mb_io_ptr->beam_flagging, &mb_io_ptr->platform_source,

--- a/src/mbio/mbr_em12ifrm.c
+++ b/src/mbio/mbr_em12ifrm.c
@@ -50,7 +50,6 @@ int mbr_info_em12ifrm(int verbose, int *system, int *beams_bath_max, int *beams_
                       int *heading_source, int *attitude_source, int *svp_source, double *beamwidth_xtrack,
                       double *beamwidth_ltrack, int *error) {
 	char *function_name = "mbr_info_em12ifrm";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -60,7 +59,6 @@ int mbr_info_em12ifrm(int verbose, int *system, int *beams_bath_max, int *beams_
 	}
 
 	/* set format info parameters */
-	status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 	*system = MB_SYS_SIMRAD;
 	*beams_bath_max = MBF_EM12IFRM_MAXBEAMS;
@@ -86,6 +84,8 @@ int mbr_info_em12ifrm(int verbose, int *system, int *beams_bath_max, int *beams_
 	*svp_source = MB_DATA_NONE;
 	*beamwidth_xtrack = 2.0;
 	*beamwidth_ltrack = 2.0;
+
+	const int status = MB_SUCCESS;
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -121,7 +121,6 @@ int mbr_info_em12ifrm(int verbose, int *system, int *beams_bath_max, int *beams_
 /*--------------------------------------------------------------------*/
 int mbr_zero_em12ifrm(int verbose, char *data_ptr, int *error) {
 	char *function_name = "mbr_zero_em12ifrm";
-	int status = MB_SUCCESS;
 	struct mbf_em12ifrm_struct *data;
 
 	/* print input debug statements */
@@ -256,7 +255,7 @@ int mbr_zero_em12ifrm(int verbose, char *data_ptr, int *error) {
 	}
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 
 	/* print output debug statements */
@@ -273,7 +272,6 @@ int mbr_zero_em12ifrm(int verbose, char *data_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_alm_em12ifrm(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_alm_em12ifrm";
-	int status = MB_SUCCESS;
 	struct stat imgfile_status, navfile_status;
 	int imgfile_stat, navfile_stat;
 	char path[MB_PATH_MAXLINE];
@@ -298,8 +296,8 @@ int mbr_alm_em12ifrm(int verbose, void *mbio_ptr, int *error) {
 	/* allocate memory for data structure */
 	mb_io_ptr->structure_size = sizeof(struct mbf_em12ifrm_struct);
 	mb_io_ptr->data_structure_size = 0;
-	status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
-	status = mbsys_simrad_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	int status = mb_mallocd(verbose, __FILE__, __LINE__, mb_io_ptr->structure_size, &mb_io_ptr->raw_data, error);
+	status &= mbsys_simrad_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* initialize everything to zeros */
 	mbr_zero_em12ifrm(verbose, mb_io_ptr->raw_data, error);
@@ -409,7 +407,6 @@ int mbr_alm_em12ifrm(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dem_em12ifrm(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_dem_em12ifrm";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -423,8 +420,8 @@ int mbr_dem_em12ifrm(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* deallocate memory for data descriptor */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
-	status = mbsys_simrad_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	int status = mb_freed(verbose, __FILE__, __LINE__, (void **)&mb_io_ptr->raw_data, error);
+	status &= mbsys_simrad_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -440,7 +437,6 @@ int mbr_dem_em12ifrm(int verbose, void *mbio_ptr, int *error) {
 
 int mbr_em12ifrm_rd_data(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_em12ifrm_rd_data";
-	int status = MB_SUCCESS;
 	struct mbf_em12ifrm_struct *data;
 	int *save_data;
 	int *nav_available;
@@ -505,6 +501,9 @@ int mbr_em12ifrm_rd_data(int verbose, void *mbio_ptr, int *error) {
 	ss_centisecond = (int *)&mb_io_ptr->save12;
 	ss_ping_number = (int *)&mb_io_ptr->save13;
 	ss_num_beams = (int *)&mb_io_ptr->save14;
+
+	int status = MB_SUCCESS;
+
 	if (*save_data == MB_DATA_DATA) {
 		data->kind = MB_DATA_DATA;
 		*save_data = MB_DATA_NONE;
@@ -963,7 +962,6 @@ int mbr_em12ifrm_rd_data(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_rt_em12ifrm(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_rt_em12ifrm";
-	int status = MB_SUCCESS;
 	struct mbf_em12ifrm_struct *data;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
@@ -995,7 +993,7 @@ int mbr_rt_em12ifrm(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	swath_width = (double *)&mb_io_ptr->saved2;
 
 	/* read next data from file */
-	status = mbr_em12ifrm_rd_data(verbose, mbio_ptr, error);
+	int status = mbr_em12ifrm_rd_data(verbose, mbio_ptr, error);
 
 	/* set error and kind in mb_io_ptr */
 	mb_io_ptr->new_error = *error;
@@ -1207,7 +1205,6 @@ int mbr_rt_em12ifrm(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_wt_em12ifrm(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_wt_em12ifrm";
-	int status = MB_SUCCESS;
 	struct mbf_em12ifrm_struct *data;
 	char *data_ptr;
 	struct mbsys_simrad_struct *store;
@@ -1353,7 +1350,7 @@ int mbr_wt_em12ifrm(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	}
 
 	/* set error as this is a read only format */
-	status = MB_FAILURE;
+	const int status = MB_SUCCESS;
 	*error = MB_ERROR_WRITE_FAIL;
 
 	/* write next data to file */
@@ -1374,7 +1371,6 @@ int mbr_wt_em12ifrm(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_em12ifrm_wr_data(int verbose, void *mbio_ptr, char *data_ptr, int *error) {
 	char *function_name = "mbr_em12ifrm_wr_data";
-	int status = MB_SUCCESS;
 	struct mbf_em12ifrm_struct *data;
 	char line[MBF_EM12IFRM_RECORD_SIZE] = "";
 	int shift;
@@ -1402,7 +1398,6 @@ int mbr_em12ifrm_wr_data(int verbose, void *mbio_ptr, char *data_ptr, int *error
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", function_name);
 		fprintf(stderr, "dbg5       kind:       %d\n", mb_io_ptr->new_kind);
 		fprintf(stderr, "dbg5       error:      %d\n", *error);
-		fprintf(stderr, "dbg5       status:     %d\n", status);
 	}
 
 	/* print debug statements */
@@ -1545,6 +1540,8 @@ int mbr_em12ifrm_wr_data(int verbose, void *mbio_ptr, char *data_ptr, int *error
 		shift += 1;
 	}
 
+	int status = MB_SUCCESS;
+
 	/* write next record to file */
 	if (status == MB_SUCCESS) {
 		if ((status = fwrite(line, 1, MBF_EM12IFRM_RECORD_SIZE, mb_io_ptr->mbfp)) == MBF_EM12IFRM_RECORD_SIZE) {
@@ -1578,7 +1575,6 @@ int mbr_em12ifrm_wr_data(int verbose, void *mbio_ptr, char *data_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbr_register_em12ifrm(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_register_em12ifrm";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -1591,7 +1587,7 @@ int mbr_register_em12ifrm(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* set format info parameters */
-	status = mbr_info_em12ifrm(
+	const int status = mbr_info_em12ifrm(
 	    verbose, &mb_io_ptr->system, &mb_io_ptr->beams_bath_max, &mb_io_ptr->beams_amp_max, &mb_io_ptr->pixels_ss_max,
 	    mb_io_ptr->format_name, mb_io_ptr->system_name, mb_io_ptr->format_description, &mb_io_ptr->numfile, &mb_io_ptr->filetype,
 	    &mb_io_ptr->variable_beams, &mb_io_ptr->traveltime, &mb_io_ptr->beam_flagging, &mb_io_ptr->platform_source,

--- a/src/mbio/mbr_em300mba.c
+++ b/src/mbio/mbr_em300mba.c
@@ -47,7 +47,6 @@ int mbr_info_em300mba(int verbose, int *system, int *beams_bath_max, int *beams_
                       int *heading_source, int *attitude_source, int *svp_source, double *beamwidth_xtrack,
                       double *beamwidth_ltrack, int *error) {
 	char *function_name = "mbr_info_em300mba";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -57,7 +56,6 @@ int mbr_info_em300mba(int verbose, int *system, int *beams_bath_max, int *beams_
 	}
 
 	/* set format info parameters */
-	status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 	*system = MB_SYS_SIMRAD2;
 	*beams_bath_max = 254;
@@ -84,6 +82,8 @@ int mbr_info_em300mba(int verbose, int *system, int *beams_bath_max, int *beams_
 	*svp_source = MB_DATA_VELOCITY_PROFILE;
 	*beamwidth_xtrack = 2.0;
 	*beamwidth_ltrack = 2.0;
+
+	const int status = MB_SUCCESS;
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -119,7 +119,6 @@ int mbr_info_em300mba(int verbose, int *system, int *beams_bath_max, int *beams_
 /*--------------------------------------------------------------------*/
 int mbr_alm_em300mba(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_alm_em300mba";
-	int status = MB_SUCCESS;
 	int *databyteswapped;
 	double *pixel_size;
 	double *swath_width;
@@ -135,13 +134,10 @@ int mbr_alm_em300mba(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to mbio descriptor */
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-	/* set initial status */
-	status = MB_SUCCESS;
-
 	/* allocate memory for data structure */
 	mb_io_ptr->structure_size = 0;
 	mb_io_ptr->data_structure_size = 0;
-	status = mbsys_simrad2_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	const int status = mbsys_simrad2_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* initialize everything to zeros */
 	databyteswapped = (int *)&mb_io_ptr->save10;
@@ -165,7 +161,6 @@ int mbr_alm_em300mba(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dem_em300mba(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_dem_em300mba";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -179,7 +174,7 @@ int mbr_dem_em300mba(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* deallocate memory for data descriptor */
-	status = mbsys_simrad2_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	const int status = mbsys_simrad2_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -195,7 +190,6 @@ int mbr_dem_em300mba(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_chk_label(int verbose, void *mbio_ptr, char *label, short *type, short *sonar) {
 	char *function_name = "mbr_em300mba_chk_label";
-	int status = MB_SUCCESS;
 	mb_u_char startbyte;
 	mb_u_char typebyte;
 	short *sonar_save;
@@ -320,6 +314,9 @@ int mbr_em300mba_chk_label(int verbose, void *mbio_ptr, char *label, short *type
 		if (verbose >= 1)
 			fprintf(stderr, "Bad datagram type: %4.4hX %4.4hX | %d %d\n", *type, *sonar, *type, *sonar);
 	}
+
+	int status = MB_SUCCESS;
+
 	if (typegood != MB_YES || sonargood != MB_YES) {
 		status = MB_FAILURE;
 	}
@@ -362,7 +359,6 @@ int mbr_em300mba_chk_label(int verbose, void *mbio_ptr, char *label, short *type
 int mbr_em300mba_rd_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short type, short sonar,
                           int *version, int *error) {
 	char *function_name = "mbr_em300mba_rd_start";
-	int status = MB_SUCCESS;
 	char line[MBSYS_SIMRAD2_BUFFER_SIZE];
 	short short_val;
 	int read_len, len;
@@ -388,6 +384,8 @@ int mbr_em300mba_rd_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 	/* set type value */
 	store->type = type;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary values into char array */
 	read_len = fread(line, 1, EM2_START_HEADER_SIZE, mbfp);
@@ -731,7 +729,6 @@ file will return error */
 int mbr_em300mba_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar,
                                   int *error) {
 	char *function_name = "mbr_em300mba_rd_run_parameter";
-	int status = MB_SUCCESS;
 	char line[EM2_RUN_PARAMETER_SIZE];
 	short short_val;
 	int read_len;
@@ -751,6 +748,8 @@ int mbr_em300mba_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 	store->kind = MB_DATA_RUN_PARAMETER;
 	store->type = EM2_RUN_PARAMETER;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary values into char array */
 	read_len = fread(line, 1, EM2_RUN_PARAMETER_SIZE - 4, mbfp);
@@ -853,7 +852,6 @@ int mbr_em300mba_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_clock";
-	int status = MB_SUCCESS;
 	char line[EM2_CLOCK_SIZE];
 	short short_val;
 	int read_len;
@@ -873,6 +871,8 @@ int mbr_em300mba_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 	store->kind = MB_DATA_CLOCK;
 	store->type = EM2_CLOCK;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary values into char array */
 	read_len = fread(line, 1, EM2_CLOCK_SIZE - 4, mbfp);
@@ -932,7 +932,6 @@ int mbr_em300mba_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_tide";
-	int status = MB_SUCCESS;
 	char line[EM2_TIDE_SIZE];
 	short short_val;
 	int read_len;
@@ -952,6 +951,8 @@ int mbr_em300mba_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	store->kind = MB_DATA_TIDE;
 	store->type = EM2_TIDE;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary values into char array */
 	read_len = fread(line, 1, EM2_TIDE_SIZE - 4, mbfp);
@@ -1012,7 +1013,6 @@ int mbr_em300mba_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_height";
-	int status = MB_SUCCESS;
 	char line[EM2_HEIGHT_SIZE];
 	short short_val;
 	int read_len;
@@ -1032,6 +1032,8 @@ int mbr_em300mba_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 	store->kind = MB_DATA_HEIGHT;
 	store->type = EM2_HEIGHT;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary values into char array */
 	read_len = fread(line, 1, EM2_HEIGHT_SIZE - 4, mbfp);
@@ -1089,7 +1091,6 @@ int mbr_em300mba_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_heading";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_heading_struct *heading;
 	char line[EM2_HEADING_HEADER_SIZE];
 	short short_val;
@@ -1113,6 +1114,8 @@ int mbr_em300mba_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 	store->kind = MB_DATA_HEADING;
 	store->type = EM2_HEADING;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_HEADING_HEADER_SIZE, mbfp);
@@ -1208,7 +1211,6 @@ int mbr_em300mba_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_ssv";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ssv_struct *ssv;
 	char line[EM2_SSV_HEADER_SIZE];
 	short short_val;
@@ -1232,6 +1234,8 @@ int mbr_em300mba_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 	store->kind = MB_DATA_SSV;
 	store->type = EM2_SSV;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_SSV_HEADER_SIZE, mbfp);
@@ -1325,7 +1329,6 @@ int mbr_em300mba_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_tilt";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_tilt_struct *tilt;
 	char line[EM2_TILT_HEADER_SIZE];
 	short short_val;
@@ -1349,6 +1352,8 @@ int mbr_em300mba_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	store->kind = MB_DATA_TILT;
 	store->type = EM2_TILT;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_TILT_HEADER_SIZE, mbfp);
@@ -1443,7 +1448,6 @@ int mbr_em300mba_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 int mbr_em300mba_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar,
                                     int *error) {
 	char *function_name = "mbr_em300mba_rd_extraparameters";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_extraparameters_struct *extraparameters;
 	char line[EM2_EXTRAPARAMETERS_HEADER_SIZE];
 	short short_val;
@@ -1467,6 +1471,8 @@ int mbr_em300mba_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 	store->kind = MB_DATA_PARAMETER;
 	store->type = EM2_EXTRAPARAMETERS;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_EXTRAPARAMETERS_HEADER_SIZE, mbfp);
@@ -1582,7 +1588,6 @@ int mbr_em300mba_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_attitude";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_attitude_struct *attitude;
 	char line[EM2_ATTITUDE_HEADER_SIZE];
 	short short_val;
@@ -1606,6 +1611,8 @@ int mbr_em300mba_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	store->kind = MB_DATA_ATTITUDE;
 	store->type = EM2_ATTITUDE;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_ATTITUDE_HEADER_SIZE, mbfp);
@@ -1710,7 +1717,6 @@ int mbr_em300mba_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_pos";
-	int status = MB_SUCCESS;
 	char line[MBSYS_SIMRAD2_COMMENT_LENGTH];
 	short short_val;
 	int read_len;
@@ -1732,6 +1738,8 @@ int mbr_em300mba_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 	store->kind = MB_DATA_NAV;
 	store->type = EM2_POS;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_POS_HEADER_SIZE, mbfp);
@@ -1876,7 +1884,6 @@ int mbr_em300mba_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_svp";
-	int status = MB_SUCCESS;
 	char line[EM2_SVP_HEADER_SIZE];
 	short short_val;
 	int read_len;
@@ -1896,6 +1903,8 @@ int mbr_em300mba_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 	store->kind = MB_DATA_VELOCITY_PROFILE;
 	store->type = EM2_SVP;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_SVP_HEADER_SIZE, mbfp);
@@ -1996,7 +2005,6 @@ int mbr_em300mba_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_svp2";
-	int status = MB_SUCCESS;
 	char line[EM2_SVP2_HEADER_SIZE];
 	short short_val;
 	int read_len;
@@ -2016,6 +2024,8 @@ int mbr_em300mba_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	store->kind = MB_DATA_VELOCITY_PROFILE;
 	store->type = EM2_SVP2;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_SVP_HEADER_SIZE, mbfp);
@@ -2115,7 +2125,6 @@ int mbr_em300mba_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 int mbr_em300mba_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *match, short sonar,
                          int version, int *error) {
 	char *function_name = "mbr_em300mba_rd_bath";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_BATH_MBA_HEADER_SIZE];
 	short short_val;
@@ -2144,6 +2153,8 @@ int mbr_em300mba_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	store->kind = MB_DATA_DATA;
 	store->type = EM2_BATH_MBA;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_BATH_MBA_HEADER_SIZE, mbfp);
@@ -2330,7 +2341,6 @@ int mbr_em300mba_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_rawbeam";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM_HEADER_SIZE];
 	short short_val;
@@ -2349,6 +2359,8 @@ int mbr_em300mba_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 
 	/* get  storage structure */
 	ping = (struct mbsys_simrad2_ping_struct *)store->ping;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_RAWBEAM_HEADER_SIZE, mbfp);
@@ -2473,7 +2485,6 @@ int mbr_em300mba_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_rawbeam2";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM2_HEADER_SIZE];
 	short short_val;
@@ -2493,6 +2504,8 @@ int mbr_em300mba_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 
 	/* get  storage structure */
 	ping = (struct mbsys_simrad2_ping_struct *)store->ping;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_RAWBEAM2_HEADER_SIZE, mbfp);
@@ -2702,7 +2715,6 @@ int mbr_em300mba_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_rawbeam3";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM3_HEADER_SIZE];
 	short short_val;
@@ -2726,6 +2738,8 @@ int mbr_em300mba_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	/* get  storage structure */
 	ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 	head = 0;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_RAWBEAM3_HEADER_SIZE, mbfp);
@@ -2920,7 +2934,6 @@ int mbr_em300mba_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 int mbr_em300mba_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int length, int *match,
                        int *error) {
 	char *function_name = "mbr_em300mba_rd_ss";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[2 * MBSYS_SIMRAD2_BUFFER_SIZE];
 	short short_val;
@@ -2953,6 +2966,8 @@ int mbr_em300mba_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 	store->kind = MB_DATA_DATA;
 	store->type = EM2_SS_MBA;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_SS_MBA_HEADER_SIZE, mbfp);
@@ -3262,7 +3277,6 @@ int mbr_em300mba_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char *function_name = "mbr_em300mba_rd_wc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_watercolumn_struct *wc;
 	char line[EM2_WC_HEADER_SIZE];
 	short short_val;
@@ -3289,6 +3303,8 @@ int mbr_em300mba_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 	store->type = EM2_WATERCOLUMN;
 	store->sonar = sonar;
 	file_bytes = ftell(mbfp);
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_WC_HEADER_SIZE, mbfp);
@@ -3465,7 +3481,6 @@ int mbr_em300mba_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_em300mba_rd_data";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 	struct mbsys_simrad2_extraparameters_struct *extraparameters;
@@ -3548,6 +3563,8 @@ int mbr_em300mba_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 
 	/* set flag to swap bytes if necessary */
 	swap = *databyteswapped;
+
+	int status = MB_SUCCESS;
 
 	/* loop over reading data until a record is ready for return */
 	done = MB_NO;
@@ -4148,7 +4165,6 @@ Have a nice day...\n");
 /*--------------------------------------------------------------------*/
 int mbr_rt_em300mba(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_rt_em300mba";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_attitude_struct *attitude;
 	struct mbsys_simrad2_heading_struct *heading;
@@ -4176,7 +4192,7 @@ int mbr_rt_em300mba(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* read next data from file */
-	status = mbr_em300mba_rd_data(verbose, mbio_ptr, store_ptr, error);
+	int status = mbr_em300mba_rd_data(verbose, mbio_ptr, store_ptr, error);
 
 	/* get pointers to data structures */
 	store = (struct mbsys_simrad2_struct *)store_ptr;
@@ -4337,7 +4353,6 @@ int mbr_rt_em300mba(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_start";
-	int status = MB_SUCCESS;
 	char line[MBSYS_SIMRAD2_BUFFER_SIZE], *buff;
 	int buff_len, write_len;
 	int write_size;
@@ -4448,15 +4463,13 @@ int mbr_em300mba_wr_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 	memset(line, 0, MBSYS_SIMRAD2_BUFFER_SIZE);
 
 	/* put binary header data into buffer */
-	if (status == MB_SUCCESS) {
-		mb_put_binary_short(swap, (short)store->type, (void *)&line[4]);
-		mb_put_binary_short(swap, (unsigned short)store->sonar, (void *)&line[6]);
-		mb_put_binary_int(swap, (int)store->par_date, (void *)&line[8]);
-		mb_put_binary_int(swap, (int)store->par_msec, (void *)&line[12]);
-		mb_put_binary_short(swap, (unsigned short)store->par_line_num, (void *)&line[16]);
-		mb_put_binary_short(swap, (unsigned short)store->par_serial_1, (void *)&line[18]);
-		mb_put_binary_short(swap, (unsigned short)store->par_serial_2, (void *)&line[20]);
-	}
+	mb_put_binary_short(swap, (short)store->type, (void *)&line[4]);
+	mb_put_binary_short(swap, (unsigned short)store->sonar, (void *)&line[6]);
+	mb_put_binary_int(swap, (int)store->par_date, (void *)&line[8]);
+	mb_put_binary_int(swap, (int)store->par_msec, (void *)&line[12]);
+	mb_put_binary_short(swap, (unsigned short)store->par_line_num, (void *)&line[16]);
+	mb_put_binary_short(swap, (unsigned short)store->par_serial_1, (void *)&line[18]);
+	mb_put_binary_short(swap, (unsigned short)store->par_serial_2, (void *)&line[20]);
 
 	/* construct ASCII parameter buffer */
 	buff = &line[22];
@@ -4637,6 +4650,8 @@ int mbr_em300mba_wr_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 	/* set checksum */
 	mb_put_binary_short(swap, (unsigned short)checksum, (void *)&line[buff_len + 23]);
 
+	int status = MB_SUCCESS;
+
 	/* finally write out the data */
 	write_len = fwrite(&line, 1, write_size, mbfp);
 	if (write_len != write_size) {
@@ -4660,7 +4675,6 @@ int mbr_em300mba_wr_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_run_parameter";
-	int status = MB_SUCCESS;
 	char line[EM2_RUN_PARAMETER_SIZE];
 	short label;
 	int write_len;
@@ -4713,6 +4727,8 @@ int mbr_em300mba_wr_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_RUN_PARAMETER_SIZE), (void *)&write_size);
@@ -4819,7 +4835,6 @@ int mbr_em300mba_wr_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_clock";
-	int status = MB_SUCCESS;
 	char line[EM2_CLOCK_SIZE];
 	short label;
 	int write_len;
@@ -4855,6 +4870,8 @@ int mbr_em300mba_wr_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_CLOCK_SIZE), (void *)&write_size);
@@ -4944,7 +4961,6 @@ int mbr_em300mba_wr_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_tide";
-	int status = MB_SUCCESS;
 	char line[EM2_TIDE_SIZE];
 	short label;
 	int write_len;
@@ -4980,6 +4996,8 @@ int mbr_em300mba_wr_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_TIDE_SIZE), (void *)&write_size);
@@ -5070,7 +5088,6 @@ int mbr_em300mba_wr_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_height(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_height";
-	int status = MB_SUCCESS;
 	char line[EM2_HEIGHT_SIZE];
 	short label;
 	int write_len;
@@ -5105,6 +5122,8 @@ int mbr_em300mba_wr_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_HEIGHT_SIZE), (void *)&write_size);
@@ -5193,7 +5212,6 @@ int mbr_em300mba_wr_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_heading";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_heading_struct *heading;
 	char line[EM2_HEADING_HEADER_SIZE];
 	short label;
@@ -5236,6 +5254,8 @@ int mbr_em300mba_wr_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_HEADING_HEADER_SIZE + EM2_HEADING_SLICE_SIZE * heading->hed_ndata + 8),
@@ -5367,7 +5387,6 @@ int mbr_em300mba_wr_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_ssv";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ssv_struct *ssv;
 	char line[EM2_SSV_HEADER_SIZE];
 	short label;
@@ -5409,6 +5428,8 @@ int mbr_em300mba_wr_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_SSV_HEADER_SIZE + EM2_SSV_SLICE_SIZE * ssv->ssv_ndata + 8), (void *)&write_size);
@@ -5539,7 +5560,6 @@ int mbr_em300mba_wr_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_tilt";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_tilt_struct *tilt;
 	char line[EM2_TILT_HEADER_SIZE];
 	short label;
@@ -5581,6 +5601,8 @@ int mbr_em300mba_wr_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_TILT_HEADER_SIZE + EM2_TILT_SLICE_SIZE * tilt->tlt_ndata + 8), (void *)&write_size);
@@ -5711,7 +5733,6 @@ int mbr_em300mba_wr_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_extraparameters(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_extraparameters";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_extraparameters_struct *extraparameters;
 	char line[EM2_EXTRAPARAMETERS_HEADER_SIZE];
 	short label;
@@ -5761,6 +5782,8 @@ int mbr_em300mba_wr_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_EXTRAPARAMETERS_HEADER_SIZE + extraparameters->xtr_data_size + 8), (void *)&write_size);
@@ -5887,7 +5910,6 @@ int mbr_em300mba_wr_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_attitude";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_attitude_struct *attitude;
 	char line[EM2_ATTITUDE_HEADER_SIZE];
 	short label;
@@ -5931,6 +5953,8 @@ int mbr_em300mba_wr_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_ATTITUDE_HEADER_SIZE + EM2_ATTITUDE_SLICE_SIZE * attitude->att_ndata + 8),
@@ -6066,7 +6090,6 @@ int mbr_em300mba_wr_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_pos";
-	int status = MB_SUCCESS;
 	char line[EM2_POS_HEADER_SIZE];
 	short label;
 	int write_len;
@@ -6108,6 +6131,8 @@ int mbr_em300mba_wr_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_POS_HEADER_SIZE + store->pos_input_size - (store->pos_input_size % 2) + 8),
@@ -6239,7 +6264,6 @@ int mbr_em300mba_wr_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_svp";
-	int status = MB_SUCCESS;
 	char line[EM2_SVP2_HEADER_SIZE];
 	short label;
 	int write_len;
@@ -6280,6 +6304,8 @@ int mbr_em300mba_wr_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_SVP2_HEADER_SIZE + EM2_SVP2_SLICE_SIZE * store->svp_num + 8), (void *)&write_size);
@@ -6413,7 +6439,6 @@ int mbr_em300mba_wr_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int head, int *error) {
 	char *function_name = "mbr_em300mba_wr_bath";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_BATH_MBA_HEADER_SIZE];
 	short label;
@@ -6473,6 +6498,8 @@ int mbr_em300mba_wr_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_BATH_MBA_HEADER_SIZE + EM2_BATH_MBA_BEAM_SIZE * ping->png_nbeams + 8), (void *)&write_size);
@@ -6628,7 +6655,6 @@ int mbr_em300mba_wr_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_rawbeam";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM_HEADER_SIZE];
 	short label;
@@ -6673,6 +6699,8 @@ int mbr_em300mba_wr_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_RAWBEAM_HEADER_SIZE + EM2_RAWBEAM_BEAM_SIZE * ping->png_raw_nbeams + 8),
@@ -6809,7 +6837,6 @@ int mbr_em300mba_wr_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_rawbeam2";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM2_HEADER_SIZE];
 	short label;
@@ -6881,6 +6908,8 @@ int mbr_em300mba_wr_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap,
@@ -7066,7 +7095,6 @@ int mbr_em300mba_wr_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int head, int *error) {
 	char *function_name = "mbr_em300mba_wr_rawbeam3";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM3_HEADER_SIZE];
 	short label;
@@ -7131,6 +7159,8 @@ int mbr_em300mba_wr_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap,
@@ -7306,7 +7336,6 @@ int mbr_em300mba_wr_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int head, int *error) {
 	char *function_name = "mbr_em300mba_wr_ss";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[2 * MBSYS_SIMRAD2_BUFFER_SIZE];
 	short label;
@@ -7374,6 +7403,8 @@ int mbr_em300mba_wr_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap,
@@ -7586,7 +7617,6 @@ int mbr_em300mba_wr_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300mba_wr_wc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_watercolumn_struct *wc;
 	char line[EM2_WC_HEADER_SIZE];
 	short label;
@@ -7665,6 +7695,7 @@ int mbr_em300mba_wr_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 	record_size += pad;
 	mb_put_binary_int(swap, record_size, (void *)&write_size);
 	write_len = fwrite(&write_size, 1, 4, mbfp);
+	int status = MB_SUCCESS;
 	if (write_len != 4) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -7842,7 +7873,6 @@ int mbr_em300mba_wr_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_em300mba_wr_data";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 	FILE *mbfp;
@@ -7872,6 +7902,8 @@ int mbr_em300mba_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 
 	/* set swap flag */
 	swap = MB_NO;
+
+	int status = MB_SUCCESS;
 
 	if (store->kind == MB_DATA_COMMENT || store->kind == MB_DATA_START || store->kind == MB_DATA_STOP) {
 #ifdef MBR_EM300MBA_DEBUG
@@ -8053,7 +8085,6 @@ int mbr_em300mba_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbr_wt_em300mba(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_wt_em300mba";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 
@@ -8074,7 +8105,7 @@ int mbr_wt_em300mba(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 
 	/* write next data to file */
-	status = mbr_em300mba_wr_data(verbose, mbio_ptr, store_ptr, error);
+	const int status = mbr_em300mba_wr_data(verbose, mbio_ptr, store_ptr, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -8091,7 +8122,6 @@ int mbr_wt_em300mba(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_register_em300mba(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_register_em300mba";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -8104,7 +8134,7 @@ int mbr_register_em300mba(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* set format info parameters */
-	status = mbr_info_em300mba(
+	const int status = mbr_info_em300mba(
 	    verbose, &mb_io_ptr->system, &mb_io_ptr->beams_bath_max, &mb_io_ptr->beams_amp_max, &mb_io_ptr->pixels_ss_max,
 	    mb_io_ptr->format_name, mb_io_ptr->system_name, mb_io_ptr->format_description, &mb_io_ptr->numfile, &mb_io_ptr->filetype,
 	    &mb_io_ptr->variable_beams, &mb_io_ptr->traveltime, &mb_io_ptr->beam_flagging, &mb_io_ptr->platform_source,

--- a/src/mbio/mbr_em300raw.c
+++ b/src/mbio/mbr_em300raw.c
@@ -46,7 +46,6 @@ int mbr_info_em300raw(int verbose, int *system, int *beams_bath_max, int *beams_
                       int *heading_source, int *attitude_source, int *svp_source, double *beamwidth_xtrack,
                       double *beamwidth_ltrack, int *error) {
 	char *function_name = "mbr_info_em300raw";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -56,7 +55,6 @@ int mbr_info_em300raw(int verbose, int *system, int *beams_bath_max, int *beams_
 	}
 
 	/* set format info parameters */
-	status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 	*system = MB_SYS_SIMRAD2;
 	*beams_bath_max = 254;
@@ -82,6 +80,8 @@ int mbr_info_em300raw(int verbose, int *system, int *beams_bath_max, int *beams_
 	*svp_source = MB_DATA_VELOCITY_PROFILE;
 	*beamwidth_xtrack = 2.0;
 	*beamwidth_ltrack = 2.0;
+
+	const int status = MB_SUCCESS;
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -117,7 +117,6 @@ int mbr_info_em300raw(int verbose, int *system, int *beams_bath_max, int *beams_
 /*--------------------------------------------------------------------*/
 int mbr_alm_em300raw(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_alm_em300raw";
-	int status = MB_SUCCESS;
 	int *databyteswapped;
 	double *pixel_size;
 	double *swath_width;
@@ -133,13 +132,10 @@ int mbr_alm_em300raw(int verbose, void *mbio_ptr, int *error) {
 	/* get pointer to mbio descriptor */
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-	/* set initial status */
-	status = MB_SUCCESS;
-
 	/* allocate memory for data structure */
 	mb_io_ptr->structure_size = 0;
 	mb_io_ptr->data_structure_size = 0;
-	status = mbsys_simrad2_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	const int status = mbsys_simrad2_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* initialize saved values */
 	databyteswapped = (int *)&mb_io_ptr->save10;
@@ -163,7 +159,6 @@ int mbr_alm_em300raw(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_dem_em300raw(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_dem_em300raw";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -177,7 +172,7 @@ int mbr_dem_em300raw(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* deallocate memory for data descriptor */
-	status = mbsys_simrad2_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
+	const int status = mbsys_simrad2_deall(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -193,7 +188,6 @@ int mbr_dem_em300raw(int verbose, void *mbio_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_chk_label(int verbose, void *mbio_ptr, char *label, short *type, short *sonar) {
 	char *function_name = "mbr_em300raw_chk_label";
-	int status = MB_SUCCESS;
 	mb_u_char startbyte;
 	mb_u_char typebyte;
 	short *sonar_save = NULL;
@@ -321,6 +315,7 @@ int mbr_em300raw_chk_label(int verbose, void *mbio_ptr, char *label, short *type
 		if (verbose >= 1)
 			fprintf(stderr, "Bad datagram type: %4.4hX %4.4hX | %d %d\n", *type, *sonar, *type, *sonar);
 	}
+	int status = MB_SUCCESS;
 	if (typegood != MB_YES || sonargood != MB_YES) {
 		status = MB_FAILURE;
 	}
@@ -357,7 +352,6 @@ int mbr_em300raw_chk_label(int verbose, void *mbio_ptr, char *label, short *type
 int mbr_em300raw_rd_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short type, short sonar,
                           int *version, int *goodend, int *error) {
 	char *function_name = "mbr_em300raw_rd_start";
-	int status = MB_SUCCESS;
 	char line[MBSYS_SIMRAD2_BUFFER_SIZE];
 	short short_val;
 	int read_len, len;
@@ -386,6 +380,8 @@ int mbr_em300raw_rd_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 	/* set type value */
 	store->type = type;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary values into char array */
 	read_len = fread(line, 1, EM2_START_HEADER_SIZE, mbfp);
@@ -732,7 +728,6 @@ file will return error */
 int mbr_em300raw_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar,
                                   int *goodend, int *error) {
 	char *function_name = "mbr_em300raw_rd_run_parameter";
-	int status = MB_SUCCESS;
 	char line[EM2_RUN_PARAMETER_SIZE];
 	short short_val;
 	int read_len;
@@ -755,6 +750,8 @@ int mbr_em300raw_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 	store->kind = MB_DATA_RUN_PARAMETER;
 	store->type = EM2_RUN_PARAMETER;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary values into char array */
 	read_len = fread(line, 1, EM2_RUN_PARAMETER_SIZE - 4, mbfp);
@@ -861,7 +858,6 @@ int mbr_em300raw_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 int mbr_em300raw_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                           int *error) {
 	char *function_name = "mbr_em300raw_rd_clock";
-	int status = MB_SUCCESS;
 	char line[EM2_CLOCK_SIZE];
 	short short_val;
 	int read_len;
@@ -884,6 +880,8 @@ int mbr_em300raw_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 	store->kind = MB_DATA_CLOCK;
 	store->type = EM2_CLOCK;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary values into char array */
 	read_len = fread(line, 1, EM2_CLOCK_SIZE - 4, mbfp);
@@ -947,7 +945,6 @@ int mbr_em300raw_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 int mbr_em300raw_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                          int *error) {
 	char *function_name = "mbr_em300raw_rd_tide";
-	int status = MB_SUCCESS;
 	char line[EM2_TIDE_SIZE];
 	short short_val;
 	int read_len;
@@ -970,6 +967,8 @@ int mbr_em300raw_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	store->kind = MB_DATA_TIDE;
 	store->type = EM2_TIDE;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary values into char array */
 	read_len = fread(line, 1, EM2_TIDE_SIZE - 4, mbfp);
@@ -1034,7 +1033,6 @@ int mbr_em300raw_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 int mbr_em300raw_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                            int *error) {
 	char *function_name = "mbr_em300raw_rd_height";
-	int status = MB_SUCCESS;
 	char line[EM2_HEIGHT_SIZE];
 	short short_val;
 	int read_len;
@@ -1057,6 +1055,8 @@ int mbr_em300raw_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 	store->kind = MB_DATA_HEIGHT;
 	store->type = EM2_HEIGHT;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary values into char array */
 	read_len = fread(line, 1, EM2_HEIGHT_SIZE - 4, mbfp);
@@ -1118,7 +1118,6 @@ int mbr_em300raw_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 int mbr_em300raw_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                             int *error) {
 	char *function_name = "mbr_em300raw_rd_heading";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_heading_struct *heading;
 	char line[EM2_HEADING_HEADER_SIZE];
 	short short_val;
@@ -1145,6 +1144,8 @@ int mbr_em300raw_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 	store->kind = MB_DATA_HEADING;
 	store->type = EM2_HEADING;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_HEADING_HEADER_SIZE, mbfp);
@@ -1244,7 +1245,6 @@ int mbr_em300raw_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 int mbr_em300raw_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                         int *error) {
 	char *function_name = "mbr_em300raw_rd_ssv";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ssv_struct *ssv;
 	char line[EM2_SSV_HEADER_SIZE];
 	short short_val;
@@ -1271,6 +1271,8 @@ int mbr_em300raw_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 	store->kind = MB_DATA_SSV;
 	store->type = EM2_SSV;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_SSV_HEADER_SIZE, mbfp);
@@ -1368,7 +1370,6 @@ int mbr_em300raw_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 int mbr_em300raw_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                          int *error) {
 	char *function_name = "mbr_em300raw_rd_tilt";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_tilt_struct *tilt;
 	char line[EM2_TILT_HEADER_SIZE];
 	short short_val;
@@ -1395,6 +1396,8 @@ int mbr_em300raw_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	store->kind = MB_DATA_TILT;
 	store->type = EM2_TILT;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_TILT_HEADER_SIZE, mbfp);
@@ -1492,7 +1495,6 @@ int mbr_em300raw_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 int mbr_em300raw_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar,
                                     int *goodend, int *error) {
 	char *function_name = "mbr_em300raw_rd_extraparameters";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_extraparameters_struct *extraparameters;
 	char line[EM2_EXTRAPARAMETERS_HEADER_SIZE];
 	short short_val;
@@ -1519,6 +1521,8 @@ int mbr_em300raw_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 	store->kind = MB_DATA_PARAMETER;
 	store->type = EM2_EXTRAPARAMETERS;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_EXTRAPARAMETERS_HEADER_SIZE, mbfp);
@@ -1639,7 +1643,6 @@ int mbr_em300raw_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 int mbr_em300raw_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                              int *error) {
 	char *function_name = "mbr_em300raw_rd_attitude";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_attitude_struct *attitude;
 	char line[EM2_ATTITUDE_HEADER_SIZE];
 	short short_val;
@@ -1666,6 +1669,8 @@ int mbr_em300raw_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	store->kind = MB_DATA_ATTITUDE;
 	store->type = EM2_ATTITUDE;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_ATTITUDE_HEADER_SIZE, mbfp);
@@ -1774,7 +1779,6 @@ int mbr_em300raw_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 int mbr_em300raw_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                         int *error) {
 	char *function_name = "mbr_em300raw_rd_pos";
-	int status = MB_SUCCESS;
 	char line[MBSYS_SIMRAD2_COMMENT_LENGTH];
 	short short_val;
 	int read_len;
@@ -1799,6 +1803,8 @@ int mbr_em300raw_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 	store->kind = MB_DATA_NAV;
 	store->type = EM2_POS;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_POS_HEADER_SIZE, mbfp);
@@ -1949,7 +1955,6 @@ int mbr_em300raw_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 int mbr_em300raw_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                         int *error) {
 	char *function_name = "mbr_em300raw_rd_svp";
-	int status = MB_SUCCESS;
 	char line[EM2_SVP_HEADER_SIZE];
 	short short_val;
 	int read_len;
@@ -1972,6 +1977,8 @@ int mbr_em300raw_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 	store->kind = MB_DATA_VELOCITY_PROFILE;
 	store->type = EM2_SVP;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_SVP_HEADER_SIZE, mbfp);
@@ -2076,7 +2083,6 @@ int mbr_em300raw_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 int mbr_em300raw_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                          int *error) {
 	char *function_name = "mbr_em300raw_rd_svp2";
-	int status = MB_SUCCESS;
 	char line[EM2_SVP2_HEADER_SIZE];
 	short short_val;
 	int read_len;
@@ -2099,6 +2105,8 @@ int mbr_em300raw_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	store->kind = MB_DATA_VELOCITY_PROFILE;
 	store->type = EM2_SVP2;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_SVP_HEADER_SIZE, mbfp);
@@ -2201,7 +2209,6 @@ int mbr_em300raw_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 int mbr_em300raw_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *match, short sonar,
                          int version, int *goodend, int *error) {
 	char *function_name = "mbr_em300raw_rd_bath";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_BATH_HEADER_SIZE];
 	short short_val;
@@ -2233,6 +2240,8 @@ int mbr_em300raw_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	store->kind = MB_DATA_DATA;
 	store->type = EM2_BATH;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_BATH_HEADER_SIZE, mbfp);
@@ -2423,7 +2432,6 @@ int mbr_em300raw_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 int mbr_em300raw_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                             int *error) {
 	char *function_name = "mbr_em300raw_rd_rawbeam";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM_HEADER_SIZE];
 	short short_val;
@@ -2445,6 +2453,8 @@ int mbr_em300raw_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 
 	/* get  storage structure */
 	ping = (struct mbsys_simrad2_ping_struct *)store->ping;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_RAWBEAM_HEADER_SIZE, mbfp);
@@ -2573,7 +2583,6 @@ int mbr_em300raw_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 int mbr_em300raw_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                              int *error) {
 	char *function_name = "mbr_em300raw_rd_rawbeam2";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM2_HEADER_SIZE];
 	short short_val;
@@ -2597,6 +2606,8 @@ int mbr_em300raw_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 
 	/* get  storage structure */
 	ping = (struct mbsys_simrad2_ping_struct *)store->ping;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_RAWBEAM2_HEADER_SIZE, mbfp);
@@ -2810,7 +2821,6 @@ int mbr_em300raw_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 int mbr_em300raw_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                              int *error) {
 	char *function_name = "mbr_em300raw_rd_rawbeam3";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM3_HEADER_SIZE];
 	short short_val;
@@ -2837,6 +2847,8 @@ int mbr_em300raw_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	/* get  storage structure */
 	ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 	head = 0;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_RAWBEAM3_HEADER_SIZE, mbfp);
@@ -3036,7 +3048,6 @@ int mbr_em300raw_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 int mbr_em300raw_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int length, int *match,
                        int *goodend, int *error) {
 	char *function_name = "mbr_em300raw_rd_ss";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_SS_HEADER_SIZE];
 	short short_val;
@@ -3070,6 +3081,8 @@ int mbr_em300raw_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 	store->kind = MB_DATA_DATA;
 	store->type = EM2_SS;
 	store->sonar = sonar;
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_SS_HEADER_SIZE, mbfp);
@@ -3327,7 +3340,6 @@ int mbr_em300raw_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 int mbr_em300raw_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                        int *error) {
 	char *function_name = "mbr_em300raw_rd_wc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_watercolumn_struct *wc;
 	char line[EM2_WC_HEADER_SIZE];
 	short short_val;
@@ -3357,6 +3369,8 @@ int mbr_em300raw_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 	store->type = EM2_WATERCOLUMN;
 	store->sonar = sonar;
 	file_bytes = ftell(mbfp);
+
+	int status = MB_SUCCESS;
 
 	/* read binary header values into char array */
 	read_len = fread(line, 1, EM2_WC_HEADER_SIZE, mbfp);
@@ -3535,7 +3549,6 @@ int mbr_em300raw_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_em300raw_rd_data";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 	struct mbsys_simrad2_ping_struct *ping2;
@@ -3629,6 +3642,8 @@ int mbr_em300raw_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 
 	/* set flag to swap bytes if necessary */
 	swap = *databyteswapped;
+
+	int status = MB_SUCCESS;
 
 	/* loop over reading data until a record is ready for return */
 	done = MB_NO;
@@ -4244,7 +4259,6 @@ Have a nice day...\n");
 /*--------------------------------------------------------------------*/
 int mbr_rt_em300raw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_rt_em300raw";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_attitude_struct *attitude;
 	struct mbsys_simrad2_heading_struct *heading;
@@ -4274,7 +4288,7 @@ int mbr_rt_em300raw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* read next data from file */
-	status = mbr_em300raw_rd_data(verbose, mbio_ptr, store_ptr, error);
+	int status = mbr_em300raw_rd_data(verbose, mbio_ptr, store_ptr, error);
 
 	/* get pointers to data structures */
 	store = (struct mbsys_simrad2_struct *)store_ptr;
@@ -4494,7 +4508,6 @@ int mbr_rt_em300raw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_start";
-	int status = MB_SUCCESS;
 	char line[MBSYS_SIMRAD2_BUFFER_SIZE], *buff;
 	int buff_len, write_len;
 	int write_size;
@@ -4605,15 +4618,13 @@ int mbr_em300raw_wr_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 	memset(line, 0, MBSYS_SIMRAD2_BUFFER_SIZE);
 
 	/* put binary header data into buffer */
-	if (status == MB_SUCCESS) {
-		mb_put_binary_short(swap, (short)store->type, (void *)&line[4]);
-		mb_put_binary_short(swap, (unsigned short)store->sonar, (void *)&line[6]);
-		mb_put_binary_int(swap, (int)store->par_date, (void *)&line[8]);
-		mb_put_binary_int(swap, (int)store->par_msec, (void *)&line[12]);
-		mb_put_binary_short(swap, (unsigned short)store->par_line_num, (void *)&line[16]);
-		mb_put_binary_short(swap, (unsigned short)store->par_serial_1, (void *)&line[18]);
-		mb_put_binary_short(swap, (unsigned short)store->par_serial_2, (void *)&line[20]);
-	}
+	mb_put_binary_short(swap, (short)store->type, (void *)&line[4]);
+	mb_put_binary_short(swap, (unsigned short)store->sonar, (void *)&line[6]);
+	mb_put_binary_int(swap, (int)store->par_date, (void *)&line[8]);
+	mb_put_binary_int(swap, (int)store->par_msec, (void *)&line[12]);
+	mb_put_binary_short(swap, (unsigned short)store->par_line_num, (void *)&line[16]);
+	mb_put_binary_short(swap, (unsigned short)store->par_serial_1, (void *)&line[18]);
+	mb_put_binary_short(swap, (unsigned short)store->par_serial_2, (void *)&line[20]);
 
 	/* construct ASCII parameter buffer */
 	buff = &line[22];
@@ -4794,6 +4805,8 @@ int mbr_em300raw_wr_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 	/* set checksum */
 	mb_put_binary_short(swap, (unsigned short)checksum, (void *)&line[buff_len + 23]);
 
+	int status = MB_SUCCESS;
+
 	/* finally write out the data */
 	write_len = fwrite(&line, 1, write_size, mbfp);
 	if (write_len != write_size) {
@@ -4817,7 +4830,6 @@ int mbr_em300raw_wr_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_run_parameter";
-	int status = MB_SUCCESS;
 	char line[EM2_RUN_PARAMETER_SIZE];
 	short label;
 	int write_len;
@@ -4870,6 +4882,8 @@ int mbr_em300raw_wr_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_RUN_PARAMETER_SIZE), (void *)&write_size);
@@ -4976,7 +4990,6 @@ int mbr_em300raw_wr_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_clock";
-	int status = MB_SUCCESS;
 	char line[EM2_CLOCK_SIZE];
 	short label;
 	int write_len;
@@ -5012,6 +5025,8 @@ int mbr_em300raw_wr_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_CLOCK_SIZE), (void *)&write_size);
@@ -5101,7 +5116,6 @@ int mbr_em300raw_wr_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_tide";
-	int status = MB_SUCCESS;
 	char line[EM2_TIDE_SIZE];
 	short label;
 	int write_len;
@@ -5137,6 +5151,8 @@ int mbr_em300raw_wr_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_TIDE_SIZE), (void *)&write_size);
@@ -5227,7 +5243,6 @@ int mbr_em300raw_wr_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_height(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_height";
-	int status = MB_SUCCESS;
 	char line[EM2_HEIGHT_SIZE];
 	short label;
 	int write_len;
@@ -5262,6 +5277,8 @@ int mbr_em300raw_wr_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_HEIGHT_SIZE), (void *)&write_size);
@@ -5350,7 +5367,6 @@ int mbr_em300raw_wr_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_heading";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_heading_struct *heading;
 	char line[EM2_HEADING_HEADER_SIZE];
 	short label;
@@ -5393,6 +5409,8 @@ int mbr_em300raw_wr_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_HEADING_HEADER_SIZE + EM2_HEADING_SLICE_SIZE * heading->hed_ndata + 8),
@@ -5524,7 +5542,6 @@ int mbr_em300raw_wr_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_ssv";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ssv_struct *ssv;
 	char line[EM2_SSV_HEADER_SIZE];
 	short label;
@@ -5566,6 +5583,8 @@ int mbr_em300raw_wr_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_SSV_HEADER_SIZE + EM2_SSV_SLICE_SIZE * ssv->ssv_ndata + 8), (void *)&write_size);
@@ -5696,7 +5715,6 @@ int mbr_em300raw_wr_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_tilt";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_tilt_struct *tilt;
 	char line[EM2_TILT_HEADER_SIZE];
 	short label;
@@ -5738,6 +5756,8 @@ int mbr_em300raw_wr_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_TILT_HEADER_SIZE + EM2_TILT_SLICE_SIZE * tilt->tlt_ndata + 8), (void *)&write_size);
@@ -5868,7 +5888,6 @@ int mbr_em300raw_wr_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_extraparameters(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_extraparameters";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_extraparameters_struct *extraparameters;
 	char line[EM2_EXTRAPARAMETERS_HEADER_SIZE];
 	short label;
@@ -5918,6 +5937,8 @@ int mbr_em300raw_wr_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_EXTRAPARAMETERS_HEADER_SIZE + extraparameters->xtr_data_size + 8), (void *)&write_size);
@@ -6044,7 +6065,6 @@ int mbr_em300raw_wr_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_attitude";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_attitude_struct *attitude;
 	char line[EM2_ATTITUDE_HEADER_SIZE];
 	short label;
@@ -6088,6 +6108,8 @@ int mbr_em300raw_wr_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 
 	/* zero checksum */
 	checksum = 0;
+
+	int status = MB_SUCCESS;
 
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_ATTITUDE_HEADER_SIZE + EM2_ATTITUDE_SLICE_SIZE * attitude->att_ndata + 8),
@@ -6223,7 +6245,6 @@ int mbr_em300raw_wr_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_pos";
-	int status = MB_SUCCESS;
 	char line[EM2_POS_HEADER_SIZE];
 	short label;
 	int write_len;
@@ -6270,6 +6291,7 @@ int mbr_em300raw_wr_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 	mb_put_binary_int(swap, (int)(EM2_POS_HEADER_SIZE + store->pos_input_size - (store->pos_input_size % 2) + 8),
 	                  (void *)&write_size);
 	write_len = fwrite(&write_size, 1, 4, mbfp);
+	int status = MB_SUCCESS;
 	if (write_len != 4) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -6396,7 +6418,6 @@ int mbr_em300raw_wr_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_svp";
-	int status = MB_SUCCESS;
 	char line[EM2_SVP_HEADER_SIZE];
 	short label;
 	int write_len;
@@ -6441,6 +6462,7 @@ int mbr_em300raw_wr_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_SVP_HEADER_SIZE + EM2_SVP_SLICE_SIZE * store->svp_num + 8), (void *)&write_size);
 	write_len = fwrite(&write_size, 1, 4, mbfp);
+	int status = MB_SUCCESS;
 	if (write_len != 4) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -6570,7 +6592,6 @@ int mbr_em300raw_wr_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_svp2";
-	int status = MB_SUCCESS;
 	char line[EM2_SVP2_HEADER_SIZE];
 	short label;
 	int write_len;
@@ -6615,6 +6636,7 @@ int mbr_em300raw_wr_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_SVP2_HEADER_SIZE + EM2_SVP2_SLICE_SIZE * store->svp_num + 8), (void *)&write_size);
 	write_len = fwrite(&write_size, 1, 4, mbfp);
+	int status = MB_SUCCESS;
 	if (write_len != 4) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -6744,7 +6766,6 @@ int mbr_em300raw_wr_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int head, int *error) {
 	char *function_name = "mbr_em300raw_wr_bath";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_BATH_HEADER_SIZE];
 	short label;
@@ -6804,6 +6825,7 @@ int mbr_em300raw_wr_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	/* write the record size */
 	mb_put_binary_int(swap, (int)(EM2_BATH_HEADER_SIZE + EM2_BATH_BEAM_SIZE * ping->png_nbeams + 8), (void *)&write_size);
 	write_len = fwrite(&write_size, 1, 4, mbfp);
+	int status = MB_SUCCESS;
 	if (write_len != 4) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -6950,7 +6972,6 @@ int mbr_em300raw_wr_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_rawbeam";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM_HEADER_SIZE];
 	short label;
@@ -7000,6 +7021,7 @@ int mbr_em300raw_wr_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 	mb_put_binary_int(swap, (int)(EM2_RAWBEAM_HEADER_SIZE + EM2_RAWBEAM_BEAM_SIZE * ping->png_raw_nbeams + 8),
 	                  (void *)&write_size);
 	write_len = fwrite(&write_size, 1, 4, mbfp);
+	int status = MB_SUCCESS;
 	if (write_len != 4) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -7131,7 +7153,6 @@ int mbr_em300raw_wr_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_rawbeam2";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM2_HEADER_SIZE];
 	short label;
@@ -7210,6 +7231,7 @@ int mbr_em300raw_wr_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	                        EM2_RAWBEAM2_BEAM_SIZE * ping->png_raw_nbeams + 8),
 	                  (void *)&write_size);
 	write_len = fwrite(&write_size, 1, 4, mbfp);
+	int status = MB_SUCCESS;
 	if (write_len != 4) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -7388,7 +7410,6 @@ int mbr_em300raw_wr_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int head, int *error) {
 	char *function_name = "mbr_em300raw_wr_rawbeam3";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM3_HEADER_SIZE];
 	short label;
@@ -7460,6 +7481,7 @@ int mbr_em300raw_wr_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	                        EM2_RAWBEAM3_BEAM_SIZE * ping->png_raw3_nbeams + 8),
 	                  (void *)&write_size);
 	write_len = fwrite(&write_size, 1, 4, mbfp);
+	int status = MB_SUCCESS;
 	if (write_len != 4) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -7628,7 +7650,6 @@ int mbr_em300raw_wr_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int head, int *error) {
 	char *function_name = "mbr_em300raw_wr_ss";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_SS_HEADER_SIZE];
 	short label;
@@ -7696,6 +7717,7 @@ int mbr_em300raw_wr_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 	    (int)(EM2_SS_HEADER_SIZE + EM2_SS_BEAM_SIZE * ping->png_nbeams_ss + ping->png_npixels - (ping->png_npixels % 2) + 8),
 	    (void *)&write_size);
 	write_len = fwrite(&write_size, 1, 4, mbfp);
+	int status = MB_SUCCESS;
 	if (write_len != 4) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -7849,7 +7871,6 @@ int mbr_em300raw_wr_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, int *error) {
 	char *function_name = "mbr_em300raw_wr_wc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_watercolumn_struct *wc;
 	char line[EM2_WC_HEADER_SIZE];
 	short label;
@@ -7928,6 +7949,7 @@ int mbr_em300raw_wr_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 	record_size += pad;
 	mb_put_binary_int(swap, record_size, (void *)&write_size);
 	write_len = fwrite(&write_size, 1, 4, mbfp);
+	int status = MB_SUCCESS;
 	if (write_len != 4) {
 		status = MB_FAILURE;
 		*error = MB_ERROR_WRITE_FAIL;
@@ -8106,7 +8128,6 @@ int mbr_em300raw_wr_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 /*--------------------------------------------------------------------*/
 int mbr_em300raw_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_em300raw_wr_data";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 	FILE *mbfp;
@@ -8136,6 +8157,8 @@ int mbr_em300raw_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 
 	/* set swap flag */
 	swap = MB_NO;
+
+	int status = MB_SUCCESS;
 
 	if (store->kind == MB_DATA_COMMENT || store->kind == MB_DATA_START || store->kind == MB_DATA_STOP) {
 #ifdef MBR_EM300RAW_DEBUG
@@ -8320,7 +8343,6 @@ int mbr_em300raw_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbr_wt_em300raw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbr_wt_em300raw";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 
 	/* print input debug statements */
@@ -8339,7 +8361,7 @@ int mbr_wt_em300raw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	store = (struct mbsys_simrad2_struct *)store_ptr;
 
 	/* write next data to file */
-	status = mbr_em300raw_wr_data(verbose, mbio_ptr, store_ptr, error);
+	const int status = mbr_em300raw_wr_data(verbose, mbio_ptr, store_ptr, error);
 
 	/* print output debug statements */
 	if (verbose >= 2) {
@@ -8355,7 +8377,6 @@ int mbr_wt_em300raw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_register_em300raw(int verbose, void *mbio_ptr, int *error) {
 	char *function_name = "mbr_register_em300raw";
-	int status = MB_SUCCESS;
 
 	/* print input debug statements */
 	if (verbose >= 2) {
@@ -8368,7 +8389,7 @@ int mbr_register_em300raw(int verbose, void *mbio_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* set format info parameters */
-	status = mbr_info_em300raw(
+	const int status = mbr_info_em300raw(
 	    verbose, &mb_io_ptr->system, &mb_io_ptr->beams_bath_max, &mb_io_ptr->beams_amp_max, &mb_io_ptr->pixels_ss_max,
 	    mb_io_ptr->format_name, mb_io_ptr->system_name, mb_io_ptr->format_description, &mb_io_ptr->numfile, &mb_io_ptr->filetype,
 	    &mb_io_ptr->variable_beams, &mb_io_ptr->traveltime, &mb_io_ptr->beam_flagging, &mb_io_ptr->platform_source,


### PR DESCRIPTION
- Add const when possible
- Remove checks on status that happen before status can be `MB_FAILURE`
- Some `status =` -> `status &=` for simple cases of alloc and free