### PR TITLE
mb_time.c ... mbsys_xse.c:  Localize status variable.

### DIFF
--- a/src/mbio/mb_time.c
+++ b/src/mbio/mb_time.c
@@ -36,7 +36,6 @@ int yday[] = {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
  * 	1/1/70 00:00:00 calculated from (yy/mm/dd/hr/mi/sc). */
 int mb_get_time(int verbose, int time_i[7], double *time_d) {
 	char *function_name = "mb_get_time";
-	int status;
 	int yearday;
 	int leapday;
 
@@ -64,7 +63,7 @@ int mb_get_time(int verbose, int time_i[7], double *time_d) {
 	          time_i[4] * MB_SECINMINUTE + time_i[5] + 0.000001 * time_i[6];
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -83,7 +82,6 @@ int mb_get_time(int verbose, int time_i[7], double *time_d) {
 int mb_get_date(int verbose, double time_d, int time_i[7]) {
 
 	char *function_name = "mb_get_date";
-	int status;
 	int daytotal;
 	int yearday;
 	int leapday;
@@ -119,7 +117,7 @@ int mb_get_date(int verbose, double time_d, int time_i[7]) {
 	time_i[2] = yearday - yday[time_i[1] - 1] - leapday;
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\nMBIO function <%s> completed\n", function_name);
@@ -145,7 +143,6 @@ int mb_get_date(int verbose, double time_d, int time_i[7]) {
 int mb_get_date_string(int verbose, double time_d, char *string) {
 
 	char *function_name = "mb_get_date_string";
-	int status;
 	int time_i[7];
 
 	if (verbose >= 2) {
@@ -161,7 +158,7 @@ int mb_get_date_string(int verbose, double time_d, char *string) {
 	        time_i[6]);
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\nMBIO function <%s> completed\n", function_name);
@@ -179,7 +176,6 @@ int mb_get_date_string(int verbose, double time_d, char *string) {
  *	from (yy/mm/dd/hr/mi/sc). */
 int mb_get_jtime(int verbose, int time_i[7], int time_j[5]) {
 	char *function_name = "mb_get_jtime";
-	int status;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -204,7 +200,7 @@ int mb_get_jtime(int verbose, int time_i[7], int time_j[5]) {
 	time_j[4] = time_i[6];
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -228,7 +224,6 @@ int mb_get_jtime(int verbose, int time_i[7], int time_j[5]) {
  */
 int mb_get_itime(int verbose, int time_j[5], int time_i[7]) {
 	char *function_name = "mb_get_itime";
-	int status;
 	int leapday;
 
 	if (verbose >= 2) {
@@ -261,7 +256,7 @@ int mb_get_itime(int verbose, int time_j[5], int time_i[7]) {
 	time_i[2] = time_j[1] - yday[time_i[1] - 1] - leapday;
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -293,7 +288,6 @@ int mb_get_itime(int verbose, int time_j[5], int time_i[7]) {
  */
 int mb_fix_y2k(int verbose, int year_short, int *year_long) {
 	char *function_name = "mb_fix_y2k";
-	int status;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -309,7 +303,7 @@ int mb_fix_y2k(int verbose, int year_short, int *year_long) {
 		*year_long = year_short + 2000;
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -339,7 +333,6 @@ int mb_fix_y2k(int verbose, int year_short, int *year_long) {
  */
 int mb_unfix_y2k(int verbose, int year_long, int *year_short) {
 	char *function_name = "mb_unfix_y2k";
-	int status;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -352,7 +345,7 @@ int mb_unfix_y2k(int verbose, int year_long, int *year_short) {
 	*year_short = year_long % 100;
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mb_write_init.c
+++ b/src/mbio/mb_write_init.c
@@ -41,7 +41,6 @@
 int mb_write_init(int verbose, char *file, int format, void **mbio_ptr, int *beams_bath, int *beams_amp, int *pixels_ss,
                   int *error) {
 	char *function_name = "mb_write_init";
-	int status = MB_SUCCESS;
 	int status_save;
 	int error_save;
 	int sapi_status;
@@ -58,7 +57,7 @@ int mb_write_init(int verbose, char *file, int format, void **mbio_ptr, int *bea
 	}
 
 	/* allocate memory for mbio descriptor */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mb_io_struct), (void **)mbio_ptr, error);
+	int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mb_io_struct), (void **)mbio_ptr, error);
 	struct mb_io_struct *mb_io_ptr = NULL;
 	if (status == MB_SUCCESS) {
 		memset(*mbio_ptr, 0, sizeof(struct mb_io_struct));

--- a/src/mbio/mb_write_ping.c
+++ b/src/mbio/mb_write_ping.c
@@ -34,7 +34,6 @@
 /*--------------------------------------------------------------------*/
 int mb_write_ping(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mb_write_ping";
-	int status;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -46,6 +45,8 @@ int mb_write_ping(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 
 	/* get mbio descriptor */
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* call the appropriate mbr_ write and translate routine */
 	if (mb_io_ptr->mb_io_write_ping != NULL) {

--- a/src/mbio/mbsys_navnetcdf.c
+++ b/src/mbio/mbsys_navnetcdf.c
@@ -36,7 +36,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_navnetcdf_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_navnetcdf_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 	char c;
 
@@ -51,7 +50,7 @@ int mbsys_navnetcdf_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *er
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_navnetcdf_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_navnetcdf_struct), store_ptr, error);
 
 	/* get data structure pointer */
 	store = (struct mbsys_navnetcdf_struct *)*store_ptr;
@@ -357,7 +356,6 @@ int mbsys_navnetcdf_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbsys_navnetcdf_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_navnetcdf_deall";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -373,6 +371,8 @@ int mbsys_navnetcdf_deall(int verbose, void *mbio_ptr, void **store_ptr, int *er
 
 	/* get data structure pointer */
 	store = (struct mbsys_navnetcdf_struct *)*store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* deallocate any allocated arrays */
 	if (store->mbHistDate != NULL)
@@ -405,7 +405,6 @@ int mbsys_navnetcdf_deall(int verbose, void *mbio_ptr, void **store_ptr, int *er
 int mbsys_navnetcdf_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                                int *error) {
 	char *function_name = "mbsys_navnetcdf_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -441,6 +440,8 @@ int mbsys_navnetcdf_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -461,7 +462,6 @@ int mbsys_navnetcdf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *k
                             char *beamflag, double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack,
                             double *ss, double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_navnetcdf_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -483,7 +483,7 @@ int mbsys_navnetcdf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *k
 
 	/* reset error and status */
 	*error = MB_ERROR_NO_ERROR;
-	status = MB_SUCCESS;
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -603,7 +603,6 @@ int mbsys_navnetcdf_insert(int verbose, void *mbio_ptr, void *store_ptr, int kin
                            double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                            double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_navnetcdf_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -662,6 +661,8 @@ int mbsys_navnetcdf_insert(int verbose, void *mbio_ptr, void *store_ptr, int kin
 		strcpy(store->comment, comment);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -677,7 +678,6 @@ int mbsys_navnetcdf_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *ki
                            double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                            double *ssv, int *error) {
 	char *function_name = "mbsys_navnetcdf_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -702,6 +702,8 @@ int mbsys_navnetcdf_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -751,7 +753,6 @@ int mbsys_navnetcdf_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 /*--------------------------------------------------------------------*/
 int mbsys_navnetcdf_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_navnetcdf_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -771,6 +772,8 @@ int mbsys_navnetcdf_detects(int verbose, void *mbio_ptr, void *store_ptr, int *k
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -820,7 +823,6 @@ int mbsys_navnetcdf_detects(int verbose, void *mbio_ptr, void *store_ptr, int *k
 int mbsys_navnetcdf_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                      double *altitude, int *error) {
 	char *function_name = "mbsys_navnetcdf_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -839,6 +841,8 @@ int mbsys_navnetcdf_extract_altitude(int verbose, void *mbio_ptr, void *store_pt
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -882,7 +886,6 @@ int mbsys_navnetcdf_extract_altitude(int verbose, void *mbio_ptr, void *store_pt
 int mbsys_navnetcdf_insert_altitude(int verbose, void *mbio_ptr, void *store_ptr, double transducer_depth, double altitude,
                                     int *error) {
 	char *function_name = "mbsys_navnetcdf_insert_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -900,6 +903,8 @@ int mbsys_navnetcdf_insert_altitude(int verbose, void *mbio_ptr, void *store_ptr
 
 	/* get data structure pointer */
 	store = (struct mbsys_navnetcdf_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* insert data into structure */
 	if (store->kind == MB_DATA_DATA) {
@@ -941,7 +946,6 @@ int mbsys_navnetcdf_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, in
                                 double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                                 double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_navnetcdf_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -960,6 +964,8 @@ int mbsys_navnetcdf_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, in
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1065,7 +1071,6 @@ int mbsys_navnetcdf_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int
                                double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                                int *error) {
 	char *function_name = "mbsys_navnetcdf_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -1120,6 +1125,8 @@ int mbsys_navnetcdf_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int
 		/* get roll pitch and heave */
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1133,7 +1140,6 @@ int mbsys_navnetcdf_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbsys_navnetcdf_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_navnetcdf_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_navnetcdf_struct *store;
 	struct mbsys_navnetcdf_struct *copy;
 
@@ -1153,14 +1159,16 @@ int mbsys_navnetcdf_copy(int verbose, void *mbio_ptr, void *store_ptr, void *cop
 	store = (struct mbsys_navnetcdf_struct *)store_ptr;
 	copy = (struct mbsys_navnetcdf_struct *)copy_ptr;
 
+	int status = MB_SUCCESS;
+
 	/* deallocate memory if required */
 	if (store->mbHistoryRecNbr > copy->mbHistoryRecNbr) {
 		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistDate, error);
-		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistTime, error);
-		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistCode, error);
-		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistAutor, error);
-		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistModule, error);
-		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistComment, error);
+		status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistTime, error);
+		status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistCode, error);
+		status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistAutor, error);
+		status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistModule, error);
+		status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistComment, error);
 	}
 
 	/* allocate the memory in copy */
@@ -1169,25 +1177,25 @@ int mbsys_navnetcdf_copy(int verbose, void *mbio_ptr, void *store_ptr, void *cop
 		copy->mbNameLength = store->mbNameLength;
 		copy->mbCommentLength = store->mbCommentLength;
 		copy->mbPositionNbr = store->mbPositionNbr;
-		status = mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * sizeof(int), (void **)&copy->mbHistDate, error);
-		status = mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * sizeof(int), (void **)&copy->mbHistTime, error);
-		status = mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * sizeof(char), (void **)&copy->mbHistCode, error);
-		status = mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * copy->mbNameLength * sizeof(char),
+		status &= mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * sizeof(int), (void **)&copy->mbHistDate, error);
+		status &= mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * sizeof(int), (void **)&copy->mbHistTime, error);
+		status &= mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * sizeof(char), (void **)&copy->mbHistCode, error);
+		status &= mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * copy->mbNameLength * sizeof(char),
 		                    (void **)&copy->mbHistAutor, error);
-		status = mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * copy->mbNameLength * sizeof(char),
+		status &= mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * copy->mbNameLength * sizeof(char),
 		                    (void **)&copy->mbHistModule, error);
-		status = mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * copy->mbCommentLength * sizeof(char),
+		status &= mb_mallocd(verbose, __FILE__, __LINE__, copy->mbHistoryRecNbr * copy->mbCommentLength * sizeof(char),
 		                    (void **)&copy->mbHistComment, error);
 	}
 
 	/* deal with a memory allocation failure */
 	if (status == MB_FAILURE) {
-		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistDate, error);
-		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistTime, error);
-		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistCode, error);
-		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistAutor, error);
-		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistModule, error);
-		status = mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistComment, error);
+		status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistDate, error);
+		status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistTime, error);
+		status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistCode, error);
+		status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistAutor, error);
+		status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistModule, error);
+		status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&store->mbHistComment, error);
 		status = MB_FAILURE;
 		*error = MB_ERROR_MEMORY_FAIL;
 		if (verbose >= 2) {

--- a/src/mbio/mbsys_netcdf.c
+++ b/src/mbio/mbsys_netcdf.c
@@ -36,7 +36,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_netcdf_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_netcdf_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 	char c;
 
@@ -51,7 +50,7 @@ int mbsys_netcdf_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_netcdf_struct), (void **)store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_netcdf_struct), (void **)store_ptr, error);
 
 	/* get data structure pointer */
 	store = (struct mbsys_netcdf_struct *)*store_ptr;
@@ -1050,7 +1049,6 @@ int mbsys_netcdf_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbsys_netcdf_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_netcdf_deall";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -1066,6 +1064,8 @@ int mbsys_netcdf_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error
 
 	/* get data structure pointer */
 	store = (struct mbsys_netcdf_struct *)*store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* deallocate any allocated arrays */
 	if (store->mbHistDate != NULL)
@@ -1200,7 +1200,6 @@ int mbsys_netcdf_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error
 int mbsys_netcdf_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                             int *error) {
 	char *function_name = "mbsys_netcdf_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -1236,6 +1235,8 @@ int mbsys_netcdf_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		*nss = 0;
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -1256,7 +1257,6 @@ int mbsys_netcdf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
                          double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                          double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_netcdf_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 	double depthscale, distancescale;
 
@@ -1279,7 +1279,7 @@ int mbsys_netcdf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* reset error and status */
 	*error = MB_ERROR_NO_ERROR;
-	status = MB_SUCCESS;
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1431,7 +1431,6 @@ int mbsys_netcdf_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
                         double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                         double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_netcdf_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 	double depthscale, distancescale;
 	double depthmax, distancemax;
@@ -1568,7 +1567,7 @@ int mbsys_netcdf_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
 		}
 
 		/* allocate arrays */
-		status = mb_mallocd(verbose, __FILE__, __LINE__, store->mbAntennaNbr * sizeof(short), (void **)&store->mbCycle, error);
+		int status = mb_mallocd(verbose, __FILE__, __LINE__, store->mbAntennaNbr * sizeof(short), (void **)&store->mbCycle, error);
 		status = mb_mallocd(verbose, __FILE__, __LINE__, store->mbAntennaNbr * sizeof(int), (void **)&store->mbDate, error);
 		status = mb_mallocd(verbose, __FILE__, __LINE__, store->mbAntennaNbr * sizeof(int), (void **)&store->mbTime, error);
 		status = mb_mallocd(verbose, __FILE__, __LINE__, store->mbAntennaNbr * sizeof(int), (void **)&store->mbOrdinate, error);
@@ -1818,6 +1817,8 @@ int mbsys_netcdf_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
 		strcpy(store->comment, comment);
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1833,7 +1834,6 @@ int mbsys_netcdf_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
                         double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                         double *ssv, int *error) {
 	char *function_name = "mbsys_netcdf_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -1858,6 +1858,8 @@ int mbsys_netcdf_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1907,7 +1909,6 @@ int mbsys_netcdf_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 /*--------------------------------------------------------------------*/
 int mbsys_netcdf_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_netcdf_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -1927,6 +1928,8 @@ int mbsys_netcdf_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1981,7 +1984,6 @@ int mbsys_netcdf_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 int mbsys_netcdf_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                   double *altitude, int *error) {
 	char *function_name = "mbsys_netcdf_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 	double depthscale;
 	double distancescale;
@@ -2010,6 +2012,8 @@ int mbsys_netcdf_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, 
 	/* set starting values */
 	*transducer_depth = 0.0;
 	*altitude = 0.0;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -2091,7 +2095,6 @@ int mbsys_netcdf_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, 
 int mbsys_netcdf_insert_altitude(int verbose, void *mbio_ptr, void *store_ptr, double transducer_depth, double altitude,
                                  int *error) {
 	char *function_name = "mbsys_netcdf_insert_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -2109,6 +2112,8 @@ int mbsys_netcdf_insert_altitude(int verbose, void *mbio_ptr, void *store_ptr, d
 
 	/* get data structure pointer */
 	store = (struct mbsys_netcdf_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* insert data into structure */
 	if (store->kind == MB_DATA_DATA) {
@@ -2155,7 +2160,6 @@ int mbsys_netcdf_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
                              double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                              double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_netcdf_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -2174,6 +2178,8 @@ int mbsys_netcdf_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -2279,7 +2285,6 @@ int mbsys_netcdf_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
                             double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                             int *error) {
 	char *function_name = "mbsys_netcdf_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 
 	if (verbose >= 2) {
@@ -2373,6 +2378,8 @@ int mbsys_netcdf_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
 		}
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -2386,7 +2393,6 @@ int mbsys_netcdf_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
 /*--------------------------------------------------------------------*/
 int mbsys_netcdf_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_netcdf_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_netcdf_struct *store;
 	struct mbsys_netcdf_struct *copy;
 
@@ -2405,6 +2411,8 @@ int mbsys_netcdf_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_p
 	/* get data structure pointers */
 	store = (struct mbsys_netcdf_struct *)store_ptr;
 	copy = (struct mbsys_netcdf_struct *)copy_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* deallocate memory if required */
 	if (store->mbHistoryRecNbr > copy->mbHistoryRecNbr) {

--- a/src/mbio/mbsys_oic.c
+++ b/src/mbio/mbsys_oic.c
@@ -37,7 +37,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_oic_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_oic_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 
 	if (verbose >= 2) {
@@ -51,7 +50,7 @@ int mbsys_oic_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_oic_struct), (void **)store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_oic_struct), (void **)store_ptr, error);
 
 	/* get pointer to data structure */
 	store = (struct mbsys_oic_struct *)*store_ptr;
@@ -150,7 +149,6 @@ int mbsys_oic_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_oic_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_oic_deall";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 
 	if (verbose >= 2) {
@@ -163,6 +161,8 @@ int mbsys_oic_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 
 	/* get pointer to data structure */
 	store = (struct mbsys_oic_struct *)*store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* deallocate memory for data structures */
 	for (int i = 0; i < store->num_chan; i++)
@@ -194,7 +194,6 @@ int mbsys_oic_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_oic_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss, int *error) {
 	char *function_name = "mbsys_oic_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 
 	if (verbose >= 2) {
@@ -228,6 +227,8 @@ int mbsys_oic_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -248,7 +249,6 @@ int mbsys_oic_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
                       double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                       double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_oic_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 
 	if (verbose >= 2) {
@@ -399,6 +399,9 @@ int mbsys_oic_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 			fprintf(stderr, "dbg2        pixel:%d   ss:%f  acrosstrack:%f  alongtrack:%f\n", i, ss[i], ssacrosstrack[i],
 			        ssalongtrack[i]);
 	}
+
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -413,7 +416,6 @@ int mbsys_oic_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int
                      double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                      double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_oic_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 
 	if (verbose >= 2) {
@@ -467,6 +469,8 @@ int mbsys_oic_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int
 
 	/* set data kind */
 	store->kind = kind;
+
+	int status = MB_SUCCESS;
 
 	/* insert data in structure */
 	if (store->kind == MB_DATA_DATA) {
@@ -582,7 +586,6 @@ int mbsys_oic_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
                      double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                      double *ssv, int *error) {
 	char *function_name = "mbsys_oic_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 	double alpha, beta;
 
@@ -608,6 +611,8 @@ int mbsys_oic_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -676,7 +681,6 @@ int mbsys_oic_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
 /*--------------------------------------------------------------------*/
 int mbsys_oic_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_oic_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 
 	if (verbose >= 2) {
@@ -696,6 +700,8 @@ int mbsys_oic_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -750,7 +756,6 @@ int mbsys_oic_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 int mbsys_oic_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                double *altitude, int *error) {
 	char *function_name = "mbsys_oic_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 
 	if (verbose >= 2) {
@@ -769,6 +774,8 @@ int mbsys_oic_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -807,7 +814,6 @@ int mbsys_oic_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int
 int mbsys_oic_insert_altitude(int verbose, void *mbio_ptr, void *store_ptr, double transducer_depth, double altitude,
                               int *error) {
 	char *function_name = "mbsys_oic_insert_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 
 	if (verbose >= 2) {
@@ -825,6 +831,8 @@ int mbsys_oic_insert_altitude(int verbose, void *mbio_ptr, void *store_ptr, doub
 
 	/* get data structure pointer */
 	store = (struct mbsys_oic_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* insert data into structure */
 	if (store->kind == MB_DATA_DATA) {
@@ -861,7 +869,6 @@ int mbsys_oic_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
                           double *navlat, double *speed, double *heading, double *draft, double *roll, double *pitch,
                           double *heave, int *error) {
 	char *function_name = "mbsys_oic_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 
 	if (verbose >= 2) {
@@ -880,6 +887,8 @@ int mbsys_oic_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -987,7 +996,6 @@ int mbsys_oic_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 int mbsys_oic_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_i[7], double time_d, double navlon, double navlat,
                          double speed, double heading, double draft, double roll, double pitch, double heave, int *error) {
 	char *function_name = "mbsys_oic_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 
 	if (verbose >= 2) {
@@ -1047,6 +1055,8 @@ int mbsys_oic_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_
 		store->fish_pitch = pitch;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1060,7 +1070,6 @@ int mbsys_oic_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_
 /*--------------------------------------------------------------------*/
 int mbsys_oic_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_oic_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_oic_struct *store;
 	struct mbsys_oic_struct *copy;
 
@@ -1079,6 +1088,8 @@ int mbsys_oic_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr,
 	/* get data structure pointers */
 	store = (struct mbsys_oic_struct *)store_ptr;
 	copy = (struct mbsys_oic_struct *)copy_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* copy the basic header data */
 	if (store != NULL && copy != NULL) {

--- a/src/mbio/mbsys_reson.c
+++ b/src/mbio/mbsys_reson.c
@@ -40,7 +40,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_reson_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_reson_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 
 	if (verbose >= 2) {
@@ -54,7 +53,7 @@ int mbsys_reson_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error)
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_reson_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_reson_struct), store_ptr, error);
 
 	/* get data structure pointer */
 	store = (struct mbsys_reson_struct *)*store_ptr;
@@ -179,7 +178,6 @@ int mbsys_reson_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int mbsys_reson_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_reson_deall";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -190,7 +188,7 @@ int mbsys_reson_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error)
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -205,7 +203,6 @@ int mbsys_reson_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int mbsys_reson_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss, int *error) {
 	char *function_name = "mbsys_reson_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 
 	if (verbose >= 2) {
@@ -239,6 +236,8 @@ int mbsys_reson_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -259,7 +258,6 @@ int mbsys_reson_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
                         double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                         double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_reson_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 	double depthscale, dacrscale, daloscale, reflscale;
 
@@ -461,6 +459,9 @@ int mbsys_reson_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 			fprintf(stderr, "dbg2       beam:%d   amp:%f  acrosstrack:%f  alongtrack:%f\n", i, amp[i], bathacrosstrack[i],
 			        bathalongtrack[i]);
 	}
+
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -475,7 +476,6 @@ int mbsys_reson_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, i
                        double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                        double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_reson_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 	double depthscale, dacrscale, daloscale, reflscale;
 
@@ -597,6 +597,8 @@ int mbsys_reson_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, i
 		strncpy(store->comment, comment, 199);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -612,7 +614,6 @@ int mbsys_reson_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
                        double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                        double *ssv, int *error) {
 	char *function_name = "mbsys_reson_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 	double ttscale, angscale;
 	double heave_use;
@@ -641,6 +642,8 @@ int mbsys_reson_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -727,7 +730,6 @@ int mbsys_reson_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 /*--------------------------------------------------------------------*/
 int mbsys_reson_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_reson_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 
 	if (verbose >= 2) {
@@ -747,6 +749,8 @@ int mbsys_reson_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -801,7 +805,6 @@ int mbsys_reson_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 int mbsys_reson_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                  double *altitude, int *error) {
 	char *function_name = "mbsys_reson_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 	double depthscale;
 	double dacrscale;
@@ -824,6 +827,8 @@ int mbsys_reson_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, i
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -892,7 +897,6 @@ int mbsys_reson_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *k
                             double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                             double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_reson_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 
 	if (verbose >= 2) {
@@ -911,6 +915,8 @@ int mbsys_reson_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *k
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1073,7 +1079,6 @@ int mbsys_reson_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int tim
                            double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                            int *error) {
 	char *function_name = "mbsys_reson_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 
 	if (verbose >= 2) {
@@ -1162,6 +1167,8 @@ int mbsys_reson_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int tim
 		store->heave = heave * 200.0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1176,7 +1183,6 @@ int mbsys_reson_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int tim
 int mbsys_reson_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                             int *error) {
 	char *function_name = "mbsys_reson_extract_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 
 	if (verbose >= 2) {
@@ -1195,6 +1201,8 @@ int mbsys_reson_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *k
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_VELOCITY_PROFILE) {
@@ -1241,7 +1249,6 @@ int mbsys_reson_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *k
 /*--------------------------------------------------------------------*/
 int mbsys_reson_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error) {
 	char *function_name = "mbsys_reson_insert_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 
 	if (verbose >= 2) {
@@ -1273,6 +1280,8 @@ int mbsys_reson_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsv
 		}
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1286,7 +1295,6 @@ int mbsys_reson_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsv
 /*--------------------------------------------------------------------*/
 int mbsys_reson_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_reson_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_reson_struct *store;
 	struct mbsys_reson_struct *copy;
 
@@ -1308,6 +1316,8 @@ int mbsys_reson_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_pt
 
 	/* copy the data */
 	*copy = *store;
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_reson7k.c
+++ b/src/mbio/mbsys_reson7k.c
@@ -46,7 +46,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_zero7kheader(int verbose, s7k_header *header, int *error) {
   char *function_name = "mbsys_reson7k_zero7kheader";
-  int status = MB_SUCCESS;
   int i;
 
   if (verbose >= 2) {
@@ -84,6 +83,8 @@ int mbsys_reson7k_zero7kheader(int verbose, s7k_header *header, int *error) {
   header->FragmentedTotal = 0;
   header->FragmentNumber = 0;
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -98,7 +99,6 @@ int mbsys_reson7k_zero7kheader(int verbose, s7k_header *header, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
   char *function_name = "mbsys_reson7k_alloc";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_reference *reference;
   s7kr_sensoruncal *sensoruncal;
@@ -165,7 +165,7 @@ int mbsys_reson7k_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *erro
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* allocate memory for data structure */
-  status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_reson7k_struct), (void **)store_ptr, error);
+  const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_reson7k_struct), (void **)store_ptr, error);
 
   /* get data structure pointer */
   store = (struct mbsys_reson7k_struct *)*store_ptr;
@@ -1153,7 +1153,6 @@ int mbsys_reson7k_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
   char *function_name = "mbsys_reson7k_deall";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_customattitude *customattitude;
   s7kr_motion *motion;
@@ -1191,6 +1190,8 @@ int mbsys_reson7k_deall(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 
   /* get data structure pointer */
   store = (struct mbsys_reson7k_struct *)*store_ptr;
+
+  int status = MB_SUCCESS;
 
   /* Custom attitude (record 1004) */
   customattitude = &store->customattitude;
@@ -1449,7 +1450,6 @@ int mbsys_reson7k_checkheader(s7k_header header) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_header(int verbose, s7k_header *header, int *error) {
   char *function_name = "mbsys_reson7k_print_header";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1498,6 +1498,8 @@ int mbsys_reson7k_print_header(int verbose, s7k_header *header, int *error) {
   fprintf(stderr, "%s     FragmentedTotal:         %d\n", first, header->FragmentedTotal);
   fprintf(stderr, "%s     FragmentNumber:          %d\n", first, header->FragmentNumber);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1512,7 +1514,6 @@ int mbsys_reson7k_print_header(int verbose, s7k_header *header, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_reference(int verbose, s7kr_reference *reference, int *error) {
   char *function_name = "mbsys_reson7k_print_reference";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1540,6 +1541,8 @@ int mbsys_reson7k_print_reference(int verbose, s7kr_reference *reference, int *e
   fprintf(stderr, "%s     offset_z:                %f\n", first, reference->offset_z);
   fprintf(stderr, "%s     water_z:                 %f\n", first, reference->water_z);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1554,7 +1557,6 @@ int mbsys_reson7k_print_reference(int verbose, s7kr_reference *reference, int *e
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_sensoruncal(int verbose, s7kr_sensoruncal *sensoruncal, int *error) {
   char *function_name = "mbsys_reson7k_print_sensoruncal";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1584,6 +1586,8 @@ int mbsys_reson7k_print_sensoruncal(int verbose, s7kr_sensoruncal *sensoruncal, 
   fprintf(stderr, "%s     offset_pitch:            %f\n", first, sensoruncal->offset_pitch);
   fprintf(stderr, "%s     offset_yaw:              %f\n", first, sensoruncal->offset_yaw);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1598,7 +1602,6 @@ int mbsys_reson7k_print_sensoruncal(int verbose, s7kr_sensoruncal *sensoruncal, 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_sensorcal(int verbose, s7kr_sensorcal *sensorcal, int *error) {
   char *function_name = "mbsys_reson7k_print_sensorcal";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1627,6 +1630,8 @@ int mbsys_reson7k_print_sensorcal(int verbose, s7kr_sensorcal *sensorcal, int *e
   fprintf(stderr, "%s     offset_pitch:            %f\n", first, sensorcal->offset_pitch);
   fprintf(stderr, "%s     offset_yaw:              %f\n", first, sensorcal->offset_yaw);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1641,7 +1646,6 @@ int mbsys_reson7k_print_sensorcal(int verbose, s7kr_sensorcal *sensorcal, int *e
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_position(int verbose, s7kr_position *position, int *error) {
   char *function_name = "mbsys_reson7k_print_position";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1674,6 +1678,8 @@ int mbsys_reson7k_print_position(int verbose, s7kr_position *position, int *erro
   fprintf(stderr, "%s     quality:                 %d\n", first, position->quality);
   fprintf(stderr, "%s     method:                  %d\n", first, position->method);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1688,7 +1694,6 @@ int mbsys_reson7k_print_position(int verbose, s7kr_position *position, int *erro
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_customattitude(int verbose, s7kr_customattitude *customattitude, int *error) {
   char *function_name = "mbsys_reson7k_print_customattitude";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1725,6 +1730,8 @@ int mbsys_reson7k_print_customattitude(int verbose, s7kr_customattitude *customa
             customattitude->pitchrate[i], customattitude->rollrate[i], customattitude->headingrate[i],
             customattitude->heaverate[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1739,7 +1746,6 @@ int mbsys_reson7k_print_customattitude(int verbose, s7kr_customattitude *customa
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_tide(int verbose, s7kr_tide *tide, int *error) {
   char *function_name = "mbsys_reson7k_print_tide";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1774,6 +1780,8 @@ int mbsys_reson7k_print_tide(int verbose, s7kr_tide *tide, int *error) {
   fprintf(stderr, "%s     type:                       %d\n", first, tide->type);
   fprintf(stderr, "%s     utm_zone:                   %d\n", first, tide->utm_zone);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1788,7 +1796,6 @@ int mbsys_reson7k_print_tide(int verbose, s7kr_tide *tide, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_altitude(int verbose, s7kr_altitude *altitude, int *error) {
   char *function_name = "mbsys_reson7k_print_altitude";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1813,6 +1820,8 @@ int mbsys_reson7k_print_altitude(int verbose, s7kr_altitude *altitude, int *erro
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     altitude:                   %f\n", first, altitude->altitude);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1827,7 +1836,6 @@ int mbsys_reson7k_print_altitude(int verbose, s7kr_altitude *altitude, int *erro
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_motion(int verbose, s7kr_motion *motion, int *error) {
   char *function_name = "mbsys_reson7k_print_motion";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1860,6 +1868,8 @@ int mbsys_reson7k_print_motion(int verbose, s7kr_motion *motion, int *error) {
     fprintf(stderr, "%s     i:%d x:%f y:%f z:%f xa:%f ya:%f za:%f\n", first, i, motion->x[i], motion->y[i], motion->z[i],
             motion->xa[i], motion->ya[i], motion->za[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1873,7 +1883,6 @@ int mbsys_reson7k_print_motion(int verbose, s7kr_motion *motion, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_depth(int verbose, s7kr_depth *depth, int *error) {
   char *function_name = "mbsys_reson7k_print_depth";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1901,6 +1910,8 @@ int mbsys_reson7k_print_depth(int verbose, s7kr_depth *depth, int *error) {
   fprintf(stderr, "%s     reserved:                    %d\n", first, depth->reserved);
   fprintf(stderr, "%s     depth:                       %f\n", first, depth->depth);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1915,7 +1926,6 @@ int mbsys_reson7k_print_depth(int verbose, s7kr_depth *depth, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_svp(int verbose, s7kr_svp *svp, int *error) {
   char *function_name = "mbsys_reson7k_print_svp";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1949,6 +1959,8 @@ int mbsys_reson7k_print_svp(int verbose, s7kr_svp *svp, int *error) {
   for (i = 0; i < svp->n; i++)
     fprintf(stderr, "%s     i:%d depth:%f sound_velocity:%f\n", first, i, svp->depth[i], svp->sound_velocity[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1963,7 +1975,6 @@ int mbsys_reson7k_print_svp(int verbose, s7kr_svp *svp, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_ctd(int verbose, s7kr_ctd *ctd, int *error) {
   char *function_name = "mbsys_reson7k_print_ctd";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2005,6 +2016,8 @@ int mbsys_reson7k_print_ctd(int verbose, s7kr_ctd *ctd, int *error) {
             first, i, ctd->conductivity_salinity[i], ctd->temperature[i], ctd->pressure_depth[i], ctd->sound_velocity[i],
             ctd->absorption[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2019,7 +2032,6 @@ int mbsys_reson7k_print_ctd(int verbose, s7kr_ctd *ctd, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_geodesy(int verbose, s7kr_geodesy *geodesy, int *error) {
   char *function_name = "mbsys_reson7k_print_geodesy";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2068,6 +2080,8 @@ int mbsys_reson7k_print_geodesy(int verbose, s7kr_geodesy *geodesy, int *error) 
   fprintf(stderr, "%s     custum_identifier:          %d\n", first, geodesy->custum_identifier);
   fprintf(stderr, "%s     reserved3:                  %s\n", first, geodesy->reserved3);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2082,7 +2096,6 @@ int mbsys_reson7k_print_geodesy(int verbose, s7kr_geodesy *geodesy, int *error) 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_rollpitchheave(int verbose, s7kr_rollpitchheave *rollpitchheave, int *error) {
   char *function_name = "mbsys_reson7k_print_rollpitchheave";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2109,6 +2122,8 @@ int mbsys_reson7k_print_rollpitchheave(int verbose, s7kr_rollpitchheave *rollpit
   fprintf(stderr, "%s     pitch:                      %f\n", first, rollpitchheave->pitch);
   fprintf(stderr, "%s     heave:                      %f\n", first, rollpitchheave->heave);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2123,7 +2138,6 @@ int mbsys_reson7k_print_rollpitchheave(int verbose, s7kr_rollpitchheave *rollpit
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_heading(int verbose, s7kr_heading *heading, int *error) {
   char *function_name = "mbsys_reson7k_print_heading";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2148,6 +2162,8 @@ int mbsys_reson7k_print_heading(int verbose, s7kr_heading *heading, int *error) 
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     heading:                    %f\n", first, heading->heading);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2162,7 +2178,6 @@ int mbsys_reson7k_print_heading(int verbose, s7kr_heading *heading, int *error) 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_surveyline(int verbose, s7kr_surveyline *surveyline, int *error) {
   char *function_name = "mbsys_reson7k_print_surveyline";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2194,6 +2209,8 @@ int mbsys_reson7k_print_surveyline(int verbose, s7kr_surveyline *surveyline, int
   for (i = 0; i < surveyline->n; i++)
     fprintf(stderr, "%s     i:%d latitude:%f longitude:%f\n", first, i, surveyline->latitude[i], surveyline->longitude[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2208,7 +2225,6 @@ int mbsys_reson7k_print_surveyline(int verbose, s7kr_surveyline *surveyline, int
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_navigation(int verbose, s7kr_navigation *navigation, int *error) {
   char *function_name = "mbsys_reson7k_print_navigation";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2241,6 +2257,8 @@ int mbsys_reson7k_print_navigation(int verbose, s7kr_navigation *navigation, int
   fprintf(stderr, "%s     course:                     %f\n", first, navigation->course);
   fprintf(stderr, "%s     heading:                    %f\n", first, navigation->heading);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2255,7 +2273,6 @@ int mbsys_reson7k_print_navigation(int verbose, s7kr_navigation *navigation, int
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_attitude(int verbose, s7kr_attitude *attitude, int *error) {
   char *function_name = "mbsys_reson7k_print_attitude";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2285,6 +2302,8 @@ int mbsys_reson7k_print_attitude(int verbose, s7kr_attitude *attitude, int *erro
     fprintf(stderr, "%s     i:%d delta_time:%d pitch:%f roll:%f heading:%f heave:%f\n", first, i, attitude->delta_time[i],
             attitude->pitch[i], attitude->roll[i], attitude->heading[i], attitude->heave[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2299,7 +2318,6 @@ int mbsys_reson7k_print_attitude(int verbose, s7kr_attitude *attitude, int *erro
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_rec1022(int verbose, s7kr_rec1022 *rec1022, int *error) {
   char *function_name = "mbsys_reson7k_print_rec1022";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2329,6 +2347,8 @@ int mbsys_reson7k_print_rec1022(int verbose, s7kr_rec1022 *rec1022, int *error) 
   }
   fprintf(stderr, "\n");
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2343,7 +2363,6 @@ int mbsys_reson7k_print_rec1022(int verbose, s7kr_rec1022 *rec1022, int *error) 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_fsdwchannel(int verbose, int data_format, s7k_fsdwchannel *fsdwchannel, int *error) {
   char *function_name = "mbsys_reson7k_print_fsdwchannel";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2398,6 +2417,8 @@ int mbsys_reson7k_print_fsdwchannel(int verbose, int data_format, s7k_fsdwchanne
       fprintf(stderr, "%s     data[%d]:                   %d\n", first, i, ushortptr[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2412,7 +2433,6 @@ int mbsys_reson7k_print_fsdwchannel(int verbose, int data_format, s7k_fsdwchanne
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_fsdwssheader(int verbose, s7k_fsdwssheader *fsdwssheader, int *error) {
   char *function_name = "mbsys_reson7k_print_fsdwssheader";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2467,6 +2487,8 @@ int mbsys_reson7k_print_fsdwssheader(int verbose, s7k_fsdwssheader *fsdwssheader
   fprintf(stderr, "%s     longitude:                    %d\n", first, fsdwssheader->longitude);
   fprintf(stderr, "%s     latitude:                     %d\n", first, fsdwssheader->latitude);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2481,7 +2503,6 @@ int mbsys_reson7k_print_fsdwssheader(int verbose, s7k_fsdwssheader *fsdwssheader
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_fsdwsegyheader(int verbose, s7k_fsdwsegyheader *fsdwsegyheader, int *error) {
   char *function_name = "mbsys_reson7k_print_fsdwsegyheader";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2570,6 +2591,8 @@ int mbsys_reson7k_print_fsdwsegyheader(int verbose, s7k_fsdwsegyheader *fsdwsegy
   for (i = 0; i < 7; i++)
     fprintf(stderr, "%s     unuseda[%d]:                  %d\n", first, i, fsdwsegyheader->unuseda[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2584,7 +2607,6 @@ int mbsys_reson7k_print_fsdwsegyheader(int verbose, s7k_fsdwsegyheader *fsdwsegy
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_fsdwss(int verbose, s7kr_fsdwss *fsdwss, int *error) {
   char *function_name = "mbsys_reson7k_print_fsdwss";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2618,6 +2640,8 @@ int mbsys_reson7k_print_fsdwss(int verbose, s7kr_fsdwss *fsdwss, int *error) {
     mbsys_reson7k_print_fsdwssheader(verbose, &fsdwss->ssheader[i], error);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2631,7 +2655,6 @@ int mbsys_reson7k_print_fsdwss(int verbose, s7kr_fsdwss *fsdwss, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_fsdwsb(int verbose, s7kr_fsdwsb *fsdwsb, int *error) {
   char *function_name = "mbsys_reson7k_print_fsdwsb";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2662,6 +2685,8 @@ int mbsys_reson7k_print_fsdwsb(int verbose, s7kr_fsdwsb *fsdwsb, int *error) {
   mbsys_reson7k_print_fsdwchannel(verbose, fsdwsb->data_format, &fsdwsb->channel, error);
   mbsys_reson7k_print_fsdwsegyheader(verbose, &fsdwsb->segyheader, error);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2675,7 +2700,6 @@ int mbsys_reson7k_print_fsdwsb(int verbose, s7kr_fsdwsb *fsdwsb, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_bluefin(int verbose, s7kr_bluefin *bluefin, int *error) {
   char *function_name = "mbsys_reson7k_print_bluefin";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2785,6 +2809,8 @@ int mbsys_reson7k_print_bluefin(int verbose, s7kr_bluefin *bluefin, int *error) 
     }
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2798,7 +2824,6 @@ int mbsys_reson7k_print_bluefin(int verbose, s7kr_bluefin *bluefin, int *error) 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_processedsidescan(int verbose, s7kr_processedsidescan *processedsidescan, int *error) {
   char *function_name = "mbsys_reson7k_print_processedsidescan";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2835,6 +2860,8 @@ int mbsys_reson7k_print_processedsidescan(int verbose, s7kr_processedsidescan *p
     fprintf(stderr, "%s     pixel[%d]:  sidescan:%f alongtrack:%f\n", first, i, processedsidescan->sidescan[i],
             processedsidescan->alongtrack[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2848,7 +2875,6 @@ int mbsys_reson7k_print_processedsidescan(int verbose, s7kr_processedsidescan *p
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_volatilesettings(int verbose, s7kr_volatilesettings *volatilesettings, int *error) {
   char *function_name = "mbsys_reson7k_print_volatilesettings";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2911,6 +2937,8 @@ int mbsys_reson7k_print_volatilesettings(int verbose, s7kr_volatilesettings *vol
   fprintf(stderr, "%s     spreading:                  %f\n", first, volatilesettings->spreading);
   fprintf(stderr, "%s     reserved:                   %d\n", first, volatilesettings->reserved);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2924,7 +2952,6 @@ int mbsys_reson7k_print_volatilesettings(int verbose, s7kr_volatilesettings *vol
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_device(int verbose, s7k_device *device, int *error) {
   char *function_name = "mbsys_reson7k_print_device";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2951,6 +2978,8 @@ int mbsys_reson7k_print_device(int verbose, s7k_device *device, int *error) {
   fprintf(stderr, "%s     info_alloc:                 %d\n", first, device->info_alloc);
   fprintf(stderr, "%s     info:                       %s\n", first, device->info);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2964,7 +2993,6 @@ int mbsys_reson7k_print_device(int verbose, s7k_device *device, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_configuration(int verbose, s7kr_configuration *configuration, int *error) {
   char *function_name = "mbsys_reson7k_print_configuration";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2993,6 +3021,8 @@ int mbsys_reson7k_print_configuration(int verbose, s7kr_configuration *configura
   for (i = 0; i < configuration->number_devices; i++)
     mbsys_reson7k_print_device(verbose, &configuration->device[i], error);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3006,7 +3036,6 @@ int mbsys_reson7k_print_configuration(int verbose, s7kr_configuration *configura
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_matchfilter(int verbose, s7kr_matchfilter *matchfilter, int *error) {
   char *function_name = "mbsys_reson7k_print_matchfilter";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3035,6 +3064,8 @@ int mbsys_reson7k_print_matchfilter(int verbose, s7kr_matchfilter *matchfilter, 
   fprintf(stderr, "%s     start_frequency:            %f\n", first, matchfilter->start_frequency);
   fprintf(stderr, "%s     end_frequency:              %f\n", first, matchfilter->end_frequency);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3050,7 +3081,6 @@ int mbsys_reson7k_print_v2firmwarehardwareconfiguration(int verbose,
                                                         s7kr_v2firmwarehardwareconfiguration *v2firmwarehardwareconfiguration,
                                                         int *error) {
   char *function_name = "mbsys_reson7k_print_v2firmwarehardwareconfiguration";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3078,6 +3108,8 @@ int mbsys_reson7k_print_v2firmwarehardwareconfiguration(int verbose,
   fprintf(stderr, "%s     info:                       \n", first);
   fprintf(stderr, "%s\n%s\n", v2firmwarehardwareconfiguration->info, first);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3091,7 +3123,6 @@ int mbsys_reson7k_print_v2firmwarehardwareconfiguration(int verbose,
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_beamgeometry(int verbose, s7kr_beamgeometry *beamgeometry, int *error) {
   char *function_name = "mbsys_reson7k_print_beamgeometry";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3123,6 +3154,8 @@ int mbsys_reson7k_print_beamgeometry(int verbose, s7kr_beamgeometry *beamgeometr
             first, i, beamgeometry->angle_alongtrack[i], beamgeometry->angle_acrosstrack[i],
             beamgeometry->beamwidth_alongtrack[i], beamgeometry->beamwidth_acrosstrack[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3136,7 +3169,6 @@ int mbsys_reson7k_print_beamgeometry(int verbose, s7kr_beamgeometry *beamgeometr
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_calibration(int verbose, s7kr_calibration *calibration, int *error) {
   char *function_name = "mbsys_reson7k_print_calibration";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3165,6 +3197,8 @@ int mbsys_reson7k_print_calibration(int verbose, s7kr_calibration *calibration, 
   for (i = 0; i < calibration->number_channels; i++)
     fprintf(stderr, "%s     channel[%d]:  gain:%f phase:%f\n", first, i, calibration->gain[i], calibration->phase[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3178,7 +3212,6 @@ int mbsys_reson7k_print_calibration(int verbose, s7kr_calibration *calibration, 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_bathymetry(int verbose, s7kr_bathymetry *bathymetry, int *error) {
   char *function_name = "mbsys_reson7k_print_bathymetry";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3229,6 +3262,8 @@ int mbsys_reson7k_print_bathymetry(int verbose, s7kr_bathymetry *bathymetry, int
             bathymetry->alongtrack[i], bathymetry->acrosstrack[i], bathymetry->pointing_angle[i],
             bathymetry->azimuth_angle[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3242,7 +3277,6 @@ int mbsys_reson7k_print_bathymetry(int verbose, s7kr_bathymetry *bathymetry, int
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_backscatter(int verbose, s7kr_backscatter *backscatter, int *error) {
   char *function_name = "mbsys_reson7k_print_backscatter";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3319,6 +3353,8 @@ int mbsys_reson7k_print_backscatter(int verbose, s7kr_backscatter *backscatter, 
   fprintf(stderr, "%s     heading:                    %f\n", first, backscatter->heading);
   fprintf(stderr, "%s     altitude:                   %f\n", first, backscatter->altitude);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3332,7 +3368,6 @@ int mbsys_reson7k_print_backscatter(int verbose, s7kr_backscatter *backscatter, 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_beam(int verbose, s7kr_beam *beam, int *error) {
   char *function_name = "mbsys_reson7k_print_beam";
-  int status = MB_SUCCESS;
   s7kr_snippet *snippet;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
@@ -3420,6 +3455,8 @@ int mbsys_reson7k_print_beam(int verbose, s7kr_beam *beam, int *error) {
     }
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3433,7 +3470,6 @@ int mbsys_reson7k_print_beam(int verbose, s7kr_beam *beam, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_verticaldepth(int verbose, s7kr_verticaldepth *verticaldepth, int *error) {
   char *function_name = "mbsys_reson7k_print_verticaldepth";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3466,6 +3502,8 @@ int mbsys_reson7k_print_verticaldepth(int verbose, s7kr_verticaldepth *verticald
   fprintf(stderr, "%s     acrosstrack:                %f\n", first, verticaldepth->acrosstrack);
   fprintf(stderr, "%s     vertical_depth:             %f\n", first, verticaldepth->vertical_depth);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3479,7 +3517,6 @@ int mbsys_reson7k_print_verticaldepth(int verbose, s7kr_verticaldepth *verticald
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_tvg(int verbose, s7kr_tvg *tvg, int *error) {
   char *function_name = "mbsys_reson7k_print_tvg";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3515,6 +3552,8 @@ int mbsys_reson7k_print_tvg(int verbose, s7kr_tvg *tvg, int *error) {
     fprintf(stderr, "%s     tvg[%d]:  %f\n", first, i, tvg_float[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3528,7 +3567,6 @@ int mbsys_reson7k_print_tvg(int verbose, s7kr_tvg *tvg, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_image(int verbose, s7kr_image *image, int *error) {
   char *function_name = "mbsys_reson7k_print_image";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3579,6 +3617,8 @@ int mbsys_reson7k_print_image(int verbose, s7kr_image *image, int *error) {
       fprintf(stderr, "%s     image[%d]:  %u\n", first, i, intptr[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3592,7 +3632,6 @@ int mbsys_reson7k_print_image(int verbose, s7kr_image *image, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_v2pingmotion(int verbose, s7kr_v2pingmotion *v2pingmotion, int *error) {
   char *function_name = "mbsys_reson7k_print_v2pingmotion";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3632,6 +3671,8 @@ int mbsys_reson7k_print_v2pingmotion(int verbose, s7kr_v2pingmotion *v2pingmotio
             v2pingmotion->heave[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3645,7 +3686,6 @@ int mbsys_reson7k_print_v2pingmotion(int verbose, s7kr_v2pingmotion *v2pingmotio
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_v2detectionsetup(int verbose, s7kr_v2detectionsetup *v2detectionsetup, int *error) {
   char *function_name = "mbsys_reson7k_print_v2detectionsetup";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3697,6 +3737,8 @@ int mbsys_reson7k_print_v2detectionsetup(int verbose, s7kr_v2detectionsetup *v2d
             v2detectionsetup->user_limits_max_sample[i], v2detectionsetup->quality[i], v2detectionsetup->uncertainty[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3710,7 +3752,6 @@ int mbsys_reson7k_print_v2detectionsetup(int verbose, s7kr_v2detectionsetup *v2d
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_v2beamformed(int verbose, s7kr_v2beamformed *v2beamformed, int *error) {
   char *function_name = "mbsys_reson7k_print_v2beamformed";
-  int status = MB_SUCCESS;
   s7kr_v2amplitudephase *v2amplitudephase;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
@@ -3754,6 +3795,8 @@ int mbsys_reson7k_print_v2beamformed(int verbose, s7kr_v2beamformed *v2beamforme
     }
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3767,7 +3810,6 @@ int mbsys_reson7k_print_v2beamformed(int verbose, s7kr_v2beamformed *v2beamforme
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_v2bite(int verbose, s7kr_v2bite *v2bite, int *error) {
   char *function_name = "mbsys_reson7k_print_v2bite";
-  int status = MB_SUCCESS;
   s7kr_v2bitereport *v2bitereport;
   s7kr_v2bitefield *v2bitefield;
   s7k_time *s7ktime;
@@ -3827,6 +3869,8 @@ int mbsys_reson7k_print_v2bite(int verbose, s7kr_v2bite *v2bite, int *error) {
     }
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3840,7 +3884,6 @@ int mbsys_reson7k_print_v2bite(int verbose, s7kr_v2bite *v2bite, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_v27kcenterversion(int verbose, s7kr_v27kcenterversion *v27kcenterversion, int *error) {
   char *function_name = "mbsys_reson7k_print_v27kcenterversion";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3865,6 +3908,8 @@ int mbsys_reson7k_print_v27kcenterversion(int verbose, s7kr_v27kcenterversion *v
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     version:                    %s\n", first, v27kcenterversion->version);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3878,7 +3923,6 @@ int mbsys_reson7k_print_v27kcenterversion(int verbose, s7kr_v27kcenterversion *v
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_v28kwetendversion(int verbose, s7kr_v28kwetendversion *v28kwetendversion, int *error) {
   char *function_name = "mbsys_reson7k_print_v28kwetendversion";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3903,6 +3947,8 @@ int mbsys_reson7k_print_v28kwetendversion(int verbose, s7kr_v28kwetendversion *v
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     version:                    %s\n", first, v28kwetendversion->version);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3916,7 +3962,6 @@ int mbsys_reson7k_print_v28kwetendversion(int verbose, s7kr_v28kwetendversion *v
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_v2detection(int verbose, s7kr_v2detection *v2detection, int *error) {
   char *function_name = "mbsys_reson7k_print_v2detection";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3958,6 +4003,8 @@ int mbsys_reson7k_print_v2detection(int verbose, s7kr_v2detection *v2detection, 
             v2detection->angle_y_error[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3971,7 +4018,6 @@ int mbsys_reson7k_print_v2detection(int verbose, s7kr_v2detection *v2detection, 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_v2rawdetection(int verbose, s7kr_v2rawdetection *v2rawdetection, int *error) {
   char *function_name = "mbsys_reson7k_print_v2rawdetection";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4015,6 +4061,8 @@ int mbsys_reson7k_print_v2rawdetection(int verbose, s7kr_v2rawdetection *v2rawde
             v2rawdetection->quality[i], v2rawdetection->uncertainty[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4028,7 +4076,6 @@ int mbsys_reson7k_print_v2rawdetection(int verbose, s7kr_v2rawdetection *v2rawde
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_v2snippet(int verbose, s7kr_v2snippet *v2snippet, int *error) {
   char *function_name = "mbsys_reson7k_print_v2snippet";
-  int status = MB_SUCCESS;
   s7kr_v2snippettimeseries *v2snippettimeseries;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
@@ -4070,6 +4117,8 @@ int mbsys_reson7k_print_v2snippet(int verbose, s7kr_v2snippet *v2snippet, int *e
               v2snippettimeseries->amplitude[j]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4083,7 +4132,6 @@ int mbsys_reson7k_print_v2snippet(int verbose, s7kr_v2snippet *v2snippet, int *e
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_calibratedsnippet(int verbose, s7kr_calibratedsnippet *calibratedsnippet, int *error) {
   char *function_name = "mbsys_reson7k_print_calibratedsnippet";
-  int status = MB_SUCCESS;
   s7kr_calibratedsnippettimeseries *calibratedsnippettimeseries;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
@@ -4126,6 +4174,8 @@ int mbsys_reson7k_print_calibratedsnippet(int verbose, s7kr_calibratedsnippet *c
               calibratedsnippettimeseries->amplitude[j]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4139,7 +4189,6 @@ int mbsys_reson7k_print_calibratedsnippet(int verbose, s7kr_calibratedsnippet *c
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_installation(int verbose, s7kr_installation *installation, int *error) {
   char *function_name = "mbsys_reson7k_print_installation";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4202,6 +4251,8 @@ int mbsys_reson7k_print_installation(int verbose, s7kr_installation *installatio
   fprintf(stderr, "%s     position_time_delay:        %d\n", first, installation->position_time_delay);
   fprintf(stderr, "%s     waterline_z:                %f\n", first, installation->waterline_z);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4215,7 +4266,6 @@ int mbsys_reson7k_print_installation(int verbose, s7kr_installation *installatio
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_systemeventmessage(int verbose, s7kr_systemeventmessage *systemeventmessage, int *error) {
   char *function_name = "mbsys_reson7k_print_systemeventmessage";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4245,6 +4295,8 @@ int mbsys_reson7k_print_systemeventmessage(int verbose, s7kr_systemeventmessage 
   fprintf(stderr, "%s     message_alloc:              %d\n", first, systemeventmessage->message_alloc);
   fprintf(stderr, "%s     message:                    %s\n", first, systemeventmessage->message);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4258,7 +4310,6 @@ int mbsys_reson7k_print_systemeventmessage(int verbose, s7kr_systemeventmessage 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_subsystem(int verbose, s7kr_subsystem *subsystem, int *error) {
   char *function_name = "mbsys_reson7k_print_subsystem";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4281,6 +4332,8 @@ int mbsys_reson7k_print_subsystem(int verbose, s7kr_subsystem *subsystem, int *e
   fprintf(stderr, "%s     device_identifier:          %d\n", first, subsystem->device_identifier);
   fprintf(stderr, "%s     system_enumerator:          %d\n", first, subsystem->system_enumerator);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4294,7 +4347,6 @@ int mbsys_reson7k_print_subsystem(int verbose, s7kr_subsystem *subsystem, int *e
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_fileheader(int verbose, s7kr_fileheader *fileheader, int *error) {
   char *function_name = "mbsys_reson7k_print_fileheader";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4334,6 +4386,8 @@ int mbsys_reson7k_print_fileheader(int verbose, s7kr_fileheader *fileheader, int
   for (i = 0; i < fileheader->number_subsystems; i++)
     mbsys_reson7k_print_subsystem(verbose, &fileheader->subsystem[i], error);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4347,7 +4401,6 @@ int mbsys_reson7k_print_fileheader(int verbose, s7kr_fileheader *fileheader, int
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_remotecontrolsettings(int verbose, s7kr_remotecontrolsettings *remotecontrolsettings, int *error) {
   char *function_name = "mbsys_reson7k_print_remotecontrolsettings";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4424,6 +4477,8 @@ int mbsys_reson7k_print_remotecontrolsettings(int verbose, s7kr_remotecontrolset
   for (i = 0; i < 35; i++)
     fprintf(stderr, "%s     reserved2[i]:               %d\n", first, remotecontrolsettings->reserved2[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4437,7 +4492,6 @@ int mbsys_reson7k_print_remotecontrolsettings(int verbose, s7kr_remotecontrolset
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_reserved(int verbose, s7kr_reserved *reserved, int *error) {
   char *function_name = "mbsys_reson7k_print_reserved";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4464,6 +4518,8 @@ int mbsys_reson7k_print_reserved(int verbose, s7kr_reserved *reserved, int *erro
   for (i = 0; i < R7KHDRSIZE_7kReserved; i++)
     fprintf(stderr, "%s     reserved[%d]:               %u\n", first, i, reserved->reserved[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4477,7 +4533,6 @@ int mbsys_reson7k_print_reserved(int verbose, s7kr_reserved *reserved, int *erro
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_roll(int verbose, s7kr_roll *roll, int *error) {
   char *function_name = "mbsys_reson7k_print_roll";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4502,6 +4557,8 @@ int mbsys_reson7k_print_roll(int verbose, s7kr_roll *roll, int *error) {
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     roll:                       %f\n", first, roll->roll);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4515,7 +4572,6 @@ int mbsys_reson7k_print_roll(int verbose, s7kr_roll *roll, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_pitch(int verbose, s7kr_pitch *pitch, int *error) {
   char *function_name = "mbsys_reson7k_print_pitch";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4540,6 +4596,8 @@ int mbsys_reson7k_print_pitch(int verbose, s7kr_pitch *pitch, int *error) {
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     pitch:                      %f\n", first, pitch->pitch);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4553,7 +4611,6 @@ int mbsys_reson7k_print_pitch(int verbose, s7kr_pitch *pitch, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_soundvelocity(int verbose, s7kr_soundvelocity *soundvelocity, int *error) {
   char *function_name = "mbsys_reson7k_print_soundvelocity";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4578,6 +4635,8 @@ int mbsys_reson7k_print_soundvelocity(int verbose, s7kr_soundvelocity *soundvelo
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     soundvelocity:              %f\n", first, soundvelocity->soundvelocity);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4591,7 +4650,6 @@ int mbsys_reson7k_print_soundvelocity(int verbose, s7kr_soundvelocity *soundvelo
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_absorptionloss(int verbose, s7kr_absorptionloss *absorptionloss, int *error) {
   char *function_name = "mbsys_reson7k_print_absorptionloss";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4616,6 +4674,8 @@ int mbsys_reson7k_print_absorptionloss(int verbose, s7kr_absorptionloss *absorpt
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     absorptionloss:             %f\n", first, absorptionloss->absorptionloss);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4629,7 +4689,6 @@ int mbsys_reson7k_print_absorptionloss(int verbose, s7kr_absorptionloss *absorpt
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_print_spreadingloss(int verbose, s7kr_spreadingloss *spreadingloss, int *error) {
   char *function_name = "mbsys_reson7k_print_spreadingloss";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -4654,6 +4713,8 @@ int mbsys_reson7k_print_spreadingloss(int verbose, s7kr_spreadingloss *spreading
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     spreadingloss:              %f\n", first, spreadingloss->spreadingloss);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4668,7 +4729,6 @@ int mbsys_reson7k_print_spreadingloss(int verbose, s7kr_spreadingloss *spreading
 int mbsys_reson7k_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                              int *error) {
   char *function_name = "mbsys_reson7k_dimensions";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
 
@@ -4704,6 +4764,8 @@ int mbsys_reson7k_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *
     *nss = 0;
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4721,7 +4783,6 @@ int mbsys_reson7k_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber, int *error) {
   char *function_name = "mbsys_reson7k_pingnumber";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
 
@@ -4742,6 +4803,8 @@ int mbsys_reson7k_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumb
   bathymetry = (s7kr_bathymetry *)&store->bathymetry;
   *pingnumber = bathymetry->ping_number;
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4756,7 +4819,6 @@ int mbsys_reson7k_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumb
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *sonartype, int *error) {
   char *function_name = "mbsys_reson7k_sonartype";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
 
   if (verbose >= 2) {
@@ -4776,6 +4838,8 @@ int mbsys_reson7k_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *s
   /* get sonar type */
   *sonartype = MB_TOPOGRAPHY_TYPE_MULTIBEAM;
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4790,7 +4854,6 @@ int mbsys_reson7k_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *s
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int *ss_type, int *error) {
   char *function_name = "mbsys_reson7k_sidescantype";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
 
   if (verbose >= 2) {
@@ -4810,6 +4873,8 @@ int mbsys_reson7k_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int
   /* get sidescan type */
   *ss_type = MB_SIDESCAN_LINEAR;
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4827,7 +4892,6 @@ int mbsys_reson7k_preprocess(int verbose,     /* in: verbosity level set on comm
                              void *store_ptr, /* in: see mbsys_reson7k.h:/^struct mbsys_reson7k_struct/ */
                              void *platform_ptr, void *preprocess_pars_ptr, int *error) {
   char *function_name = "mbsys_reson7k_preprocess";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   struct mb_platform_struct *platform;
   struct mb_preprocess_struct *pars;
@@ -4946,7 +5010,6 @@ int mbsys_reson7k_preprocess(int verbose,     /* in: verbosity level set on comm
   }
 
   /* start successful */
-  status = MB_SUCCESS;
   *error = MB_ERROR_NO_ERROR;
 
   /* check for non-null data */
@@ -5033,6 +5096,8 @@ int mbsys_reson7k_preprocess(int verbose,     /* in: verbosity level set on comm
       }
     }
   }
+
+  int status = MB_SUCCESS;
 
   /* deal with a survey record */
   if (store->kind == MB_DATA_DATA) {
@@ -6082,7 +6147,6 @@ int mbsys_reson7k_preprocess(int verbose,     /* in: verbosity level set on comm
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_extract_platform(int verbose, void *mbio_ptr, void *store_ptr, int *kind, void **platform_ptr, int *error) {
   char *function_name = "mbsys_reson7k_extract_platform";
-  int status = MB_SUCCESS;
   struct mb_platform_struct *platform;
   struct mbsys_reson7k_struct *store;
   s7kr_installation *installation;
@@ -6104,6 +6168,8 @@ int mbsys_reson7k_extract_platform(int verbose, void *mbio_ptr, void *store_ptr,
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
   store = (struct mbsys_reson7k_struct *)store_ptr;
   installation = (s7kr_installation *)&store->installation;
+
+  int status = MB_SUCCESS;
 
   /* if needed allocate a new platform structure */
   if (*platform_ptr == NULL) {
@@ -6257,7 +6323,6 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
                           double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                           double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
   char *function_name = "mbsys_reson7k_extract";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_bluefin *bluefin;
   s7kr_processedsidescan *processedsidescan;
@@ -6797,6 +6862,9 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
       fprintf(stderr, "dbg2        pixel:%d   ss:%f  acrosstrack:%f  alongtrack:%f\n", i, ss[i], ssacrosstrack[i],
               ssalongtrack[i]);
   }
+
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "dbg2       error:      %d\n", *error);
     fprintf(stderr, "dbg2  Return status:\n");
@@ -6811,7 +6879,6 @@ int mbsys_reson7k_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
                          double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                          double *ssalongtrack, char *comment, int *error) {
   char *function_name = "mbsys_reson7k_insert";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_bluefin *bluefin;
   s7kr_processedsidescan *processedsidescan;
@@ -6891,6 +6958,8 @@ int mbsys_reson7k_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
 
   /* set data kind */
   store->kind = kind;
+
+  int status = MB_SUCCESS;
 
   /* insert data in structure */
   if (store->kind == MB_DATA_DATA) {
@@ -7118,7 +7187,6 @@ int mbsys_reson7k_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
                          double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                          double *ssv, int *error) {
   char *function_name = "mbsys_reson7k_ttimes";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   s7kr_depth *depth;
@@ -7158,6 +7226,8 @@ int mbsys_reson7k_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_DATA) {
@@ -7258,7 +7328,6 @@ int mbsys_reson7k_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
   char *function_name = "mbsys_reson7k_detects";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   mb_u_char detect;
@@ -7282,6 +7351,8 @@ int mbsys_reson7k_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_DATA) {
@@ -7342,7 +7413,6 @@ int mbsys_reson7k_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 int mbsys_reson7k_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                         double *receive_gain, int *error) {
   char *function_name = "mbsys_reson7k_gains";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_volatilesettings *volatilesettings;
@@ -7363,6 +7433,8 @@ int mbsys_reson7k_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_DATA) {
@@ -7422,7 +7494,6 @@ int mbsys_reson7k_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 int mbsys_reson7k_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                    double *altitudev, int *error) {
   char *function_name = "mbsys_reson7k_extract_altitude";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   s7kr_depth *depth;
@@ -7456,6 +7527,8 @@ int mbsys_reson7k_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr,
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_DATA) {
@@ -7563,7 +7636,6 @@ int mbsys_reson7k_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
                               double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                               double *pitch, double *heave, int *error) {
   char *function_name = "mbsys_reson7k_extract_nav";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   s7kr_bluefin *bluefin;
@@ -7605,6 +7677,8 @@ int mbsys_reson7k_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from ping structure */
   if (*kind == MB_DATA_DATA) {
@@ -7931,7 +8005,6 @@ int mbsys_reson7k_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr, int
                                double *time_d, double *navlon, double *navlat, double *speed, double *heading, double *draft,
                                double *roll, double *pitch, double *heave, int *error) {
   char *function_name = "mbsys_reson7k_extract_nnav";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   s7kr_bluefin *bluefin;
@@ -7968,6 +8041,8 @@ int mbsys_reson7k_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr, int
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from ping structure */
   if (*kind == MB_DATA_DATA) {
@@ -8245,7 +8320,6 @@ int mbsys_reson7k_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
                              double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                              int *error) {
   char *function_name = "mbsys_reson7k_insert_nav";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   s7kr_position *position;
@@ -8334,6 +8408,8 @@ int mbsys_reson7k_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
     /* get roll pitch and heave */
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return value:\n");
@@ -8348,7 +8424,6 @@ int mbsys_reson7k_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
 int mbsys_reson7k_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                               int *error) {
   char *function_name = "mbsys_reson7k_extract_svp";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_svp *svp;
   int i;
@@ -8370,6 +8445,8 @@ int mbsys_reson7k_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_VELOCITY_PROFILE) {
@@ -8417,7 +8494,6 @@ int mbsys_reson7k_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
 int mbsys_reson7k_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity,
                              int *error) {
   char *function_name = "mbsys_reson7k_insert_svp";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_svp *svp;
   int i;
@@ -8439,6 +8515,8 @@ int mbsys_reson7k_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
   /* get data structure pointer */
   store = (struct mbsys_reson7k_struct *)store_ptr;
   svp = (s7kr_svp *)&store->svp;
+
+  int status = MB_SUCCESS;
 
   /* insert data in structure */
   if (store->kind == MB_DATA_VELOCITY_PROFILE) {
@@ -8479,7 +8557,6 @@ int mbsys_reson7k_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
 int mbsys_reson7k_extract_segytraceheader(int verbose, void *mbio_ptr, void *store_ptr, int *kind, void *segytraceheader_ptr,
                                           int *error) {
   char *function_name = "mbsys_reson7k_extract_segytraceheader";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   struct mb_segytraceheader_struct *mb_segytraceheader_ptr;
   s7k_header *header;
@@ -8518,6 +8595,8 @@ int mbsys_reson7k_extract_segytraceheader(int verbose, void *mbio_ptr, void *sto
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_SUBBOTTOM_SUBBOTTOM) {
@@ -8738,7 +8817,6 @@ int mbsys_reson7k_extract_segytraceheader(int verbose, void *mbio_ptr, void *sto
 int mbsys_reson7k_extract_segy(int verbose, void *mbio_ptr, void *store_ptr, int *sampleformat, int *kind, void *segyheader_ptr,
                                float *segydata, int *error) {
   char *function_name = "mbsys_reson7k_extract_segy";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   struct mb_segytraceheader_struct *mb_segytraceheader_ptr;
   s7k_header *header;
@@ -8770,6 +8848,8 @@ int mbsys_reson7k_extract_segy(int verbose, void *mbio_ptr, void *store_ptr, int
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_SUBBOTTOM_SUBBOTTOM) {
@@ -8944,7 +9024,6 @@ int mbsys_reson7k_extract_segy(int verbose, void *mbio_ptr, void *store_ptr, int
 int mbsys_reson7k_insert_segy(int verbose, void *mbio_ptr, void *store_ptr, int kind, void *segyheader_ptr, float *segydata,
                               int *error) {
   char *function_name = "mbsys_reson7k_insert_segy";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   struct mb_segytraceheader_struct *mb_segytraceheader_ptr;
   s7k_header *header;
@@ -8983,6 +9062,8 @@ int mbsys_reson7k_insert_segy(int verbose, void *mbio_ptr, void *store_ptr, int 
 
   /* get data kind */
   store->kind = kind;
+
+  int status = MB_SUCCESS;
 
   /* insert data to structure */
   if (store->kind == MB_DATA_SUBBOTTOM_SUBBOTTOM) {
@@ -9193,7 +9274,6 @@ int mbsys_reson7k_ctd(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
   s7kr_bluefin *bluefin;
   s7k_bluefin_environmental *environmental;
   s7kr_ctd *ctd;
-  int status = MB_SUCCESS;
   int time_j[5];
   int time_i[7];
   int i;
@@ -9214,6 +9294,8 @@ int mbsys_reson7k_ctd(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract ctd data from bluefin environmental SSV record */
   if (*kind == MB_DATA_SSV) {
@@ -9314,7 +9396,6 @@ int mbsys_reson7k_ancilliarysensor(int verbose, void *mbio_ptr, void *store_ptr,
   s7k_header *header;
   s7kr_bluefin *bluefin;
   s7k_bluefin_environmental *environmental;
-  int status = MB_SUCCESS;
   int i;
 
   if (verbose >= 2) {
@@ -9379,6 +9460,9 @@ int mbsys_reson7k_ancilliarysensor(int verbose, void *mbio_ptr, void *store_ptr,
       fprintf(stderr, "dbg2       sensor8:       %f\n", sensor8[i]);
     }
   }
+
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "dbg2       error:      %d\n", *error);
     fprintf(stderr, "dbg2  Return status:\n");
@@ -9390,7 +9474,6 @@ int mbsys_reson7k_ancilliarysensor(int verbose, void *mbio_ptr, void *store_ptr,
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
   char *function_name = "mbsys_reson7k_copy";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   struct mbsys_reson7k_struct *copy;
   s7kr_attitude *attitude;
@@ -9458,6 +9541,9 @@ int mbsys_reson7k_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_
   copy->attitude.roll = attitude->roll;
   copy->attitude.heading = attitude->heading;
   copy->attitude.heave = attitude->heave;
+
+  int status = MB_SUCCESS;
+
   if (status == MB_SUCCESS && copy->attitude.nalloc < copy->attitude.n * sizeof(float)) {
     copy->attitude.nalloc = copy->attitude.n * sizeof(float);
     if (status == MB_SUCCESS)
@@ -9857,7 +9943,6 @@ int mbsys_reson7k_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_
 int mbsys_reson7k_makess(int verbose, void *mbio_ptr, void *store_ptr, int source, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error) {
   char *function_name = "mbsys_reson7k_makess";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k_struct *store;
   s7kr_reference *reference;
   s7kr_volatilesettings *volatilesettings;
@@ -10404,6 +10489,8 @@ int mbsys_reson7k_makess(int verbose, void *mbio_ptr, void *store_ptr, int sourc
                 ssacrosstrack[i], ssalongtrack[i]);
     }
   }
+
+  const int status = MB_SUCCESS;
 
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_reson7k3.c
+++ b/src/mbio/mbsys_reson7k3.c
@@ -44,7 +44,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_zero7kheader(int verbose, s7k3_header *header, int *error) {
   char *function_name = "mbsys_reson7k3_zero7kheader";
-  int status = MB_SUCCESS;
 
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -55,6 +54,8 @@ int mbsys_reson7k3_zero7kheader(int verbose, s7k3_header *header, int *error) {
 
   /* Reson 7k data record header information */
   memset((void *)header, 0 , sizeof(s7k3_header));
+
+  const int status = MB_SUCCESS;
 
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -70,7 +71,6 @@ int mbsys_reson7k3_zero7kheader(int verbose, s7k3_header *header, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
   char *function_name = "mbsys_reson7k3_alloc";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
 
   if (verbose >= 2) {
@@ -84,7 +84,7 @@ int mbsys_reson7k3_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *err
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* allocate memory for data structure */
-  status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_reson7k3_struct), (void **)store_ptr, error);
+  const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_reson7k3_struct), (void **)store_ptr, error);
 
   /* get data structure pointer */
   store = (struct mbsys_reson7k3_struct *)*store_ptr;
@@ -110,7 +110,6 @@ int mbsys_reson7k3_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *err
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
   char *function_name = "mbsys_reson7k3_deall";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_time *time;
   s7k3_header *header;
@@ -224,6 +223,9 @@ int mbsys_reson7k3_deall(int verbose, void *mbio_ptr, void **store_ptr, int *err
   CustomAttitude = &store->CustomAttitude;
   CustomAttitude->n = 0;
   CustomAttitude->nalloc = 0;
+
+  int status = MB_SUCCESS;
+
   if (CustomAttitude->pitch != NULL)
     status = mb_freed(verbose, __FILE__, __LINE__, (void **)&(CustomAttitude->pitch), error);
   if (CustomAttitude->roll != NULL)
@@ -540,7 +542,6 @@ int mbsys_reson7k3_checkheader(s7k3_header header) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_header(int verbose, s7k3_header *header, int *error) {
   char *function_name = "mbsys_reson7k3_print_header";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -583,6 +584,8 @@ int mbsys_reson7k3_print_header(int verbose, s7k3_header *header, int *error) {
   fprintf(stderr, "%s     FragmentedTotal:         %d\n", first, header->FragmentedTotal);
   fprintf(stderr, "%s     FragmentNumber:          %d\n", first, header->FragmentNumber);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -597,7 +600,6 @@ int mbsys_reson7k3_print_header(int verbose, s7k3_header *header, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_ReferencePoint(int verbose, s7k3_ReferencePoint *ReferencePoint, int *error) {
   char *function_name = "mbsys_reson7k3_print_ReferencePoint";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -625,6 +627,8 @@ int mbsys_reson7k3_print_ReferencePoint(int verbose, s7k3_ReferencePoint *Refere
   fprintf(stderr, "%s     offset_z:                %f\n", first, ReferencePoint->offset_z);
   fprintf(stderr, "%s     water_z:                 %f\n", first, ReferencePoint->water_z);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -639,7 +643,6 @@ int mbsys_reson7k3_print_ReferencePoint(int verbose, s7k3_ReferencePoint *Refere
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_UncalibratedSensorOffset(int verbose, s7k3_UncalibratedSensorOffset *UncalibratedSensorOffset, int *error) {
   char *function_name = "mbsys_reson7k3_print_UncalibratedSensorOffset";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -669,6 +672,8 @@ int mbsys_reson7k3_print_UncalibratedSensorOffset(int verbose, s7k3_Uncalibrated
   fprintf(stderr, "%s     offset_pitch:            %f\n", first, UncalibratedSensorOffset->offset_pitch);
   fprintf(stderr, "%s     offset_yaw:              %f\n", first, UncalibratedSensorOffset->offset_yaw);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -683,7 +688,6 @@ int mbsys_reson7k3_print_UncalibratedSensorOffset(int verbose, s7k3_Uncalibrated
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_CalibratedSensorOffset(int verbose, s7k3_CalibratedSensorOffset *CalibratedSensorOffset, int *error) {
   char *function_name = "mbsys_reson7k3_print_CalibratedSensorOffset";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -712,6 +716,8 @@ int mbsys_reson7k3_print_CalibratedSensorOffset(int verbose, s7k3_CalibratedSens
   fprintf(stderr, "%s     offset_pitch:            %f\n", first, CalibratedSensorOffset->offset_pitch);
   fprintf(stderr, "%s     offset_yaw:              %f\n", first, CalibratedSensorOffset->offset_yaw);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -726,7 +732,6 @@ int mbsys_reson7k3_print_CalibratedSensorOffset(int verbose, s7k3_CalibratedSens
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Position(int verbose, s7k3_Position *Position, int *error) {
   char *function_name = "mbsys_reson7k3_print_Position";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -760,6 +765,8 @@ int mbsys_reson7k3_print_Position(int verbose, s7k3_Position *Position, int *err
   fprintf(stderr, "%s     method:                  %d\n", first, Position->method);
   fprintf(stderr, "%s     nsat:                  %d\n", first, Position->nsat);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -774,7 +781,6 @@ int mbsys_reson7k3_print_Position(int verbose, s7k3_Position *Position, int *err
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_CustomAttitude(int verbose, s7k3_CustomAttitude *CustomAttitude, int *error) {
   char *function_name = "mbsys_reson7k3_print_CustomAttitude";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -810,6 +816,8 @@ int mbsys_reson7k3_print_CustomAttitude(int verbose, s7k3_CustomAttitude *Custom
             CustomAttitude->pitchrate[i], CustomAttitude->rollrate[i], CustomAttitude->headingrate[i],
             CustomAttitude->heaverate[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -824,7 +832,6 @@ int mbsys_reson7k3_print_CustomAttitude(int verbose, s7k3_CustomAttitude *Custom
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Tide(int verbose, s7k3_Tide *Tide, int *error) {
   char *function_name = "mbsys_reson7k3_print_Tide";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -859,6 +866,8 @@ int mbsys_reson7k3_print_Tide(int verbose, s7k3_Tide *Tide, int *error) {
   fprintf(stderr, "%s     type:                       %d\n", first, Tide->type);
   fprintf(stderr, "%s     utm_zone:                   %d\n", first, Tide->utm_zone);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -873,7 +882,6 @@ int mbsys_reson7k3_print_Tide(int verbose, s7k3_Tide *Tide, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Altitude(int verbose, s7k3_Altitude *Altitude, int *error) {
   char *function_name = "mbsys_reson7k3_print_Altitude";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -898,6 +906,8 @@ int mbsys_reson7k3_print_Altitude(int verbose, s7k3_Altitude *Altitude, int *err
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     Altitude:                   %f\n", first, Altitude->altitude);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -912,7 +922,6 @@ int mbsys_reson7k3_print_Altitude(int verbose, s7k3_Altitude *Altitude, int *err
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_MotionOverGround(int verbose, s7k3_MotionOverGround *MotionOverGround, int *error) {
   char *function_name = "mbsys_reson7k3_print_MotionOverGround";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -944,6 +953,8 @@ int mbsys_reson7k3_print_MotionOverGround(int verbose, s7k3_MotionOverGround *Mo
     fprintf(stderr, "%s     i:%d x:%f y:%f z:%f xa:%f ya:%f za:%f\n", first, i, MotionOverGround->x[i], MotionOverGround->y[i], MotionOverGround->z[i],
             MotionOverGround->xa[i], MotionOverGround->ya[i], MotionOverGround->za[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -957,7 +968,6 @@ int mbsys_reson7k3_print_MotionOverGround(int verbose, s7k3_MotionOverGround *Mo
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Depth(int verbose, s7k3_Depth *Depth, int *error) {
   char *function_name = "mbsys_reson7k3_print_Depth";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -985,6 +995,8 @@ int mbsys_reson7k3_print_Depth(int verbose, s7k3_Depth *Depth, int *error) {
   fprintf(stderr, "%s     reserved:                    %d\n", first, Depth->reserved);
   fprintf(stderr, "%s     depth:                       %f\n", first, Depth->depth);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -999,7 +1011,6 @@ int mbsys_reson7k3_print_Depth(int verbose, s7k3_Depth *Depth, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_SoundVelocityProfile(int verbose, s7k3_SoundVelocityProfile *SoundVelocityProfile, int *error) {
   char *function_name = "mbsys_reson7k3_print_SoundVelocityProfile";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1032,6 +1043,8 @@ int mbsys_reson7k3_print_SoundVelocityProfile(int verbose, s7k3_SoundVelocityPro
   for (int i = 0; i < SoundVelocityProfile->n; i++)
     fprintf(stderr, "%s     i:%d depth:%f sound_velocity:%f\n", first, i, SoundVelocityProfile->depth[i], SoundVelocityProfile->sound_velocity[i]);
 
+  int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1046,7 +1059,6 @@ int mbsys_reson7k3_print_SoundVelocityProfile(int verbose, s7k3_SoundVelocityPro
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_CTD(int verbose, s7k3_CTD *CTD, int *error) {
   char *function_name = "mbsys_reson7k3_print_CTD";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1087,6 +1099,8 @@ int mbsys_reson7k3_print_CTD(int verbose, s7k3_CTD *CTD, int *error) {
             first, i, CTD->conductivity_salinity[i], CTD->temperature[i], CTD->pressure_depth[i], CTD->sound_velocity[i],
             CTD->absorption[i]);
 
+  int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1101,7 +1115,6 @@ int mbsys_reson7k3_print_CTD(int verbose, s7k3_CTD *CTD, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Geodesy(int verbose, s7k3_Geodesy *Geodesy, int *error) {
   char *function_name = "mbsys_reson7k3_print_Geodesy";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1150,6 +1163,8 @@ int mbsys_reson7k3_print_Geodesy(int verbose, s7k3_Geodesy *Geodesy, int *error)
   fprintf(stderr, "%s     custom_identifier:          %d\n", first, Geodesy->custom_identifier);
   fprintf(stderr, "%s     reserved3:                  %s\n", first, Geodesy->reserved3);
 
+  int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1164,7 +1179,6 @@ int mbsys_reson7k3_print_Geodesy(int verbose, s7k3_Geodesy *Geodesy, int *error)
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_RollPitchHeave(int verbose, s7k3_RollPitchHeave *RollPitchHeave, int *error) {
   char *function_name = "mbsys_reson7k3_print_RollPitchHeave";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1191,6 +1205,8 @@ int mbsys_reson7k3_print_RollPitchHeave(int verbose, s7k3_RollPitchHeave *RollPi
   fprintf(stderr, "%s     pitch:                      %f\n", first, RollPitchHeave->pitch);
   fprintf(stderr, "%s     heave:                      %f\n", first, RollPitchHeave->heave);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1205,7 +1221,6 @@ int mbsys_reson7k3_print_RollPitchHeave(int verbose, s7k3_RollPitchHeave *RollPi
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Heading(int verbose, s7k3_Heading *Heading, int *error) {
   char *function_name = "mbsys_reson7k3_print_Heading";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1230,6 +1245,8 @@ int mbsys_reson7k3_print_Heading(int verbose, s7k3_Heading *Heading, int *error)
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     Heading:                    %f\n", first, Heading->heading);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1244,7 +1261,6 @@ int mbsys_reson7k3_print_Heading(int verbose, s7k3_Heading *Heading, int *error)
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_SurveyLine(int verbose, s7k3_SurveyLine *SurveyLine, int *error) {
   char *function_name = "mbsys_reson7k3_print_SurveyLine";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1275,6 +1291,8 @@ int mbsys_reson7k3_print_SurveyLine(int verbose, s7k3_SurveyLine *SurveyLine, in
   for (int i = 0; i < SurveyLine->n; i++)
     fprintf(stderr, "%s     i:%d latitude_northing:%f longitude_easting:%f\n", first, i, SurveyLine->latitude_northing[i], SurveyLine->longitude_easting[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1289,7 +1307,6 @@ int mbsys_reson7k3_print_SurveyLine(int verbose, s7k3_SurveyLine *SurveyLine, in
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Navigation(int verbose, s7k3_Navigation *Navigation, int *error) {
   char *function_name = "mbsys_reson7k3_print_Navigation";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1322,6 +1339,8 @@ int mbsys_reson7k3_print_Navigation(int verbose, s7k3_Navigation *Navigation, in
   fprintf(stderr, "%s     course:                     %f\n", first, Navigation->course);
   fprintf(stderr, "%s     heading:                    %f\n", first, Navigation->heading);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1336,7 +1355,6 @@ int mbsys_reson7k3_print_Navigation(int verbose, s7k3_Navigation *Navigation, in
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Attitude(int verbose, s7k3_Attitude *Attitude, int *error) {
   char *function_name = "mbsys_reson7k3_print_Attitude";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1365,6 +1383,8 @@ int mbsys_reson7k3_print_Attitude(int verbose, s7k3_Attitude *Attitude, int *err
     fprintf(stderr, "%s     i:%d delta_time:%d roll:%f pitch:%f heading:%f heave:%f\n", first, i, Attitude->delta_time[i],
             Attitude->roll[i], Attitude->pitch[i], Attitude->heave[i], Attitude->heading[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1379,7 +1399,6 @@ int mbsys_reson7k3_print_Attitude(int verbose, s7k3_Attitude *Attitude, int *err
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_PanTilt(int verbose, s7k3_PanTilt *PanTilt, int *error) {
   char *function_name = "mbsys_reson7k3_print_PanTilt";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1405,6 +1424,8 @@ int mbsys_reson7k3_print_PanTilt(int verbose, s7k3_PanTilt *PanTilt, int *error)
   fprintf(stderr, "%s     pan:                    %f\n", first, PanTilt->pan);
   fprintf(stderr, "%s     tilt:                   %f\n", first, PanTilt->tilt);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1419,7 +1440,7 @@ int mbsys_reson7k3_print_PanTilt(int verbose, s7k3_PanTilt *PanTilt, int *error)
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_SonarInstallationIDs(int verbose, s7k3_SonarInstallationIDs *SonarInstallationIDs, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   // Notdone
   return (status);
 }
@@ -1427,7 +1448,7 @@ int mbsys_reson7k3_print_SonarInstallationIDs(int verbose, s7k3_SonarInstallatio
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_Mystery(int verbose, s7k3_Mystery *Mystery, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   // Notdone
   return (status);
 }
@@ -1435,7 +1456,7 @@ int mbsys_reson7k3_print_Mystery(int verbose, s7k3_Mystery *Mystery, int *error)
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_SonarPipeEnvironment(int verbose, s7k3_SonarPipeEnvironment *SonarPipeEnvironment, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   // Notdone
   return (status);
 }
@@ -1443,7 +1464,7 @@ int mbsys_reson7k3_print_SonarPipeEnvironment(int verbose, s7k3_SonarPipeEnviron
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_ContactOutput(int verbose, s7k3_ContactOutput *ContactOutput, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   // Notdone
   return (status);
 }
@@ -1451,7 +1472,6 @@ int mbsys_reson7k3_print_ContactOutput(int verbose, s7k3_ContactOutput *ContactO
 
 int mbsys_reson7k3_print_ProcessedSideScan(int verbose, s7k3_ProcessedSideScan *ProcessedSideScan, int *error) {
   char *function_name = "mbsys_reson7k3_print_ProcessedSideScan";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1487,6 +1507,8 @@ int mbsys_reson7k3_print_ProcessedSideScan(int verbose, s7k3_ProcessedSideScan *
     fprintf(stderr, "%s     pixel[%d]:  sidescan:%f alongtrack:%f\n", first, i, ProcessedSideScan->sidescan[i],
             ProcessedSideScan->alongtrack[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1502,7 +1524,6 @@ int mbsys_reson7k3_print_ProcessedSideScan(int verbose, s7k3_ProcessedSideScan *
 
 int mbsys_reson7k3_print_SonarSettings(int verbose, s7k3_SonarSettings *SonarSettings, int *error) {
   char *function_name = "mbsys_reson7k3_print_SonarSettings";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1565,6 +1586,8 @@ int mbsys_reson7k3_print_SonarSettings(int verbose, s7k3_SonarSettings *SonarSet
   fprintf(stderr, "%s     spreading:                  %f\n", first, SonarSettings->spreading);
   fprintf(stderr, "%s     reserved:                   %d\n", first, SonarSettings->reserved);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1579,7 +1602,6 @@ int mbsys_reson7k3_print_SonarSettings(int verbose, s7k3_SonarSettings *SonarSet
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_device(int verbose, s7k3_device *device, int *error) {
   char *function_name = "mbsys_reson7k3_print_device";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1606,6 +1628,8 @@ int mbsys_reson7k3_print_device(int verbose, s7k3_device *device, int *error) {
   fprintf(stderr, "%s     info_alloc:                 %d\n", first, device->info_alloc);
   fprintf(stderr, "%s     info:                       %s\n", first, device->info);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1620,7 +1644,6 @@ int mbsys_reson7k3_print_device(int verbose, s7k3_device *device, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Configuration(int verbose, s7k3_Configuration *Configuration, int *error) {
   char *function_name = "mbsys_reson7k3_print_Configuration";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1648,6 +1671,8 @@ int mbsys_reson7k3_print_Configuration(int verbose, s7k3_Configuration *Configur
   for (int i = 0; i < Configuration->number_devices; i++)
     mbsys_reson7k3_print_device(verbose, &Configuration->device[i], error);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1662,7 +1687,6 @@ int mbsys_reson7k3_print_Configuration(int verbose, s7k3_Configuration *Configur
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_MatchFilter(int verbose, s7k3_MatchFilter *MatchFilter, int *error) {
   char *function_name = "mbsys_reson7k3_print_MatchFilter";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1697,6 +1721,8 @@ int mbsys_reson7k3_print_MatchFilter(int verbose, s7k3_MatchFilter *MatchFilter,
     fprintf(stderr, "%s     reserved[%d]:                %u\n", first, i, MatchFilter->reserved[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1713,7 +1739,6 @@ int mbsys_reson7k3_print_FirmwareHardwareConfiguration(int verbose,
                                                         s7k3_FirmwareHardwareConfiguration *FirmwareHardwareConfiguration,
                                                         int *error) {
   char *function_name = "mbsys_reson7k3_print_FirmwareHardwareConfiguration";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1741,6 +1766,8 @@ int mbsys_reson7k3_print_FirmwareHardwareConfiguration(int verbose,
   fprintf(stderr, "%s     info:                       \n", first);
   fprintf(stderr, "%s\n%s\n", FirmwareHardwareConfiguration->info, first);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1755,7 +1782,6 @@ int mbsys_reson7k3_print_FirmwareHardwareConfiguration(int verbose,
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_BeamGeometry(int verbose, s7k3_BeamGeometry *BeamGeometry, int *error) {
   char *function_name = "mbsys_reson7k3_print_BeamGeometry";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1786,6 +1812,8 @@ int mbsys_reson7k3_print_BeamGeometry(int verbose, s7k3_BeamGeometry *BeamGeomet
             first, i, BeamGeometry->angle_alongtrack[i], BeamGeometry->angle_acrosstrack[i],
             BeamGeometry->beamwidth_alongtrack[i], BeamGeometry->beamwidth_acrosstrack[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1800,7 +1828,6 @@ int mbsys_reson7k3_print_BeamGeometry(int verbose, s7k3_BeamGeometry *BeamGeomet
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Bathymetry(int verbose, s7k3_Bathymetry *Bathymetry, int *error) {
   char *function_name = "mbsys_reson7k3_print_Bathymetry";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1850,6 +1877,8 @@ int mbsys_reson7k3_print_Bathymetry(int verbose, s7k3_Bathymetry *Bathymetry, in
             Bathymetry->alongtrack[i], Bathymetry->acrosstrack[i], Bathymetry->pointing_angle[i],
             Bathymetry->azimuth_angle[i]);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1864,7 +1893,6 @@ int mbsys_reson7k3_print_Bathymetry(int verbose, s7k3_Bathymetry *Bathymetry, in
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_SideScan(int verbose, s7k3_SideScan *SideScan, int *error) {
   char *function_name = "mbsys_reson7k3_print_SideScan";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1937,6 +1965,8 @@ int mbsys_reson7k3_print_SideScan(int verbose, s7k3_SideScan *SideScan, int *err
   fprintf(stderr, "%s     altitude:                   %f\n", first, SideScan->altitude);
   fprintf(stderr, "%s     depth:                      %f\n", first, SideScan->depth);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -1951,7 +1981,7 @@ int mbsys_reson7k3_print_SideScan(int verbose, s7k3_SideScan *SideScan, int *err
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_WaterColumn(int verbose, s7k3_WaterColumn *WaterColumn, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   // Notdone
   return (status);
 }
@@ -1959,7 +1989,6 @@ int mbsys_reson7k3_print_WaterColumn(int verbose, s7k3_WaterColumn *WaterColumn,
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_VerticalDepth(int verbose, s7k3_VerticalDepth *VerticalDepth, int *error) {
   char *function_name = "mbsys_reson7k3_print_VerticalDepth";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -1992,6 +2021,8 @@ int mbsys_reson7k3_print_VerticalDepth(int verbose, s7k3_VerticalDepth *Vertical
   fprintf(stderr, "%s     acrosstrack:                %f\n", first, VerticalDepth->acrosstrack);
   fprintf(stderr, "%s     vertical_depth:             %f\n", first, VerticalDepth->vertical_depth);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2006,7 +2037,6 @@ int mbsys_reson7k3_print_VerticalDepth(int verbose, s7k3_VerticalDepth *Vertical
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_TVG(int verbose, s7k3_TVG *TVG, int *error) {
   char *function_name = "mbsys_reson7k3_print_TVG";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2041,6 +2071,8 @@ int mbsys_reson7k3_print_TVG(int verbose, s7k3_TVG *TVG, int *error) {
     fprintf(stderr, "%s     TVG[%d]:  %f\n", first, i, tvg_float[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2055,7 +2087,6 @@ int mbsys_reson7k3_print_TVG(int verbose, s7k3_TVG *TVG, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Image(int verbose, s7k3_Image *Image, int *error) {
   char *function_name = "mbsys_reson7k3_print_Image";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2111,6 +2142,8 @@ int mbsys_reson7k3_print_Image(int verbose, s7k3_Image *Image, int *error) {
       fprintf(stderr, "%s     Image[%d]:  %u\n", first, i, intptr[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2125,7 +2158,6 @@ int mbsys_reson7k3_print_Image(int verbose, s7k3_Image *Image, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_PingMotion(int verbose, s7k3_PingMotion *PingMotion, int *error) {
   char *function_name = "mbsys_reson7k3_print_PingMotion";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2164,6 +2196,8 @@ int mbsys_reson7k3_print_PingMotion(int verbose, s7k3_PingMotion *PingMotion, in
             PingMotion->heave[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2178,7 +2212,7 @@ int mbsys_reson7k3_print_PingMotion(int verbose, s7k3_PingMotion *PingMotion, in
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_AdaptiveGate(int verbose, s7k3_AdaptiveGate *AdaptiveGate, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   // Notdone
   return (status);
 }
@@ -2186,7 +2220,6 @@ int mbsys_reson7k3_print_AdaptiveGate(int verbose, s7k3_AdaptiveGate *AdaptiveGa
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_DetectionDataSetup(int verbose, s7k3_DetectionDataSetup *DetectionDataSetup, int *error) {
   char *function_name = "mbsys_reson7k3_print_DetectionDataSetup";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2238,6 +2271,8 @@ int mbsys_reson7k3_print_DetectionDataSetup(int verbose, s7k3_DetectionDataSetup
             DetectionDataSetup->user_limits_max_sample[i], DetectionDataSetup->quality[i], DetectionDataSetup->uncertainty[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2252,7 +2287,6 @@ int mbsys_reson7k3_print_DetectionDataSetup(int verbose, s7k3_DetectionDataSetup
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Beamformed(int verbose, s7k3_Beamformed *Beamformed, int *error) {
   char *function_name = "mbsys_reson7k3_print_Beamformed";
-  int status = MB_SUCCESS;
   s7k3_amplitudephase *amplitudephase;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
@@ -2296,6 +2330,8 @@ int mbsys_reson7k3_print_Beamformed(int verbose, s7k3_Beamformed *Beamformed, in
     }
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2310,7 +2346,7 @@ int mbsys_reson7k3_print_Beamformed(int verbose, s7k3_Beamformed *Beamformed, in
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_VernierProcessingDataRaw(int verbose, s7k3_VernierProcessingDataRaw *VernierProcessingDataRaw, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   // Notdone
   return (status);
 }
@@ -2318,7 +2354,6 @@ int mbsys_reson7k3_print_VernierProcessingDataRaw(int verbose, s7k3_VernierProce
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_BITE(int verbose, s7k3_BITE *BITE, int *error) {
   char *function_name = "mbsys_reson7k3_print_BITE";
-  int status = MB_SUCCESS;
   s7k3_bitereport *bitereport;
   s7k3_bitefield *bitefield;
   s7k3_time *s7kTime;
@@ -2380,6 +2415,8 @@ int mbsys_reson7k3_print_BITE(int verbose, s7k3_BITE *BITE, int *error) {
     }
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2394,7 +2431,6 @@ int mbsys_reson7k3_print_BITE(int verbose, s7k3_BITE *BITE, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_SonarSourceVersion(int verbose, s7k3_SonarSourceVersion *SonarSourceVersion, int *error) {
   char *function_name = "mbsys_reson7k3_print_SonarSourceVersion";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2419,6 +2455,8 @@ int mbsys_reson7k3_print_SonarSourceVersion(int verbose, s7k3_SonarSourceVersion
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     version:                    %s\n", first, SonarSourceVersion->version);
 
+  int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2433,7 +2471,6 @@ int mbsys_reson7k3_print_SonarSourceVersion(int verbose, s7k3_SonarSourceVersion
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_WetEndVersion8k(int verbose, s7k3_WetEndVersion8k *WetEndVersion8k, int *error) {
   char *function_name = "mbsys_reson7k3_print_WetEndVersion8k";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2458,6 +2495,8 @@ int mbsys_reson7k3_print_WetEndVersion8k(int verbose, s7k3_WetEndVersion8k *WetE
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     version:                    %s\n", first, WetEndVersion8k->version);
 
+  int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2472,7 +2511,6 @@ int mbsys_reson7k3_print_WetEndVersion8k(int verbose, s7k3_WetEndVersion8k *WetE
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_RawDetection(int verbose, s7k3_RawDetection *RawDetection, int *error) {
   char *function_name = "mbsys_reson7k3_print_RawDetection";
-  int status = MB_SUCCESS;
   s7k3_rawdetectiondata *rawdetectiondata;
   s7k3_bathydata *bathydata;
   char *debug_str = "dbg2  ";
@@ -2543,6 +2581,8 @@ int mbsys_reson7k3_print_RawDetection(int verbose, s7k3_RawDetection *RawDetecti
     }
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2557,7 +2597,6 @@ int mbsys_reson7k3_print_RawDetection(int verbose, s7k3_RawDetection *RawDetecti
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Snippet(int verbose, s7k3_Snippet *Snippet, int *error) {
   char *function_name = "mbsys_reson7k3_print_Snippet";
-  int status = MB_SUCCESS;
   s7k3_snippetdata *snippetdata;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
@@ -2628,6 +2667,8 @@ int mbsys_reson7k3_print_Snippet(int verbose, s7k3_Snippet *Snippet, int *error)
     }
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2642,7 +2683,7 @@ int mbsys_reson7k3_print_Snippet(int verbose, s7k3_Snippet *Snippet, int *error)
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_VernierProcessingDataFiltered(int verbose, s7k3_VernierProcessingDataFiltered *VernierProcessingDataFiltered, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   // Notdone
   return (status);
 }
@@ -2650,7 +2691,6 @@ int mbsys_reson7k3_print_VernierProcessingDataFiltered(int verbose, s7k3_Vernier
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_InstallationParameters(int verbose, s7k3_InstallationParameters *InstallationParameters, int *error) {
   char *function_name = "mbsys_reson7k3_print_InstallationParameters";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2707,6 +2747,8 @@ int mbsys_reson7k3_print_InstallationParameters(int verbose, s7k3_InstallationPa
   fprintf(stderr, "%s     Position_time_delay:        %d\n", first, InstallationParameters->position_time_delay);
   fprintf(stderr, "%s     waterline_z:                %f\n", first, InstallationParameters->waterline_z);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2721,14 +2763,14 @@ int mbsys_reson7k3_print_InstallationParameters(int verbose, s7k3_InstallationPa
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_BITESummary(int verbose, s7k3_BITESummary *BITESummary, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_CompressedBeamformedMagnitude(int verbose, s7k3_CompressedBeamformedMagnitude *CompressedBeamformedMagnitude, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
@@ -2736,7 +2778,6 @@ int mbsys_reson7k3_print_CompressedBeamformedMagnitude(int verbose, s7k3_Compres
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_CompressedWaterColumn(int verbose, s7k3_CompressedWaterColumn *CompressedWaterColumn, int *error) {
   char *function_name = "mbsys_reson7k3_print_CompressedWaterColumn";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -2823,6 +2864,8 @@ int mbsys_reson7k3_print_CompressedWaterColumn(int verbose, s7k3_CompressedWater
     }
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2837,7 +2880,6 @@ int mbsys_reson7k3_print_CompressedWaterColumn(int verbose, s7k3_CompressedWater
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_SegmentedRawDetection(int verbose, s7k3_SegmentedRawDetection *SegmentedRawDetection, int *error) {
   char *function_name = "mbsys_reson7k3_print_SegmentedRawDetection";
-  int status = MB_SUCCESS;
   s7k3_rawdetectiondata *rawdetectiondata;
   s7k3_segmentedrawdetectiontxdata *segmentedrawdetectiontxdata;
   s7k3_segmentedrawdetectionrxdata *segmentedrawdetectionrxdata;
@@ -2943,6 +2985,8 @@ int mbsys_reson7k3_print_SegmentedRawDetection(int verbose, s7k3_SegmentedRawDet
     }
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -2956,14 +3000,14 @@ int mbsys_reson7k3_print_SegmentedRawDetection(int verbose, s7k3_SegmentedRawDet
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_CalibratedBeam(int verbose, s7k3_CalibratedBeam *CalibratedBeam, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_SystemEvents(int verbose, s7k3_SystemEvents *SystemEvents, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
@@ -2971,7 +3015,6 @@ int mbsys_reson7k3_print_SystemEvents(int verbose, s7k3_SystemEvents *SystemEven
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_SystemEventMessage(int verbose, s7k3_SystemEventMessage *SystemEventMessage, int *error) {
   char *function_name = "mbsys_reson7k3_print_SystemEventMessage";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3001,6 +3044,8 @@ int mbsys_reson7k3_print_SystemEventMessage(int verbose, s7k3_SystemEventMessage
   fprintf(stderr, "%s     message_alloc:              %d\n", first, SystemEventMessage->message_alloc);
   fprintf(stderr, "%s     message:                    %s\n", first, SystemEventMessage->message);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3015,35 +3060,35 @@ int mbsys_reson7k3_print_SystemEventMessage(int verbose, s7k3_SystemEventMessage
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_RDRRecordingStatus(int verbose, s7k3_RDRRecordingStatus *RDRRecordingStatus, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_Subscriptions(int verbose, s7k3_Subscriptions *Subscriptions, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_RDRStorageRecording(int verbose, s7k3_RDRStorageRecording *RDRStorageRecording, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_CalibrationStatus(int verbose, s7k3_CalibrationStatus *CalibrationStatus, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_CalibratedSideScan(int verbose, s7k3_CalibratedSideScan *CalibratedSideScan, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
@@ -3051,7 +3096,6 @@ int mbsys_reson7k3_print_CalibratedSideScan(int verbose, s7k3_CalibratedSideScan
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_SnippetBackscatteringStrength(int verbose, s7k3_SnippetBackscatteringStrength *s7k3_SnippetBackscatteringStrength, int *error) {
   char *function_name = "mbsys_reson7k3_print_SnippetBackscatteringStrength";
-  int status = MB_SUCCESS;
   s7k3_snippetbackscatteringstrengthdata *snippetbackscatteringstrengthdata;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
@@ -3097,6 +3141,8 @@ int mbsys_reson7k3_print_SnippetBackscatteringStrength(int verbose, s7k3_Snippet
               snippetbackscatteringstrengthdata->footprints[j]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3111,7 +3157,7 @@ int mbsys_reson7k3_print_SnippetBackscatteringStrength(int verbose, s7k3_Snippet
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_MB2Status(int verbose, s7k3_MB2Status *MB2Status, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
@@ -3119,7 +3165,6 @@ int mbsys_reson7k3_print_MB2Status(int verbose, s7k3_MB2Status *MB2Status, int *
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_FileHeader(int verbose, s7k3_FileHeader *FileHeader, int *error) {
   char *function_name = "mbsys_reson7k3_print_FileHeader";
-  int status = MB_SUCCESS;
   s7k3_subsystem *subsystem;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
@@ -3168,6 +3213,8 @@ int mbsys_reson7k3_print_FileHeader(int verbose, s7k3_FileHeader *FileHeader, in
   fprintf(stderr, "%s     file_catalog_size:            %u\n", first, FileHeader->file_catalog_size);
   fprintf(stderr, "%s     file_catalog_offset:          %llu\n", first, FileHeader->file_catalog_offset);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3182,7 +3229,6 @@ int mbsys_reson7k3_print_FileHeader(int verbose, s7k3_FileHeader *FileHeader, in
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_FileCatalog(int verbose, s7k3_FileCatalog *FileCatalog, int *error) {
   char *function_name = "mbsys_reson7k3_print_FileCatalog";
-  int status = MB_SUCCESS;
   s7k3_filecatalogdata *filecatalogdata;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
@@ -3612,6 +3658,8 @@ fprintf(stderr, "nrec_SoundVelocity:                        %7d\n", nrec_SoundVe
 fprintf(stderr, "nrec_AbsorptionLoss:                       %7d\n", nrec_AbsorptionLoss);
 fprintf(stderr, "nrec_SpreadingLoss:                        %7d\n", nrec_SpreadingLoss);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3625,28 +3673,28 @@ fprintf(stderr, "nrec_SpreadingLoss:                        %7d\n", nrec_Spreadi
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_TimeMessage(int verbose, s7k3_TimeMessage *TimeMessage, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_RemoteControl(int verbose, s7k3_RemoteControl *RemoteControl, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_RemoteControlAcknowledge(int verbose, s7k3_RemoteControlAcknowledge *RemoteControlAcknowledge, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_RemoteControlNotAcknowledge(int verbose, s7k3_RemoteControlNotAcknowledge *RemoteControlNotAcknowledge, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
@@ -3654,7 +3702,6 @@ int mbsys_reson7k3_print_RemoteControlNotAcknowledge(int verbose, s7k3_RemoteCon
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_RemoteControlSonarSettings(int verbose, s7k3_RemoteControlSonarSettings *RemoteControlSonarSettings, int *error) {
   char *function_name = "mbsys_reson7k3_print_RemoteControlSonarSettings";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3748,6 +3795,8 @@ int mbsys_reson7k3_print_RemoteControlSonarSettings(int verbose, s7k3_RemoteCont
   fprintf(stderr, "%s     applied_frequency:          %f\n", first, RemoteControlSonarSettings->applied_frequency);
   fprintf(stderr, "%s     element_number:             %d\n", first, RemoteControlSonarSettings->element_number);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3763,7 +3812,6 @@ int mbsys_reson7k3_print_RemoteControlSonarSettings(int verbose, s7k3_RemoteCont
 
 int mbsys_reson7k3_print_CommonSystemSettings(int verbose, s7k3_CommonSystemSettings *CommonSystemSettings, int *error) {
   char *function_name = "mbsys_reson7k3_print_CommonSystemSettings";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3851,6 +3899,8 @@ int mbsys_reson7k3_print_CommonSystemSettings(int verbose, s7k3_CommonSystemSett
     fprintf(stderr, "%s     reserved5[%d]:              %u\n", first, i, CommonSystemSettings->reserved5[i]);
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3865,7 +3915,7 @@ int mbsys_reson7k3_print_CommonSystemSettings(int verbose, s7k3_CommonSystemSett
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_SVFiltering(int verbose, s7k3_SVFiltering *SVFiltering, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
@@ -3873,7 +3923,7 @@ int mbsys_reson7k3_print_SVFiltering(int verbose, s7k3_SVFiltering *SVFiltering,
 /*--------------------------------------------------------------------*/
 
 int mbsys_reson7k3_print_SystemLockStatus(int verbose, s7k3_SystemLockStatus *SystemLockStatus, int *error) {
-  int status = MB_SUCCESS;
+  const int status = MB_SUCCESS;
   //Notdone
   return (status);
 }
@@ -3881,7 +3931,6 @@ int mbsys_reson7k3_print_SystemLockStatus(int verbose, s7k3_SystemLockStatus *Sy
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_SoundVelocity(int verbose, s7k3_SoundVelocity *SoundVelocity, int *error) {
   char *function_name = "mbsys_reson7k3_print_SoundVelocity";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3908,6 +3957,8 @@ int mbsys_reson7k3_print_SoundVelocity(int verbose, s7k3_SoundVelocity *SoundVel
 
   /* Optional data */
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3922,7 +3973,6 @@ int mbsys_reson7k3_print_SoundVelocity(int verbose, s7k3_SoundVelocity *SoundVel
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_AbsorptionLoss(int verbose, s7k3_AbsorptionLoss *AbsorptionLoss, int *error) {
   char *function_name = "mbsys_reson7k3_print_absorptionloss";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3947,6 +3997,8 @@ int mbsys_reson7k3_print_AbsorptionLoss(int verbose, s7k3_AbsorptionLoss *Absorp
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     absorptionloss:             %f\n", first, AbsorptionLoss->absorptionloss);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -3961,7 +4013,6 @@ int mbsys_reson7k3_print_AbsorptionLoss(int verbose, s7k3_AbsorptionLoss *Absorp
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_print_SpreadingLoss(int verbose, s7k3_SpreadingLoss *SpreadingLoss, int *error) {
   char *function_name = "mbsys_reson7k3_print_SpreadingLoss";
-  int status = MB_SUCCESS;
   char *debug_str = "dbg2  ";
   char *nodebug_str = "  ";
   char *first;
@@ -3986,6 +4037,8 @@ int mbsys_reson7k3_print_SpreadingLoss(int verbose, s7k3_SpreadingLoss *Spreadin
   fprintf(stderr, "%sStructure Contents:\n", first);
   fprintf(stderr, "%s     SpreadingLoss:              %f\n", first, SpreadingLoss->spreadingloss);
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4001,7 +4054,6 @@ int mbsys_reson7k3_print_SpreadingLoss(int verbose, s7k3_SpreadingLoss *Spreadin
 int mbsys_reson7k3_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                              int *error) {
   char *function_name = "mbsys_reson7k3_dimensions";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_bathydata *bathydata;
   s7k3_rawdetectiondata *rawdetectiondata;
@@ -4050,6 +4102,8 @@ int mbsys_reson7k3_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int 
     *nss = 0;
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4068,7 +4122,6 @@ int mbsys_reson7k3_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber, int *error) {
   char *function_name = "mbsys_reson7k3_pingnumber";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_bathydata *bathydata;
   s7k3_rawdetectiondata *rawdetectiondata;
@@ -4100,6 +4153,8 @@ int mbsys_reson7k3_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnum
     *pingnumber = SegmentedRawDetection->ping_number;
   }
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4115,7 +4170,6 @@ int mbsys_reson7k3_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnum
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *sonartype, int *error) {
   char *function_name = "mbsys_reson7k3_sonartype";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
 
   if (verbose >= 2) {
@@ -4135,6 +4189,8 @@ int mbsys_reson7k3_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *
   /* get sonar type */
   *sonartype = MB_TOPOGRAPHY_TYPE_MULTIBEAM;
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4150,7 +4206,6 @@ int mbsys_reson7k3_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int *ss_type, int *error) {
   char *function_name = "mbsys_reson7k3_sidescantype";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
 
   if (verbose >= 2) {
@@ -4170,6 +4225,8 @@ int mbsys_reson7k3_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, in
   /* get SideScan type */
   *ss_type = MB_SIDESCAN_LINEAR;
 
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
     fprintf(stderr, "dbg2  Return values:\n");
@@ -4188,7 +4245,6 @@ int mbsys_reson7k3_preprocess(int verbose,     /* in: verbosity level set on com
                              void *store_ptr, /* in: see mbsys_reson7k.h:/^struct mbsys_reson7k3_struct/ */
                              void *platform_ptr, void *preprocess_pars_ptr, int *error) {
   char *function_name = "mbsys_reson7k3_preprocess";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   struct mb_platform_struct *platform;
   struct mb_preprocess_struct *pars;
@@ -4295,8 +4351,6 @@ int mbsys_reson7k3_preprocess(int verbose,     /* in: verbosity level set on com
     fprintf(stderr, "dbg2       preprocess_pars_ptr:        %p\n", (void *)preprocess_pars_ptr);
   }
 
-  /* always successful */
-  status = MB_SUCCESS;
   *error = MB_ERROR_NO_ERROR;
 
   /* check for non-null data */
@@ -4383,6 +4437,8 @@ int mbsys_reson7k3_preprocess(int verbose,     /* in: verbosity level set on com
       }
     }
   }
+
+  int status = MB_SUCCESS;
 
   /* deal with a survey record */
   if (store->kind == MB_DATA_DATA) {
@@ -5314,7 +5370,6 @@ int mbsys_reson7k3_preprocess(int verbose,     /* in: verbosity level set on com
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_extract_platform(int verbose, void *mbio_ptr, void *store_ptr, int *kind, void **platform_ptr, int *error) {
   char *function_name = "mbsys_reson7k3_extract_platform";
-  int status = MB_SUCCESS;
   struct mb_platform_struct *platform;
   struct mbsys_reson7k3_struct *store;
   s7k3_InstallationParameters *InstallationParameters;
@@ -5336,6 +5391,8 @@ int mbsys_reson7k3_extract_platform(int verbose, void *mbio_ptr, void *store_ptr
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
   store = (struct mbsys_reson7k3_struct *)store_ptr;
   InstallationParameters = (s7k3_InstallationParameters *)&store->InstallationParameters;
+
+  int status = MB_SUCCESS;
 
   /* if needed allocate a new platform structure */
   if (*platform_ptr == NULL) {
@@ -5489,7 +5546,6 @@ int mbsys_reson7k3_extract(int verbose, void *mbio_ptr, void *store_ptr, int *ki
                           double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                           double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
   char *function_name = "mbsys_reson7k3_extract";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SonarSettings *SonarSettings = NULL;
@@ -5591,6 +5647,8 @@ if (store->kind == MB_DATA_DATA) {
     fprintf(stderr, "  read_RemoteControlSonarSettings\n");
 }
 #endif
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_DATA) {
@@ -5981,7 +6039,6 @@ int mbsys_reson7k3_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind
                          double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                          double *ssalongtrack, char *comment, int *error) {
   char *function_name = "mbsys_reson7k3_insert";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store = NULL;
   s7k3_SonarSettings *SonarSettings = NULL;
   s7k3_BeamGeometry *BeamGeometry = NULL;
@@ -6058,6 +6115,8 @@ int mbsys_reson7k3_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind
 
   /* set data kind */
   store->kind = kind;
+
+  int status = MB_SUCCESS;
 
   /* insert data in structure */
   if (store->kind == MB_DATA_DATA) {
@@ -6293,7 +6352,6 @@ int mbsys_reson7k3_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kin
                          double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                          double *ssv, int *error) {
   char *function_name = "mbsys_reson7k3_ttimes";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_SonarSettings *SonarSettings;
   s7k3_BeamGeometry *BeamGeometry;
@@ -6331,6 +6389,8 @@ int mbsys_reson7k3_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_DATA) {
@@ -6437,7 +6497,6 @@ int mbsys_reson7k3_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
   char *function_name = "mbsys_reson7k3_detects";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_RawDetection *RawDetection;
   s7k3_rawdetectiondata *rawdetectiondata;
@@ -6467,6 +6526,8 @@ int mbsys_reson7k3_detects(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_DATA) {
@@ -6554,7 +6615,6 @@ int mbsys_reson7k3_detects(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 int mbsys_reson7k3_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                         double *receive_gain, int *error) {
   char *function_name = "mbsys_reson7k3_gains";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_RawDetection *RawDetection;
   s7k3_rawdetectiondata *rawdetectiondata;
@@ -6582,6 +6642,8 @@ int mbsys_reson7k3_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_DATA) {
@@ -6646,7 +6708,6 @@ int mbsys_reson7k3_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr
                                     int *kind, double *transducer_depth,
                                     double *altitudev, int *error) {
   char *function_name = "mbsys_reson7k3_extract_altitude";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_header *header;
   s7k3_Navigation *Navigation;
@@ -6691,6 +6752,8 @@ int mbsys_reson7k3_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_DATA) {
@@ -6805,7 +6868,6 @@ int mbsys_reson7k3_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int
                               double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                               double *pitch, double *heave, int *error) {
   char *function_name = "mbsys_reson7k3_extract_nav";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_header *header;
   s7k3_Position *Position;
@@ -6855,6 +6917,8 @@ int mbsys_reson7k3_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from ping structure */
   if (*kind == MB_DATA_DATA) {
@@ -7234,7 +7298,6 @@ int mbsys_reson7k3_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr,
                                 double *speed, double *heading, double *draft,
                                 double *roll, double *pitch, double *heave, int *error) {
   char *function_name = "mbsys_reson7k3_extract_nnav";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_CustomAttitude *CustomAttitude;
   s7k3_Attitude *Attitude;
@@ -7253,6 +7316,8 @@ int mbsys_reson7k3_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr,
 
   /* get data structure pointer */
   store = (struct mbsys_reson7k3_struct *)store_ptr;
+
+  int status = MB_SUCCESS;
 
   /* extract data from Attitude structure (record 1016) */
   if (store->kind == MB_DATA_ATTITUDE) {
@@ -7370,7 +7435,6 @@ int mbsys_reson7k3_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
                              double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                              int *error) {
   char *function_name = "mbsys_reson7k3_insert_nav";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_SonarSettings *SonarSettings;
   s7k3_BeamGeometry *BeamGeometry;
@@ -7417,6 +7481,8 @@ int mbsys_reson7k3_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
   RawDetection = (s7k3_RawDetection *)&store->RawDetection;
   Position = (s7k3_Position *)&store->Position;
   Navigation = (s7k3_Navigation *)&store->Navigation;
+
+  int status = MB_SUCCESS;
 
   /* insert data in ping structure */
   if (store->kind == MB_DATA_DATA) {
@@ -7498,7 +7564,6 @@ int mbsys_reson7k3_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 int mbsys_reson7k3_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                               int *error) {
   char *function_name = "mbsys_reson7k3_extract_svp";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_SoundVelocityProfile *SoundVelocityProfile;
 
@@ -7519,6 +7584,8 @@ int mbsys_reson7k3_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int
 
   /* get data kind */
   *kind = store->kind;
+
+  int status = MB_SUCCESS;
 
   /* extract data from structure */
   if (*kind == MB_DATA_VELOCITY_PROFILE) {
@@ -7566,7 +7633,6 @@ int mbsys_reson7k3_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int
 int mbsys_reson7k3_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity,
                              int *error) {
   char *function_name = "mbsys_reson7k3_insert_svp";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   s7k3_SoundVelocityProfile *SoundVelocityProfile;
 
@@ -7587,6 +7653,8 @@ int mbsys_reson7k3_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
   /* get data structure pointer */
   store = (struct mbsys_reson7k3_struct *)store_ptr;
   SoundVelocityProfile = (s7k3_SoundVelocityProfile *)&(store->SoundVelocityProfile);
+
+  int status = MB_SUCCESS;
 
   /* insert data in structure */
   if (store->kind == MB_DATA_VELOCITY_PROFILE) {
@@ -7630,7 +7698,6 @@ int mbsys_reson7k3_ctd(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
   struct mbsys_reson7k3_struct *store;
   s7k3_header *header;
   s7k3_CTD *CTD;
-  int status = MB_SUCCESS;
   int time_j[5];
   int time_i[7];
 
@@ -7700,6 +7767,9 @@ int mbsys_reson7k3_ctd(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
       fprintf(stderr, "dbg2       soundspeed:    %f\n", soundspeed[i]);
     }
   }
+
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "dbg2       error:      %d\n", *error);
     fprintf(stderr, "dbg2  Return status:\n");
@@ -7715,7 +7785,6 @@ int mbsys_reson7k3_ancilliarysensor(int verbose, void *mbio_ptr, void *store_ptr
   char *function_name = "mbsys_reson7k3_ancilliarysensor";
   struct mbsys_reson7k3_struct *store;
   s7k3_header *header;
-  int status = MB_SUCCESS;
 
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -7756,6 +7825,9 @@ int mbsys_reson7k3_ancilliarysensor(int verbose, void *mbio_ptr, void *store_ptr
       fprintf(stderr, "dbg2       sensor8:       %f\n", sensor8[i]);
     }
   }
+
+  const int status = MB_SUCCESS;
+
   if (verbose >= 2) {
     fprintf(stderr, "dbg2       error:      %d\n", *error);
     fprintf(stderr, "dbg2  Return status:\n");
@@ -7767,7 +7839,6 @@ int mbsys_reson7k3_ancilliarysensor(int verbose, void *mbio_ptr, void *store_ptr
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
   char *function_name = "mbsys_reson7k3_copy";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store;
   struct mbsys_reson7k3_struct *copy;
   int nalloc;
@@ -7845,6 +7916,9 @@ int mbsys_reson7k3_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy
   copy->CustomAttitude.reserved = store->CustomAttitude.reserved;
   copy->CustomAttitude.n = store->CustomAttitude.n;
   copy->CustomAttitude.frequency = store->CustomAttitude.frequency;
+
+  int status = MB_SUCCESS;
+
   if (status == MB_SUCCESS && (copy->CustomAttitude.nalloc < copy->CustomAttitude.n * sizeof(float))) {
     copy->CustomAttitude.nalloc = copy->CustomAttitude.n * sizeof(float);
     if (status == MB_SUCCESS)
@@ -8426,7 +8500,6 @@ int mbsys_reson7k3_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy
 int mbsys_reson7k3_makess(int verbose, void *mbio_ptr, void *store_ptr, int source, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error) {
   char *function_name = "mbsys_reson7k3_makess";
-  int status = MB_SUCCESS;
   struct mbsys_reson7k3_struct *store = NULL;
   s7k3_SonarSettings *SonarSettings = NULL;
   s7k3_BeamGeometry *BeamGeometry = NULL;
@@ -9219,6 +9292,8 @@ int mbsys_reson7k3_makess(int verbose, void *mbio_ptr, void *store_ptr, int sour
                 ssacrosstrack[i], ssalongtrack[i]);
     }
   }
+
+  const int status = MB_SUCCESS;
 
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_reson8k.c
+++ b/src/mbio/mbsys_reson8k.c
@@ -40,7 +40,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_reson8k_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_reson8k_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 
 	if (verbose >= 2) {
@@ -54,7 +53,7 @@ int mbsys_reson8k_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_reson8k_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_reson8k_struct), store_ptr, error);
 
 	/* get data structure pointer */
 	store = (struct mbsys_reson8k_struct *)*store_ptr;
@@ -218,7 +217,6 @@ int mbsys_reson8k_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbsys_reson8k_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_reson8k_deall";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -229,7 +227,7 @@ int mbsys_reson8k_deall(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -245,7 +243,6 @@ int mbsys_reson8k_deall(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 int mbsys_reson8k_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                              int *error) {
 	char *function_name = "mbsys_reson8k_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 
 	if (verbose >= 2) {
@@ -280,6 +277,8 @@ int mbsys_reson8k_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -300,7 +299,6 @@ int mbsys_reson8k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
                           double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                           double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_reson8k_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 
 	if (verbose >= 2) {
@@ -481,6 +479,9 @@ int mbsys_reson8k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 			fprintf(stderr, "dbg2       beam:%d   amp:%f  acrosstrack:%f  alongtrack:%f\n", i, amp[i], bathacrosstrack[i],
 			        bathalongtrack[i]);
 	}
+
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -495,7 +496,6 @@ int mbsys_reson8k_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
                          double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                          double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_reson8k_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 
 	if (verbose >= 2) {
@@ -601,6 +601,8 @@ int mbsys_reson8k_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
 		strncpy(store->comment, comment, 199);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -616,7 +618,6 @@ int mbsys_reson8k_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
                          double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                          double *ssv, int *error) {
 	char *function_name = "mbsys_reson8k_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 	double ttscale, angscale;
 	double heave_use;
@@ -645,6 +646,8 @@ int mbsys_reson8k_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -715,7 +718,6 @@ int mbsys_reson8k_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 /*--------------------------------------------------------------------*/
 int mbsys_reson8k_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_reson8k_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 	int detect;
 
@@ -736,6 +738,8 @@ int mbsys_reson8k_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -803,7 +807,6 @@ int mbsys_reson8k_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 int mbsys_reson8k_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                    double *altitude, int *error) {
 	char *function_name = "mbsys_reson8k_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 	double bath_best;
 	double xtrack_min;
@@ -824,6 +827,8 @@ int mbsys_reson8k_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -890,7 +895,6 @@ int mbsys_reson8k_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
                               double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                               double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_reson8k_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 
 	if (verbose >= 2) {
@@ -909,6 +913,8 @@ int mbsys_reson8k_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1060,7 +1066,6 @@ int mbsys_reson8k_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
                              double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                              int *error) {
 	char *function_name = "mbsys_reson8k_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 
 	if (verbose >= 2) {
@@ -1135,6 +1140,8 @@ int mbsys_reson8k_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
 		store->MBOffsetZ = draft;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1149,7 +1156,6 @@ int mbsys_reson8k_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
 int mbsys_reson8k_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                               int *error) {
 	char *function_name = "mbsys_reson8k_extract_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 
 	if (verbose >= 2) {
@@ -1168,6 +1174,8 @@ int mbsys_reson8k_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_VELOCITY_PROFILE) {
@@ -1215,7 +1223,6 @@ int mbsys_reson8k_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
 int mbsys_reson8k_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity,
                              int *error) {
 	char *function_name = "mbsys_reson8k_insert_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 
 	if (verbose >= 2) {
@@ -1247,6 +1254,8 @@ int mbsys_reson8k_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
 		}
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1260,7 +1269,6 @@ int mbsys_reson8k_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
 /*--------------------------------------------------------------------*/
 int mbsys_reson8k_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_reson8k_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 	struct mbsys_reson8k_struct *copy;
 
@@ -1283,6 +1291,8 @@ int mbsys_reson8k_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_
 	/* copy the data */
 	*copy = *store;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -1297,7 +1307,6 @@ int mbsys_reson8k_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_
 int mbsys_reson8k_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int *error) {
 	char *function_name = "mbsys_reson8k_makess";
-	int status = MB_SUCCESS;
 	struct mbsys_reson8k_struct *store;
 	double ss[MBSYS_RESON8K_MAXPIXELS];
 	int ss_cnt[MBSYS_RESON8K_MAXPIXELS];
@@ -1507,6 +1516,8 @@ int mbsys_reson8k_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel
 				        store->ss_acrosstrack[i], store->ss_alongtrack[i]);
 		}
 	}
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_sb.c
+++ b/src/mbio/mbsys_sb.c
@@ -44,7 +44,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_sb_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_sb_alloc";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -57,7 +56,7 @@ int mbsys_sb_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_sb_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_sb_struct), store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -73,7 +72,6 @@ int mbsys_sb_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_sb_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_sb_deall";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -84,7 +82,7 @@ int mbsys_sb_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -99,7 +97,6 @@ int mbsys_sb_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_sb_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss, int *error) {
 	char *function_name = "mbsys_sb_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_sb_struct *store;
 
 	if (verbose >= 2) {
@@ -133,6 +130,8 @@ int mbsys_sb_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -153,7 +152,6 @@ int mbsys_sb_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
                      double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                      double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_sb_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_sb_struct *store;
 	int time_j[5];
 	int id;
@@ -291,6 +289,9 @@ int mbsys_sb_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
 		for (int i = 0; i < *nbath; i++)
 			fprintf(stderr, "dbg2       beam:%2d  flag:%3d  bath:%f  bathdist:%f\n", i, beamflag[i], bath[i], bathacrosstrack[i]);
 	}
+
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -305,7 +306,6 @@ int mbsys_sb_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int 
                     double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                     double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_sb_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_sb_struct *store;
 	int time_j[5];
 	int id;
@@ -426,6 +426,8 @@ int mbsys_sb_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int 
 		fprintf(stderr, "dbg2       comment:     \ndbg2       %s\n", store->comment);
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -441,7 +443,6 @@ int mbsys_sb_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int
                     double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                     double *ssv, int *error) {
 	char *function_name = "mbsys_sb_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_sb_struct *store;
 
 	if (verbose >= 2) {
@@ -466,6 +467,8 @@ int mbsys_sb_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -531,7 +534,6 @@ int mbsys_sb_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int
 /*--------------------------------------------------------------------*/
 int mbsys_sb_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_sb_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_sb_struct *store;
 
 	if (verbose >= 2) {
@@ -551,6 +553,8 @@ int mbsys_sb_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -605,7 +609,6 @@ int mbsys_sb_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
 int mbsys_sb_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth, double *altitude,
                               int *error) {
 	char *function_name = "mbsys_sb_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_sb_struct *store;
 	double bath_best;
 	double xtrack_min;
@@ -626,6 +629,8 @@ int mbsys_sb_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -692,7 +697,6 @@ int mbsys_sb_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kind
                          double *navlat, double *speed, double *heading, double *draft, double *roll, double *pitch,
                          double *heave, int *error) {
 	char *function_name = "mbsys_sb_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_sb_struct *store;
 	int time_j[5];
 
@@ -712,6 +716,8 @@ int mbsys_sb_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -818,7 +824,6 @@ int mbsys_sb_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 int mbsys_sb_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_i[7], double time_d, double navlon, double navlat,
                         double speed, double heading, double draft, double roll, double pitch, double heave, int *error) {
 	char *function_name = "mbsys_sb_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_sb_struct *store;
 	int time_j[5];
 
@@ -878,6 +883,8 @@ int mbsys_sb_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_i
 		/* get roll pitch and heave */
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -891,7 +898,6 @@ int mbsys_sb_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_i
 /*--------------------------------------------------------------------*/
 int mbsys_sb_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_sb_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_sb_struct *store;
 	struct mbsys_sb_struct *copy;
 
@@ -913,6 +919,8 @@ int mbsys_sb_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, 
 
 	/* copy the data */
 	*copy = *store;
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_sb2000.c
+++ b/src/mbio/mbsys_sb2000.c
@@ -39,7 +39,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_sb2000_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_sb2000_alloc";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -52,7 +51,7 @@ int mbsys_sb2000_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_sb2000_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_sb2000_struct), store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -68,7 +67,6 @@ int mbsys_sb2000_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbsys_sb2000_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_sb2000_deall";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -79,7 +77,7 @@ int mbsys_sb2000_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -95,7 +93,6 @@ int mbsys_sb2000_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error
 int mbsys_sb2000_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                             int *error) {
 	char *function_name = "mbsys_sb2000_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2000_struct *store;
 
 	if (verbose >= 2) {
@@ -129,6 +126,8 @@ int mbsys_sb2000_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -149,7 +148,6 @@ int mbsys_sb2000_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
                          double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                          double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_sb2000_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2000_struct *store;
 	unsigned short *short_ptr;
 	int time_j[5];
@@ -310,6 +308,9 @@ int mbsys_sb2000_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 		for (int i = 0; i < *nbath; i++)
 			fprintf(stderr, "dbg2       beam:%4d  flag:%3d  bath:%f  bathdist:%f\n", i, beamflag[i], bath[i], bathacrosstrack[i]);
 	}
+
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -324,7 +325,6 @@ int mbsys_sb2000_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
                         double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                         double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_sb2000_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2000_struct *store;
 	int time_j[5];
 	unsigned short *short_ptr;
@@ -459,6 +459,8 @@ int mbsys_sb2000_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
 		strcpy(store->comment, comment);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -474,7 +476,6 @@ int mbsys_sb2000_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
                         double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                         double *ssv, int *error) {
 	char *function_name = "mbsys_sb2000_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2000_struct *store;
 
 	if (verbose >= 2) {
@@ -499,6 +500,8 @@ int mbsys_sb2000_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -564,7 +567,6 @@ int mbsys_sb2000_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 /*--------------------------------------------------------------------*/
 int mbsys_sb2000_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_sb2000_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2000_struct *store;
 
 	if (verbose >= 2) {
@@ -584,6 +586,8 @@ int mbsys_sb2000_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -638,7 +642,6 @@ int mbsys_sb2000_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 int mbsys_sb2000_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                   double *altitude, int *error) {
 	char *function_name = "mbsys_sb2000_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2000_struct *store;
 	double bath_best;
 	double xtrack_min;
@@ -659,6 +662,8 @@ int mbsys_sb2000_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -725,7 +730,6 @@ int mbsys_sb2000_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
                              double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                              double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_sb2000_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2000_struct *store;
 	int time_j[5];
 
@@ -745,6 +749,8 @@ int mbsys_sb2000_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -853,7 +859,6 @@ int mbsys_sb2000_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
                             double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                             int *error) {
 	char *function_name = "mbsys_sb2000_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2000_struct *store;
 	int time_j[5];
 
@@ -915,6 +920,8 @@ int mbsys_sb2000_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
 		store->pitch = pitch * 100.0;
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -928,7 +935,6 @@ int mbsys_sb2000_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
 /*--------------------------------------------------------------------*/
 int mbsys_sb2000_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_sb2000_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2000_struct *store;
 	struct mbsys_sb2000_struct *copy;
 
@@ -950,6 +956,8 @@ int mbsys_sb2000_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_p
 
 	/* copy the data */
 	*copy = *store;
+
+	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_sb2100.c
+++ b/src/mbio/mbsys_sb2100.c
@@ -39,7 +39,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_sb2100_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_sb2100_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 
 	if (verbose >= 2) {
@@ -53,7 +52,7 @@ int mbsys_sb2100_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_sb2100_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_sb2100_struct), store_ptr, error);
 
 	/* get store structure pointer */
 	store = (struct mbsys_sb2100_struct *)*store_ptr;
@@ -75,7 +74,6 @@ int mbsys_sb2100_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbsys_sb2100_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_sb2100_deall";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -86,7 +84,7 @@ int mbsys_sb2100_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -102,7 +100,6 @@ int mbsys_sb2100_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error
 int mbsys_sb2100_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                             int *error) {
 	char *function_name = "mbsys_sb2100_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 
 	if (verbose >= 2) {
@@ -136,6 +133,8 @@ int mbsys_sb2100_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -156,7 +155,6 @@ int mbsys_sb2100_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
                          double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                          double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_sb2100_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 	int time_j[5];
 	double gain_db;
@@ -326,6 +324,9 @@ int mbsys_sb2100_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 			fprintf(stderr, "dbg2        pixel:%d   ss:%f  acrosstrack:%f  alongtrack:%f\n", i, ss[i], ssacrosstrack[i],
 			        ssalongtrack[i]);
 	}
+
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -340,7 +341,6 @@ int mbsys_sb2100_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
                         double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                         double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_sb2100_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 	int time_j[5];
 	int set_pixel_size;
@@ -473,6 +473,8 @@ int mbsys_sb2100_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
 		strcpy(store->comment, comment);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -488,7 +490,6 @@ int mbsys_sb2100_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
                         double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                         double *ssv, int *error) {
 	char *function_name = "mbsys_sb2100_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 
 	if (verbose >= 2) {
@@ -513,6 +514,8 @@ int mbsys_sb2100_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -581,7 +584,6 @@ int mbsys_sb2100_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 /*--------------------------------------------------------------------*/
 int mbsys_sb2100_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_sb2100_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 
 	if (verbose >= 2) {
@@ -601,6 +603,8 @@ int mbsys_sb2100_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -660,7 +664,6 @@ int mbsys_sb2100_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 int mbsys_sb2100_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                        double *receive_gain, int *error) {
 	char *function_name = "mbsys_sb2100_gains";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 
 	if (verbose >= 2) {
@@ -679,6 +682,8 @@ int mbsys_sb2100_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -734,7 +739,6 @@ int mbsys_sb2100_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 int mbsys_sb2100_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                   double *altitude, int *error) {
 	char *function_name = "mbsys_sb2100_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 	double bath_best;
 	double xtrack_min;
@@ -755,6 +759,8 @@ int mbsys_sb2100_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -821,7 +827,6 @@ int mbsys_sb2100_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
                              double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                              double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_sb2100_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 	int time_j[5];
 
@@ -841,6 +846,8 @@ int mbsys_sb2100_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -948,7 +955,6 @@ int mbsys_sb2100_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
                             double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                             int *error) {
 	char *function_name = "mbsys_sb2100_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 	int time_j[5];
 
@@ -1014,6 +1020,8 @@ int mbsys_sb2100_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
 		store->heave = -heave;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1028,7 +1036,6 @@ int mbsys_sb2100_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
 int mbsys_sb2100_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                              int *error) {
 	char *function_name = "mbsys_sb2100_extract_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 
 	if (verbose >= 2) {
@@ -1047,6 +1054,8 @@ int mbsys_sb2100_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_VELOCITY_PROFILE) {
@@ -1093,7 +1102,6 @@ int mbsys_sb2100_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbsys_sb2100_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error) {
 	char *function_name = "mbsys_sb2100_insert_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 
 	if (verbose >= 2) {
@@ -1125,6 +1133,8 @@ int mbsys_sb2100_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int ns
 		}
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1138,7 +1148,6 @@ int mbsys_sb2100_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int ns
 /*--------------------------------------------------------------------*/
 int mbsys_sb2100_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_sb2100_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_sb2100_struct *store;
 	struct mbsys_sb2100_struct *copy;
 
@@ -1163,6 +1172,8 @@ int mbsys_sb2100_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_p
 
 	/* reset the comment pointer */
 	copy->comment = (char *)&(copy->roll_bias_port);
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_simrad.c
+++ b/src/mbio/mbsys_simrad.c
@@ -49,7 +49,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_simrad_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_simrad_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 
 	if (verbose >= 2) {
@@ -63,7 +62,7 @@ int mbsys_simrad_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_simrad_struct), (void **)store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_simrad_struct), (void **)store_ptr, error);
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad_struct *)*store_ptr;
@@ -166,7 +165,6 @@ int mbsys_simrad_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbsys_simrad_survey_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad_survey_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 
@@ -183,6 +181,8 @@ int mbsys_simrad_survey_alloc(int verbose, void *mbio_ptr, void *store_ptr, int 
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->ping == NULL)
@@ -258,7 +258,6 @@ int mbsys_simrad_survey_alloc(int verbose, void *mbio_ptr, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbsys_simrad_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_simrad_deall";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 
 	if (verbose >= 2) {
@@ -271,6 +270,8 @@ int mbsys_simrad_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad_struct *)*store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* deallocate memory for survey data structure */
 	if (store->ping != NULL)
@@ -293,7 +294,6 @@ int mbsys_simrad_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error
 int mbsys_simrad_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                             int *error) {
 	char *function_name = "mbsys_simrad_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 
@@ -329,6 +329,8 @@ int mbsys_simrad_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		*nss = 0;
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -349,7 +351,6 @@ int mbsys_simrad_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
                          double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                          double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_simrad_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 	double ss_spacing;
@@ -372,6 +373,8 @@ int mbsys_simrad_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -664,7 +667,6 @@ int mbsys_simrad_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
                         double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                         double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_simrad_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 	double depthscale, dacrscale, daloscale, ttscale, reflscale;
@@ -720,6 +722,8 @@ int mbsys_simrad_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
 
 	/* set data kind */
 	store->kind = kind;
+
+	int status = MB_SUCCESS;
 
 	/* insert data in structure */
 	if (store->kind == MB_DATA_DATA) {
@@ -891,7 +895,6 @@ int mbsys_simrad_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
                         double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                         double *ssv, int *error) {
 	char *function_name = "mbsys_simrad_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 	double ttscale;
@@ -923,6 +926,8 @@ int mbsys_simrad_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1160,7 +1165,6 @@ int mbsys_simrad_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 /*--------------------------------------------------------------------*/
 int mbsys_simrad_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_simrad_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 
@@ -1181,6 +1185,8 @@ int mbsys_simrad_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1239,7 +1245,6 @@ int mbsys_simrad_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 /*--------------------------------------------------------------------*/
 int mbsys_simrad_pulses(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *pulses, int *error) {
 	char *function_name = "mbsys_simrad_pulses";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 
@@ -1260,6 +1265,8 @@ int mbsys_simrad_pulses(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1314,7 +1321,6 @@ int mbsys_simrad_pulses(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 int mbsys_simrad_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                        double *receive_gain, int *error) {
 	char *function_name = "mbsys_simrad_gains";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 
@@ -1334,6 +1340,8 @@ int mbsys_simrad_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1392,7 +1400,6 @@ int mbsys_simrad_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 int mbsys_simrad_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                   double *altitude, int *error) {
 	char *function_name = "mbsys_simrad_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 	double depthscale, dacrscale;
@@ -1415,6 +1422,8 @@ int mbsys_simrad_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1524,7 +1533,6 @@ int mbsys_simrad_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
                              double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                              double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_simrad_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 
@@ -1544,6 +1552,8 @@ int mbsys_simrad_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1727,7 +1737,6 @@ int mbsys_simrad_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
                             double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                             int *error) {
 	char *function_name = "mbsys_simrad_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 
@@ -1836,6 +1845,8 @@ int mbsys_simrad_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
 			store->em1000_td = draft;
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -1850,7 +1861,6 @@ int mbsys_simrad_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int ti
 int mbsys_simrad_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                              int *error) {
 	char *function_name = "mbsys_simrad_extract_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 
 	if (verbose >= 2) {
@@ -1869,6 +1879,8 @@ int mbsys_simrad_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_VELOCITY_PROFILE) {
@@ -1915,7 +1927,6 @@ int mbsys_simrad_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbsys_simrad_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error) {
 	char *function_name = "mbsys_simrad_insert_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 
 	if (verbose >= 2) {
@@ -1947,6 +1958,8 @@ int mbsys_simrad_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int ns
 		}
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -1960,7 +1973,6 @@ int mbsys_simrad_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int ns
 /*--------------------------------------------------------------------*/
 int mbsys_simrad_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_simrad_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_struct *copy;
 	struct mbsys_simrad_survey_struct *ping_store;
@@ -1982,6 +1994,8 @@ int mbsys_simrad_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_p
 	/* get data structure pointers */
 	store = (struct mbsys_simrad_struct *)store_ptr;
 	copy = (struct mbsys_simrad_struct *)copy_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* check if survey data needs to be copied */
 	if (store->kind == MB_DATA_DATA && store->ping != NULL) {
@@ -2024,7 +2038,6 @@ int mbsys_simrad_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_p
 int mbsys_simrad_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size, int swath_width_set,
                         double *swath_width, int pixel_int, int *error) {
 	char *function_name = "mbsys_simrad_makess";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad_struct *store;
 	struct mbsys_simrad_survey_struct *ping;
 	double ss[MBSYS_SIMRAD_MAXPIXELS];
@@ -2444,6 +2457,8 @@ int mbsys_simrad_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_
 				fprintf(stderr, "dbg2       pixel:%4d  ss:%8d  ltrack:%8d\n", i, ping->ss[i], ping->ssalongtrack[i]);
 		}
 	}
+
+	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_simrad2.c
+++ b/src/mbio/mbsys_simrad2.c
@@ -45,7 +45,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 
 	if (verbose >= 2) {
@@ -59,7 +58,7 @@ int mbsys_simrad2_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_simrad2_struct), (void **)store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_simrad2_struct), (void **)store_ptr, error);
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad2_struct *)*store_ptr;
@@ -355,7 +354,6 @@ int mbsys_simrad2_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_survey_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_survey_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 
@@ -372,6 +370,8 @@ int mbsys_simrad2_survey_alloc(int verbose, void *mbio_ptr, void *store_ptr, int
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad2_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->ping == NULL)
@@ -1018,7 +1018,6 @@ int mbsys_simrad2_survey_alloc(int verbose, void *mbio_ptr, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_wc_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_wc_survey_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_watercolumn_struct *wc;
 
@@ -1035,6 +1034,8 @@ int mbsys_simrad2_wc_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *er
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad2_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->wc == NULL)
@@ -1098,7 +1099,6 @@ int mbsys_simrad2_wc_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_extraparameters_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_extraparameters_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 
 	if (verbose >= 2) {
@@ -1114,6 +1114,8 @@ int mbsys_simrad2_extraparameters_alloc(int verbose, void *mbio_ptr, void *store
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad2_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->extraparameters == NULL) {
@@ -1137,7 +1139,6 @@ int mbsys_simrad2_extraparameters_alloc(int verbose, void *mbio_ptr, void *store
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_attitude_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_attitude_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_attitude_struct *attitude;
 
@@ -1154,6 +1155,8 @@ int mbsys_simrad2_attitude_alloc(int verbose, void *mbio_ptr, void *store_ptr, i
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad2_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->attitude == NULL)
@@ -1209,7 +1212,6 @@ int mbsys_simrad2_attitude_alloc(int verbose, void *mbio_ptr, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_heading_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_heading_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_heading_struct *heading;
 
@@ -1226,6 +1228,8 @@ int mbsys_simrad2_heading_alloc(int verbose, void *mbio_ptr, void *store_ptr, in
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad2_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->heading == NULL)
@@ -1273,7 +1277,6 @@ int mbsys_simrad2_heading_alloc(int verbose, void *mbio_ptr, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_ssv_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_ssv_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ssv_struct *ssv;
 
@@ -1290,6 +1293,8 @@ int mbsys_simrad2_ssv_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *e
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad2_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->ssv == NULL)
@@ -1334,7 +1339,6 @@ int mbsys_simrad2_ssv_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *e
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_tilt_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_tilt_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_tilt_struct *tilt;
 
@@ -1351,6 +1355,8 @@ int mbsys_simrad2_tilt_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad2_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->tilt == NULL)
@@ -1396,7 +1402,6 @@ int mbsys_simrad2_tilt_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_deall";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_extraparameters_struct *extraparameters;
 
@@ -1410,6 +1415,8 @@ int mbsys_simrad2_deall(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad2_struct *)*store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* deallocate memory for survey data structure */
 	if (store->ping != NULL)
@@ -1463,7 +1470,6 @@ int mbsys_simrad2_deall(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_zero_ss(int verbose, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_zero_ss";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 
@@ -1543,7 +1549,7 @@ int mbsys_simrad2_zero_ss(int verbose, void *store_ptr, int *error) {
 	}
 
 	/* assume success */
-	status = MB_SUCCESS;
+	const int status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 
 	if (verbose >= 2) {
@@ -1560,7 +1566,6 @@ int mbsys_simrad2_zero_ss(int verbose, void *store_ptr, int *error) {
 int mbsys_simrad2_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                              int *error) {
 	char *function_name = "mbsys_simrad2_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 
@@ -1604,6 +1609,8 @@ int mbsys_simrad2_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -1621,7 +1628,6 @@ int mbsys_simrad2_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber, int *error) {
 	char *function_name = "mbsys_simrad2_pingnumber";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 
@@ -1642,6 +1648,8 @@ int mbsys_simrad2_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumb
 	ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 	*pingnumber = ping->png_count;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -1656,7 +1664,6 @@ int mbsys_simrad2_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumb
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *sonartype, int *error) {
 	char *function_name = "mbsys_simrad2_sonartype";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 
 	if (verbose >= 2) {
@@ -1676,6 +1683,8 @@ int mbsys_simrad2_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *s
 	/* get sonar type */
 	*sonartype = MB_TOPOGRAPHY_TYPE_MULTIBEAM;
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -1690,7 +1699,6 @@ int mbsys_simrad2_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *s
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int *ss_type, int *error) {
 	char *function_name = "mbsys_simrad2_sidescantype";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 
 	if (verbose >= 2) {
@@ -1710,6 +1718,8 @@ int mbsys_simrad2_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int
 	/* get sidescan type */
 	*ss_type = MB_SIDESCAN_LOGARITHMIC;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -1727,7 +1737,6 @@ int mbsys_simrad2_preprocess(int verbose,     /* in: verbosity level set on comm
                              void *store_ptr, /* in: see mbsys_reson7k.h:/^struct mbsys_reson7k_struct/ */
                              void *platform_ptr, void *preprocess_pars_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_preprocess";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store = NULL;
 	struct mbsys_simrad2_ping_struct *ping = NULL;
 	struct mb_platform_struct *platform = NULL;
@@ -1905,6 +1914,8 @@ int mbsys_simrad2_preprocess(int verbose,     /* in: verbosity level set on comm
 		ss_status = mbsys_simrad2_makess(verbose, mbio_ptr, store_ptr, MB_NO, pixel_size, MB_NO, swath_width, 1, &ss_error);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -1918,7 +1929,6 @@ int mbsys_simrad2_preprocess(int verbose,     /* in: verbosity level set on comm
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_extract_platform(int verbose, void *mbio_ptr, void *store_ptr, int *kind, void **platform_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_extract_platform";
-	int status = MB_SUCCESS;
 	struct mb_platform_struct *platform;
 	struct mbsys_simrad2_struct *store;
 	int sensor_multibeam;
@@ -1954,6 +1964,8 @@ int mbsys_simrad2_extract_platform(int verbose, void *mbio_ptr, void *store_ptr,
 	/* get mbio descriptor */
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 	store = (struct mbsys_simrad2_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* if needed allocate a new platform structure */
 	if (*platform_ptr == NULL) {
@@ -2443,7 +2455,6 @@ int mbsys_simrad2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
                           double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                           double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_simrad2_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 	double depthscale, depthoffset;
@@ -2782,6 +2793,9 @@ int mbsys_simrad2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 			fprintf(stderr, "dbg2        pixel:%d   ss:%f  acrosstrack:%f  alongtrack:%f\n", i, ss[i], ssacrosstrack[i],
 			        ssalongtrack[i]);
 	}
+
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -2796,7 +2810,6 @@ int mbsys_simrad2_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
                          double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                          double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_simrad2_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 	struct mbsys_simrad2_ping_struct *ping2;
@@ -2858,6 +2871,8 @@ int mbsys_simrad2_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
 
 	/* set data kind */
 	store->kind = kind;
+
+	int status = MB_SUCCESS;
 
 	/* insert data in structure */
 	if (store->kind == MB_DATA_DATA) {
@@ -3195,7 +3210,6 @@ int mbsys_simrad2_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
                          double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                          double *ssv, int *error) {
 	char *function_name = "mbsys_simrad2_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 	struct mbsys_simrad2_ping_struct *ping2;
@@ -3224,6 +3238,8 @@ int mbsys_simrad2_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -3376,7 +3392,6 @@ int mbsys_simrad2_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_simrad2_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 	struct mbsys_simrad2_ping_struct *ping2;
@@ -3398,6 +3413,8 @@ int mbsys_simrad2_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -3485,7 +3502,6 @@ int mbsys_simrad2_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_pulses(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *pulses, int *error) {
 	char *function_name = "mbsys_simrad2_pulses";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 	struct mbsys_simrad2_ping_struct *ping2;
@@ -3507,6 +3523,8 @@ int mbsys_simrad2_pulses(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -3586,7 +3604,6 @@ int mbsys_simrad2_pulses(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 int mbsys_simrad2_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                         double *receive_gain, int *error) {
 	char *function_name = "mbsys_simrad2_gains";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_survey_struct *ping;
 
@@ -3606,6 +3623,8 @@ int mbsys_simrad2_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -3664,7 +3683,6 @@ int mbsys_simrad2_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 int mbsys_simrad2_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                    double *altitude, int *error) {
 	char *function_name = "mbsys_simrad2_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 	double depthscale, dacrscale;
@@ -3688,6 +3706,8 @@ int mbsys_simrad2_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -3763,7 +3783,6 @@ int mbsys_simrad2_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr, int
                                double *time_d, double *navlon, double *navlat, double *speed, double *heading, double *draft,
                                double *roll, double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_simrad2_extract_nnav";
-	int status = MB_SUCCESS;
 	int interp_error = MB_ERROR_NO_ERROR;
 	struct mbsys_simrad2_struct *store = NULL;
 	struct mbsys_simrad2_ping_struct *ping = NULL;
@@ -3789,6 +3808,8 @@ int mbsys_simrad2_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr, int
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from ping structure */
 	if (*kind == MB_DATA_DATA) {
@@ -3979,7 +4000,6 @@ int mbsys_simrad2_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
                               double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                               double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_simrad2_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store = NULL;
 	struct mbsys_simrad2_ping_struct *ping = NULL;
 
@@ -3999,6 +4019,8 @@ int mbsys_simrad2_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from ping structure */
 	if (*kind == MB_DATA_DATA) {
@@ -4195,7 +4217,6 @@ int mbsys_simrad2_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
                              double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                              int *error) {
 	char *function_name = "mbsys_simrad2_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 
@@ -4228,6 +4249,8 @@ int mbsys_simrad2_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad2_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* insert data in ping structure */
 	if (store->kind == MB_DATA_DATA) {
@@ -4330,7 +4353,6 @@ int mbsys_simrad2_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
 int mbsys_simrad2_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                               int *error) {
 	char *function_name = "mbsys_simrad2_extract_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 
 	if (verbose >= 2) {
@@ -4349,6 +4371,8 @@ int mbsys_simrad2_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_VELOCITY_PROFILE) {
@@ -4396,7 +4420,6 @@ int mbsys_simrad2_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
 int mbsys_simrad2_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity,
                              int *error) {
 	char *function_name = "mbsys_simrad2_insert_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 
 	if (verbose >= 2) {
@@ -4429,6 +4452,8 @@ int mbsys_simrad2_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
 		}
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -4442,7 +4467,6 @@ int mbsys_simrad2_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
 /*--------------------------------------------------------------------*/
 int mbsys_simrad2_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_simrad2_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_struct *copy;
 	struct mbsys_simrad2_ping_struct *ping_store;
@@ -4476,6 +4500,8 @@ int mbsys_simrad2_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_
 	/* get data structure pointers */
 	store = (struct mbsys_simrad2_struct *)store_ptr;
 	copy = (struct mbsys_simrad2_struct *)copy_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* check if survey data needs to be copied */
 	if (store->kind == MB_DATA_DATA && store->ping != NULL) {
@@ -4598,7 +4624,6 @@ int mbsys_simrad2_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_
 int mbsys_simrad2_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error) {
 	char *function_name = "mbsys_simrad2_makess";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad2_struct *store;
 	struct mbsys_simrad2_ping_struct *ping;
 	double ss[MBSYS_SIMRAD2_MAXPIXELS];
@@ -5156,6 +5181,8 @@ int mbsys_simrad2_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel
 				fprintf(stderr, "dbg2       pixel:%4d  ss:%8d  ltrack:%8d\n", i, ping->png_ss[i], ping->png_ssalongtrack[i]);
 		}
 	}
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_simrad3.c
+++ b/src/mbio/mbsys_simrad3.c
@@ -51,7 +51,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_alloc";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -64,7 +63,7 @@ int mbsys_simrad3_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_simrad3_struct), (void **)store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_simrad3_struct), (void **)store_ptr, error);
 
 	/* initialize everything to zero */
 	if (status == MB_SUCCESS)
@@ -85,7 +84,6 @@ int mbsys_simrad3_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_survey_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_survey_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 
 	if (verbose >= 2) {
@@ -101,6 +99,8 @@ int mbsys_simrad3_survey_alloc(int verbose, void *mbio_ptr, void *store_ptr, int
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad3_struct *)store_ptr;
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -116,7 +116,6 @@ int mbsys_simrad3_survey_alloc(int verbose, void *mbio_ptr, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_extraparameters_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_extraparameters_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 
 	if (verbose >= 2) {
@@ -132,6 +131,8 @@ int mbsys_simrad3_extraparameters_alloc(int verbose, void *mbio_ptr, void *store
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad3_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->extraparameters == NULL) {
@@ -155,7 +156,6 @@ int mbsys_simrad3_extraparameters_alloc(int verbose, void *mbio_ptr, void *store
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_wc_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_wc_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_watercolumn_struct *wc;
 
@@ -172,6 +172,8 @@ int mbsys_simrad3_wc_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *er
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad3_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->wc == NULL)
@@ -235,7 +237,6 @@ int mbsys_simrad3_wc_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_attitude_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_attitude_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_attitude_struct *attitude;
 
@@ -252,6 +253,8 @@ int mbsys_simrad3_attitude_alloc(int verbose, void *mbio_ptr, void *store_ptr, i
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad3_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->attitude == NULL)
@@ -308,7 +311,6 @@ int mbsys_simrad3_attitude_alloc(int verbose, void *mbio_ptr, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_netattitude_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_netattitude_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_netattitude_struct *netattitude;
 
@@ -325,6 +327,8 @@ int mbsys_simrad3_netattitude_alloc(int verbose, void *mbio_ptr, void *store_ptr
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad3_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->netattitude == NULL)
@@ -381,7 +385,6 @@ int mbsys_simrad3_netattitude_alloc(int verbose, void *mbio_ptr, void *store_ptr
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_heading_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_heading_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_heading_struct *heading;
 
@@ -398,6 +401,8 @@ int mbsys_simrad3_heading_alloc(int verbose, void *mbio_ptr, void *store_ptr, in
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad3_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->heading == NULL)
@@ -445,7 +450,6 @@ int mbsys_simrad3_heading_alloc(int verbose, void *mbio_ptr, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_ssv_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_ssv_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ssv_struct *ssv;
 
@@ -462,6 +466,8 @@ int mbsys_simrad3_ssv_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *e
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad3_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->ssv == NULL)
@@ -506,7 +512,6 @@ int mbsys_simrad3_ssv_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *e
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_tilt_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_tilt_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_tilt_struct *tilt;
 
@@ -523,6 +528,8 @@ int mbsys_simrad3_tilt_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad3_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory for data structure if needed */
 	if (store->tilt == NULL)
@@ -568,7 +575,6 @@ int mbsys_simrad3_tilt_alloc(int verbose, void *mbio_ptr, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_deall";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_extraparameters_struct *extraparameters;
 
@@ -582,6 +588,8 @@ int mbsys_simrad3_deall(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 
 	/* get data structure pointer */
 	store = (struct mbsys_simrad3_struct *)*store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* deallocate memory for extraparameters data structure */
 	if (store->extraparameters != NULL) {
@@ -631,7 +639,6 @@ int mbsys_simrad3_deall(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_zero_ss(int verbose, void *store_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_zero_ss";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 
@@ -722,7 +729,7 @@ int mbsys_simrad3_zero_ss(int verbose, void *store_ptr, int *error) {
 	}
 
 	/* assume success */
-	status = MB_SUCCESS;
+	int status = MB_SUCCESS;
 	*error = MB_ERROR_NO_ERROR;
 
 	if (verbose >= 2) {
@@ -739,7 +746,6 @@ int mbsys_simrad3_zero_ss(int verbose, void *store_ptr, int *error) {
 int mbsys_simrad3_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                              int *error) {
 	char *function_name = "mbsys_simrad3_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 
@@ -775,6 +781,8 @@ int mbsys_simrad3_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *
 		*nss = 0;
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -792,7 +800,6 @@ int mbsys_simrad3_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber, int *error) {
 	char *function_name = "mbsys_simrad3_pingnumber";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 
@@ -813,6 +820,8 @@ int mbsys_simrad3_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumb
 	ping = (struct mbsys_simrad3_ping_struct *)&(store->pings[store->ping_index]);
 	*pingnumber = ping->png_count;
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -827,7 +836,6 @@ int mbsys_simrad3_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumb
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *sonartype, int *error) {
 	char *function_name = "mbsys_simrad3_sonartype";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 
 	if (verbose >= 2) {
@@ -847,6 +855,8 @@ int mbsys_simrad3_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *s
 	/* get sonar type */
 	*sonartype = MB_TOPOGRAPHY_TYPE_MULTIBEAM;
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -861,7 +871,6 @@ int mbsys_simrad3_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *s
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int *ss_type, int *error) {
 	char *function_name = "mbsys_simrad3_sidescantype";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 
 	if (verbose >= 2) {
@@ -881,6 +890,8 @@ int mbsys_simrad3_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int
 	/* get sidescan type */
 	*ss_type = MB_SIDESCAN_LOGARITHMIC;
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -898,7 +909,6 @@ int mbsys_simrad3_preprocess(int verbose,     /* in: verbosity level set on comm
                              void *store_ptr, /* in: see mbsys_reson7k.h:/^struct mbsys_reson7k_struct/ */
                              void *platform_ptr, void *preprocess_pars_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_preprocess";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store = NULL;
 	struct mbsys_simrad3_ping_struct *ping = NULL;
 	struct mb_platform_struct *platform = NULL;
@@ -984,6 +994,8 @@ int mbsys_simrad3_preprocess(int verbose,     /* in: verbosity level set on comm
 		for (int i = 0; i < pars->n_kluge; i++)
 			fprintf(stderr, "dbg2       kluge_id[%d]:                    %d\n", i, pars->kluge_id[i]);
 	}
+
+	int status = MB_SUCCESS;
 
 	/* deal with a survey record */
 	if (store->kind == MB_DATA_DATA) {
@@ -1390,7 +1402,6 @@ int mbsys_simrad3_preprocess(int verbose,     /* in: verbosity level set on comm
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_extract_platform(int verbose, void *mbio_ptr, void *store_ptr, int *kind, void **platform_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_extract_platform";
-	int status = MB_SUCCESS;
 	struct mb_platform_struct *platform;
 	struct mbsys_simrad3_struct *store;
 	int sensor_multibeam;
@@ -1425,6 +1436,8 @@ int mbsys_simrad3_extract_platform(int verbose, void *mbio_ptr, void *store_ptr,
 	/* get mbio descriptor */
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 	store = (struct mbsys_simrad3_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* if needed allocate a new platform structure */
 	if (*platform_ptr == NULL) {
@@ -2076,7 +2089,6 @@ int mbsys_simrad3_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
                           double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                           double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_simrad3_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 	double reflscale;
@@ -2313,6 +2325,9 @@ int mbsys_simrad3_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 			fprintf(stderr, "dbg2        pixel:%d   ss:%f  acrosstrack:%f  alongtrack:%f\n", i, ss[i], ssacrosstrack[i],
 			        ssalongtrack[i]);
 	}
+
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -2327,7 +2342,6 @@ int mbsys_simrad3_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
                          double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                          double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_simrad3_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 	double reflscale;
@@ -2383,6 +2397,8 @@ int mbsys_simrad3_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
 
 	/* set data kind */
 	store->kind = kind;
+
+	int status = MB_SUCCESS;
 
 	/* insert data in structure */
 	if (store->kind == MB_DATA_DATA) {
@@ -2523,7 +2539,6 @@ int mbsys_simrad3_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
                          double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                          double *ssv, int *error) {
 	char *function_name = "mbsys_simrad3_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 	int time_i[7];
@@ -2553,6 +2568,8 @@ int mbsys_simrad3_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -2667,7 +2684,6 @@ int mbsys_simrad3_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_simrad3_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 
@@ -2688,6 +2704,8 @@ int mbsys_simrad3_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -2749,7 +2767,6 @@ int mbsys_simrad3_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_pulses(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *pulses, int *error) {
 	char *function_name = "mbsys_simrad3_pulses";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 
@@ -2770,6 +2787,8 @@ int mbsys_simrad3_pulses(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -2832,7 +2851,6 @@ int mbsys_simrad3_pulses(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 int mbsys_simrad3_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                         double *receive_gain, int *error) {
 	char *function_name = "mbsys_simrad3_gains";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 
@@ -2852,6 +2870,8 @@ int mbsys_simrad3_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -2910,7 +2930,6 @@ int mbsys_simrad3_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 int mbsys_simrad3_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                    double *altitude, int *error) {
 	char *function_name = "mbsys_simrad3_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 	double altitude_best;
@@ -2933,6 +2952,8 @@ int mbsys_simrad3_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -3005,7 +3026,6 @@ int mbsys_simrad3_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr, int
                                double *time_d, double *navlon, double *navlat, double *speed, double *heading, double *draft,
                                double *roll, double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_simrad3_extract_nnav";
-	int status = MB_SUCCESS;
 	int interp_error = MB_ERROR_NO_ERROR;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
@@ -3032,6 +3052,8 @@ int mbsys_simrad3_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr, int
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from ping structure */
 	if (*kind == MB_DATA_DATA) {
@@ -3271,7 +3293,6 @@ int mbsys_simrad3_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
                               double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                               double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_simrad3_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 
@@ -3291,6 +3312,8 @@ int mbsys_simrad3_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from ping structure */
 	if (*kind == MB_DATA_DATA) {
@@ -3442,7 +3465,6 @@ int mbsys_simrad3_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
                              double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                              int *error) {
 	char *function_name = "mbsys_simrad3_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 
@@ -3561,6 +3583,8 @@ int mbsys_simrad3_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
 		}
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -3575,7 +3599,6 @@ int mbsys_simrad3_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
 int mbsys_simrad3_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                               int *error) {
 	char *function_name = "mbsys_simrad3_extract_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 
 	if (verbose >= 2) {
@@ -3594,6 +3617,8 @@ int mbsys_simrad3_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_VELOCITY_PROFILE) {
@@ -3641,7 +3666,6 @@ int mbsys_simrad3_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
 int mbsys_simrad3_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity,
                              int *error) {
 	char *function_name = "mbsys_simrad3_insert_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 
 	if (verbose >= 2) {
@@ -3674,6 +3698,8 @@ int mbsys_simrad3_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
 		}
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -3687,7 +3713,6 @@ int mbsys_simrad3_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
 /*--------------------------------------------------------------------*/
 int mbsys_simrad3_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_simrad3_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_struct *copy;
 	struct mbsys_simrad3_attitude_struct *attitude_store;
@@ -3721,6 +3746,8 @@ int mbsys_simrad3_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_
 	/* get data structure pointers */
 	store = (struct mbsys_simrad3_struct *)store_ptr;
 	copy = (struct mbsys_simrad3_struct *)copy_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* check if attitude data needs to be copied */
 	if (store->attitude != NULL) {
@@ -3839,7 +3866,6 @@ int mbsys_simrad3_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_
 int mbsys_simrad3_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error) {
 	char *function_name = "mbsys_simrad3_makess";
-	int status = MB_SUCCESS;
 	struct mbsys_simrad3_struct *store;
 	struct mbsys_simrad3_ping_struct *ping;
 	double ss[MBSYS_SIMRAD3_MAXPIXELS];
@@ -4087,6 +4113,8 @@ int mbsys_simrad3_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel
 				fprintf(stderr, "dbg2       pixel:%4d  ss:%8d  ltrack:%8d\n", i, ping->png_ss[i], ping->png_ssalongtrack[i]);
 		}
 	}
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_singlebeam.c
+++ b/src/mbio/mbsys_singlebeam.c
@@ -43,7 +43,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_singlebeam_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_singlebeam_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -54,7 +53,7 @@ int mbsys_singlebeam_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *e
 	}
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_singlebeam_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_singlebeam_struct), store_ptr, error);
 
 	/* get data structure pointer */
 	store = (struct mbsys_singlebeam_struct *)*store_ptr;
@@ -129,7 +128,6 @@ int mbsys_singlebeam_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *e
 /*--------------------------------------------------------------------*/
 int mbsys_singlebeam_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_singlebeam_deall";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -140,7 +138,7 @@ int mbsys_singlebeam_deall(int verbose, void *mbio_ptr, void **store_ptr, int *e
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -156,7 +154,6 @@ int mbsys_singlebeam_deall(int verbose, void *mbio_ptr, void **store_ptr, int *e
 int mbsys_singlebeam_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                                 int *error) {
 	char *function_name = "mbsys_singlebeam_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -190,6 +187,8 @@ int mbsys_singlebeam_dimensions(int verbose, void *mbio_ptr, void *store_ptr, in
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -207,7 +206,6 @@ int mbsys_singlebeam_dimensions(int verbose, void *mbio_ptr, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbsys_singlebeam_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber, int *error) {
 	char *function_name = "mbsys_singlebeam_pingnumber";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -226,6 +224,8 @@ int mbsys_singlebeam_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingn
 	/* extract data from structure */
 	*pingnumber = store->seismic_shot;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -240,7 +240,6 @@ int mbsys_singlebeam_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingn
 /*--------------------------------------------------------------------*/
 int mbsys_singlebeam_segynumber(int verbose, void *mbio_ptr, int *line, int *shot, int *cdp, int *error) {
 	char *function_name = "mbsys_singlebeam_segynumber";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -261,6 +260,8 @@ int mbsys_singlebeam_segynumber(int verbose, void *mbio_ptr, int *line, int *sho
 	*shot = store->seismic_shot;
 	*cdp = store->seismic_cdp;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -280,7 +281,6 @@ int mbsys_singlebeam_extract(int verbose, void *mbio_ptr, void *store_ptr, int *
                              char *beamflag, double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack,
                              double *ss, double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_singlebeam_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -398,6 +398,9 @@ int mbsys_singlebeam_extract(int verbose, void *mbio_ptr, void *store_ptr, int *
 		for (int i = 0; i < *nbath; i++)
 			fprintf(stderr, "dbg2       beam:%2d  flag:%3d  bath:%f  bathdist:%f\n", i, beamflag[i], bath[i], bathacrosstrack[i]);
 	}
+
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -412,7 +415,6 @@ int mbsys_singlebeam_insert(int verbose, void *mbio_ptr, void *store_ptr, int ki
                             double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                             double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_singlebeam_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -491,6 +493,8 @@ int mbsys_singlebeam_insert(int verbose, void *mbio_ptr, void *store_ptr, int ki
 		strcpy(store->comment, comment);
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -506,7 +510,6 @@ int mbsys_singlebeam_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *k
                             double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                             double *ssv, int *error) {
 	char *function_name = "mbsys_singlebeam_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -528,6 +531,8 @@ int mbsys_singlebeam_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *k
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -595,7 +600,6 @@ int mbsys_singlebeam_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *k
 /*--------------------------------------------------------------------*/
 int mbsys_singlebeam_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_singlebeam_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -615,6 +619,8 @@ int mbsys_singlebeam_detects(int verbose, void *mbio_ptr, void *store_ptr, int *
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -669,7 +675,6 @@ int mbsys_singlebeam_detects(int verbose, void *mbio_ptr, void *store_ptr, int *
 int mbsys_singlebeam_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                       double *altitude, int *error) {
 	char *function_name = "mbsys_singlebeam_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -685,6 +690,8 @@ int mbsys_singlebeam_extract_altitude(int verbose, void *mbio_ptr, void *store_p
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -752,7 +759,6 @@ int mbsys_singlebeam_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, i
                                  double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                                  double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_singlebeam_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -771,6 +777,8 @@ int mbsys_singlebeam_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, i
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -875,7 +883,6 @@ int mbsys_singlebeam_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, in
                                 double navlat, double speed, double heading, double draft, double roll, double pitch,
                                 double heave, int *error) {
 	char *function_name = "mbsys_singlebeam_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -935,6 +942,8 @@ int mbsys_singlebeam_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, in
 		store->heave = heave;
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -949,7 +958,6 @@ int mbsys_singlebeam_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, in
 int mbsys_singlebeam_swathbounds(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *portlon, double *portlat,
                                  double *stbdlon, double *stbdlat, int *error) {
 	char *function_name = "mbsys_singlebeam_swathbounds";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 
 	if (verbose >= 2) {
@@ -968,6 +976,8 @@ int mbsys_singlebeam_swathbounds(int verbose, void *mbio_ptr, void *store_ptr, i
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1016,7 +1026,6 @@ int mbsys_singlebeam_swathbounds(int verbose, void *mbio_ptr, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbsys_singlebeam_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_singlebeam_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_singlebeam_struct *store;
 	struct mbsys_singlebeam_struct *copy;
 
@@ -1036,6 +1045,8 @@ int mbsys_singlebeam_copy(int verbose, void *mbio_ptr, void *store_ptr, void *co
 	/* copy the data */
 	*copy = *store;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -1049,7 +1060,6 @@ int mbsys_singlebeam_copy(int verbose, void *mbio_ptr, void *store_ptr, void *co
 /*--------------------------------------------------------------------*/
 int mbsys_singlebeam_pressuredepth(int verbose, double pressure, double latitude, double *depth, int *error) {
 	char *function_name = "mbsys_singlebeam_pressuredepth";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -1080,6 +1090,8 @@ int mbsys_singlebeam_pressuredepth(int verbose, double pressure, double latitude
 	}
 	else
 		*depth = 0.0;
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_stereopair.c
+++ b/src/mbio/mbsys_stereopair.c
@@ -37,7 +37,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_stereopair_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_stereopair_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -51,7 +50,7 @@ int mbsys_stereopair_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *e
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_stereopair_struct), (void **)store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_stereopair_struct), (void **)store_ptr, error);
 
 	/* get data structure pointer */
 	store = (struct mbsys_stereopair_struct *)*store_ptr;
@@ -73,7 +72,6 @@ int mbsys_stereopair_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *e
 /*--------------------------------------------------------------------*/
 int mbsys_stereopair_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_stereopair_deall";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -86,6 +84,8 @@ int mbsys_stereopair_deall(int verbose, void *mbio_ptr, void **store_ptr, int *e
 
 	/* get data structure pointer */
 	store = (struct mbsys_stereopair_struct *)*store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* deallocate any arrays or structures contained within the store data structure */
 	if (store->num_soundings_alloc > 0 && store->soundings != NULL)
@@ -109,7 +109,6 @@ int mbsys_stereopair_deall(int verbose, void *mbio_ptr, void **store_ptr, int *e
 int mbsys_stereopair_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                                 int *error) {
 	char *function_name = "mbsys_stereopair_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -143,6 +142,8 @@ int mbsys_stereopair_dimensions(int verbose, void *mbio_ptr, void *store_ptr, in
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -160,7 +161,6 @@ int mbsys_stereopair_dimensions(int verbose, void *mbio_ptr, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbsys_stereopair_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber, int *error) {
 	char *function_name = "mbsys_stereopair_pingnumber";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -179,6 +179,8 @@ int mbsys_stereopair_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingn
 	/* extract data from structure */
 	*pingnumber = 0;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -193,7 +195,6 @@ int mbsys_stereopair_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingn
 /*--------------------------------------------------------------------*/
 int mbsys_stereopair_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *sonartype, int *error) {
 	char *function_name = "mbsys_stereopair_sonartype";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -213,6 +214,8 @@ int mbsys_stereopair_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int
 	/* get sonar type */
 	*sonartype = MB_TOPOGRAPHY_TYPE_CAMERA;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -227,7 +230,6 @@ int mbsys_stereopair_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbsys_stereopair_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int *ss_type, int *error) {
 	char *function_name = "mbsys_stereopair_sidescantype";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -247,6 +249,8 @@ int mbsys_stereopair_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, 
 	/* get sidescan type */
 	*ss_type = MB_SIDESCAN_LINEAR;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -264,7 +268,6 @@ int mbsys_stereopair_extract(int verbose, void *mbio_ptr, void *store_ptr, int *
                              char *beamflag, double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack,
                              double *ss, double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_stereopair_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 	struct mbsys_stereopair_sounding_struct *sounding;
 
@@ -466,6 +469,9 @@ int mbsys_stereopair_extract(int verbose, void *mbio_ptr, void *store_ptr, int *
 			fprintf(stderr, "dbg2        pixel:%d   ss:%f  acrosstrack:%f  alongtrack:%f\n", i, ss[i], ssacrosstrack[i],
 			        ssalongtrack[i]);
 	}
+
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -480,7 +486,6 @@ int mbsys_stereopair_insert(int verbose, void *mbio_ptr, void *store_ptr, int ki
                             double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                             double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_stereopair_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 	struct mbsys_stereopair_sounding_struct *sounding;
 
@@ -537,6 +542,8 @@ int mbsys_stereopair_insert(int verbose, void *mbio_ptr, void *store_ptr, int ki
 
 	/* set data kind */
 	store->kind = kind;
+
+	int status = MB_SUCCESS;
 
 	/* insert data in structure */
 	if (store->kind == MB_DATA_DATA) {
@@ -618,7 +625,6 @@ int mbsys_stereopair_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *k
                             double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                             double *ssv, int *error) {
 	char *function_name = "mbsys_stereopair_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 	struct mbsys_stereopair_sounding_struct *sounding;
 
@@ -644,6 +650,8 @@ int mbsys_stereopair_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *k
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -710,7 +718,6 @@ int mbsys_stereopair_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *k
 /*--------------------------------------------------------------------*/
 int mbsys_stereopair_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_stereopair_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -730,6 +737,8 @@ int mbsys_stereopair_detects(int verbose, void *mbio_ptr, void *store_ptr, int *
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -787,7 +796,6 @@ int mbsys_stereopair_detects(int verbose, void *mbio_ptr, void *store_ptr, int *
 int mbsys_stereopair_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                            double *receive_gain, int *error) {
 	char *function_name = "mbsys_stereopair_gains";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -806,6 +814,8 @@ int mbsys_stereopair_gains(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -861,7 +871,6 @@ int mbsys_stereopair_gains(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 int mbsys_stereopair_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                       double *altitude, int *error) {
 	char *function_name = "mbsys_stereopair_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -880,6 +889,8 @@ int mbsys_stereopair_extract_altitude(int verbose, void *mbio_ptr, void *store_p
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -928,7 +939,6 @@ int mbsys_stereopair_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, i
                                  double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                                  double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_stereopair_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -947,6 +957,8 @@ int mbsys_stereopair_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, i
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from survey record */
 	if (*kind == MB_DATA_DATA) {
@@ -1057,7 +1069,6 @@ int mbsys_stereopair_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr, 
                                   double *time_d, double *navlon, double *navlat, double *speed, double *heading, double *draft,
                                   double *roll, double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_stereopair_extract_nnav";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -1077,6 +1088,8 @@ int mbsys_stereopair_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr, 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from survey record */
 	if (*kind == MB_DATA_DATA) {
@@ -1191,7 +1204,6 @@ int mbsys_stereopair_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, in
                                 double navlat, double speed, double heading, double draft, double roll, double pitch,
                                 double heave, int *error) {
 	char *function_name = "mbsys_stereopair_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 
 	if (verbose >= 2) {
@@ -1270,6 +1282,8 @@ int mbsys_stereopair_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, in
 		store->roll = roll;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1283,7 +1297,6 @@ int mbsys_stereopair_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbsys_stereopair_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_stereopair_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_stereopair_struct *store;
 	struct mbsys_stereopair_struct *copy;
 
@@ -1306,6 +1319,8 @@ int mbsys_stereopair_copy(int verbose, void *mbio_ptr, void *store_ptr, void *co
 	/* copy the data - for many formats memory must be allocated and
 	    sub-structures copied separately */
 	*copy = *store;
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_surf.c
+++ b/src/mbio/mbsys_surf.c
@@ -43,7 +43,6 @@ double mbsys_get_depth(SurfMultiBeamDepth *MultiBeamDepth, SurfTransducerParamet
 /*--------------------------------------------------------------------*/
 int mbsys_surf_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_surf_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 
 	if (verbose >= 2) {
@@ -57,7 +56,7 @@ int mbsys_surf_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_surf_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_surf_struct), store_ptr, error);
 	if (status == MB_SUCCESS) {
 		/* initialize everything */
 		memset(*store_ptr, 0, sizeof(struct mbsys_surf_struct));
@@ -83,7 +82,6 @@ int mbsys_surf_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 /*--------------------------------------------------------------------*/
 int mbsys_surf_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_surf_deall";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -94,7 +92,7 @@ int mbsys_surf_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -109,7 +107,6 @@ int mbsys_surf_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 /*--------------------------------------------------------------------*/
 int mbsys_surf_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss, int *error) {
 	char *function_name = "mbsys_surf_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 
 	if (verbose >= 2) {
@@ -143,6 +140,8 @@ int mbsys_surf_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -163,7 +162,6 @@ int mbsys_surf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
                        double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                        double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_surf_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 	double v0, tlx, tly, tlz, z0, t0, t2, tn, dt, y;
 
@@ -406,6 +404,9 @@ int mbsys_surf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 			fprintf(stderr, "dbg2        pixel:%d   ss:%f  acrosstrack:%f  alongtrack:%f\n", i, ss[i], ssacrosstrack[i],
 			        ssalongtrack[i]);
 	}
+
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -420,7 +421,6 @@ int mbsys_surf_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, in
                       double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                       double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_surf_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 
 	if (verbose >= 2) {
@@ -544,6 +544,8 @@ int mbsys_surf_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, in
 		    MBSYS_SURF_COMMENT_LENGTH);*/
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -559,7 +561,6 @@ int mbsys_surf_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
                       double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                       double *ssv, int *error) {
 	char *function_name = "mbsys_surf_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 	double pitch, angle;
 
@@ -585,6 +586,8 @@ int mbsys_surf_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -678,7 +681,6 @@ int mbsys_surf_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 /*--------------------------------------------------------------------*/
 int mbsys_surf_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_surf_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 
 	if (verbose >= 2) {
@@ -698,6 +700,8 @@ int mbsys_surf_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -801,7 +805,6 @@ heave in MB-System is positive down, which conforms to the cartesian
 int mbsys_surf_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                 double *altitude, int *error) {
 	char *function_name = "mbsys_surf_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 	double bath_best;
 
@@ -821,6 +824,8 @@ int mbsys_surf_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, in
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -875,7 +880,6 @@ int mbsys_surf_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *ki
                            double *navlat, double *speed, double *heading, double *draft, double *roll, double *pitch,
                            double *heave, int *error) {
 	char *function_name = "mbsys_surf_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 
 	if (verbose >= 2) {
@@ -894,6 +898,8 @@ int mbsys_surf_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from ping structure */
 	if (*kind == MB_DATA_DATA) {
@@ -996,7 +1002,6 @@ int mbsys_surf_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time
                           double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                           int *error) {
 	char *function_name = "mbsys_surf_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 
 	if (verbose >= 2) {
@@ -1053,6 +1058,8 @@ int mbsys_surf_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time
 		store->SoundingData.heaveWhileTransmitting = (float)(-heave);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1067,7 +1074,6 @@ int mbsys_surf_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time
 int mbsys_surf_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                            int *error) {
 	char *function_name = "mbsys_surf_extract_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 
 	if (verbose >= 2) {
@@ -1086,6 +1092,8 @@ int mbsys_surf_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA && store->ActualCProfileTable.numberOfActualValues > 0) {
@@ -1132,7 +1140,6 @@ int mbsys_surf_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 /*--------------------------------------------------------------------*/
 int mbsys_surf_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error) {
 	char *function_name = "mbsys_surf_insert_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 	int kind;
 
@@ -1170,6 +1177,8 @@ int mbsys_surf_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp
 		}
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1183,7 +1192,6 @@ int mbsys_surf_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp
 /*--------------------------------------------------------------------*/
 int mbsys_surf_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_surf_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_surf_struct *store;
 	struct mbsys_surf_struct *copy;
 
@@ -1205,6 +1213,8 @@ int mbsys_surf_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr
 
 	/* copy the main structure */
 	*copy = *store;
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_swathplus.c
+++ b/src/mbio/mbsys_swathplus.c
@@ -49,7 +49,6 @@ static double wrap_pi(double theta);
 /*--------------------------------------------------------------------*/
 int mbsys_swathplus_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_swathplus_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 
 	if (verbose >= 2) {
@@ -63,7 +62,7 @@ int mbsys_swathplus_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *er
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_swathplus_struct), (void **)store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_swathplus_struct), (void **)store_ptr, error);
 
 	/* initialize allocated structure to zero */
 	if (status == MB_SUCCESS) {
@@ -121,7 +120,6 @@ int mbsys_swathplus_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbsys_swathplus_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_swathplus_deall";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *sxp_ping;
 	swpls_sxiping *sxi_ping;
@@ -166,7 +164,7 @@ int mbsys_swathplus_deall(int verbose, void *mbio_ptr, void **store_ptr, int *er
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -182,7 +180,6 @@ int mbsys_swathplus_deall(int verbose, void *mbio_ptr, void **store_ptr, int *er
 int mbsys_swathplus_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                                int *error) {
 	char *function_name = "mbsys_swathplus_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *sxp_ping;
 	swpls_sxiping *sxi_ping;
@@ -228,6 +225,8 @@ int mbsys_swathplus_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -245,7 +244,6 @@ int mbsys_swathplus_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbsys_swathplus_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber, int *error) {
 	char *function_name = "mbsys_swathplus_pingnumber";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *sxp_ping;
 	swpls_sxiping *sxi_ping;
@@ -281,6 +279,8 @@ int mbsys_swathplus_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnu
 		*pingnumber = -1;
 	}
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -295,7 +295,6 @@ int mbsys_swathplus_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnu
 /*--------------------------------------------------------------------*/
 int mbsys_swathplus_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *sonartype, int *error) {
 	char *function_name = "mbsys_swathplus_sonartype";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 
 	if (verbose >= 2) {
@@ -315,6 +314,8 @@ int mbsys_swathplus_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int 
 	/* get sonar type */
 	*sonartype = MB_TOPOGRAPHY_TYPE_INTERFEROMETRIC;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -329,7 +330,6 @@ int mbsys_swathplus_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbsys_swathplus_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int *ss_type, int *error) {
 	char *function_name = "mbsys_swathplus_sidescantype";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 
 	if (verbose >= 2) {
@@ -349,6 +349,8 @@ int mbsys_swathplus_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, i
 	/* get sidescan type */
 	*ss_type = MB_SIDESCAN_LOGARITHMIC;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -366,7 +368,6 @@ int mbsys_swathplus_extract(int verbose, void *mbio_ptr, void *store_ptr, int *k
                             char *beamflag, double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack,
                             double *ss, double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_swathplus_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *sxp_ping;
 	swpls_sxiping *sxi_ping;
@@ -393,6 +394,8 @@ int mbsys_swathplus_extract(int verbose, void *mbio_ptr, void *store_ptr, int *k
 	/* get data kind */
 	*kind = store->kind;
 	type = store->type;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if ((*kind == MB_DATA_DATA) && ((type == SWPLS_ID_PROCESSED_PING) || (type == SWPLS_ID_PROCESSED_PING2))) {
@@ -615,7 +618,6 @@ int mbsys_swathplus_insert(int verbose, void *mbio_ptr, void *store_ptr, int kin
                            double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                            double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_swathplus_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_header *header;
 	swpls_sxpping *sxp_ping;
@@ -687,6 +689,8 @@ int mbsys_swathplus_insert(int verbose, void *mbio_ptr, void *store_ptr, int kin
 
 	/* set data kind */
 	store->kind = kind;
+
+	int status = MB_SUCCESS;
 
 	/* insert data in structure */
 	if ((store->kind == MB_DATA_DATA) && (mb_io_ptr->format == MBF_SWPLSSXP)) {
@@ -811,7 +815,6 @@ int mbsys_swathplus_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *ki
                            double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                            double *ssv, int *error) {
 	char *function_name = "mbsys_swathplus_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *sxp_ping;
 	swpls_point *points;
@@ -843,6 +846,8 @@ int mbsys_swathplus_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 	/* get data kind */
 	*kind = store->kind;
 	type = store->type;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if ((*kind == MB_DATA_DATA) && ((type == SWPLS_ID_PROCESSED_PING) || (type == SWPLS_ID_PROCESSED_PING2))) {
@@ -936,7 +941,6 @@ int mbsys_swathplus_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 /*--------------------------------------------------------------------*/
 int mbsys_swathplus_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_swathplus_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *sxp_ping;
 	int type;
@@ -960,6 +964,8 @@ int mbsys_swathplus_detects(int verbose, void *mbio_ptr, void *store_ptr, int *k
 	/* get data kind */
 	*kind = store->kind;
 	type = store->type;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1015,7 +1021,6 @@ int mbsys_swathplus_detects(int verbose, void *mbio_ptr, void *store_ptr, int *k
 int mbsys_swathplus_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                           double *receive_gain, int *error) {
 	char *function_name = "mbsys_swathplus_gains";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *sxp_ping;
 	int type;
@@ -1038,6 +1043,8 @@ int mbsys_swathplus_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 	/* get data kind */
 	*kind = store->kind;
 	type = store->type;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if ((*kind == MB_DATA_DATA) && ((type == SWPLS_ID_PROCESSED_PING) || (type == SWPLS_ID_PROCESSED_PING2))) {
@@ -1091,7 +1098,6 @@ int mbsys_swathplus_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 int mbsys_swathplus_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                      double *altitude, int *error) {
 	char *function_name = "mbsys_swathplus_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *sxp_ping;
 	int n;
@@ -1116,6 +1122,8 @@ int mbsys_swathplus_extract_altitude(int verbose, void *mbio_ptr, void *store_pt
 	/* get data kind */
 	*kind = store->kind;
 	type = store->type;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if ((*kind == MB_DATA_DATA) && ((type == SWPLS_ID_PROCESSED_PING) || (type == SWPLS_ID_PROCESSED_PING2))) {
@@ -1180,7 +1188,6 @@ int mbsys_swathplus_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, in
                                 double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                                 double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_swathplus_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *sxp_ping;
 	int type;
@@ -1203,6 +1210,8 @@ int mbsys_swathplus_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, in
 	/* get data kind */
 	*kind = store->kind;
 	type = store->type;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from survey record */
 	if ((*kind == MB_DATA_DATA) && ((type == SWPLS_ID_PROCESSED_PING) || (type == SWPLS_ID_PROCESSED_PING2))) {
@@ -1299,7 +1308,6 @@ int mbsys_swathplus_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int
                                double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                                int *error) {
 	char *function_name = "mbsys_swathplus_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *sxp_ping;
 	int kind, type;
@@ -1338,6 +1346,8 @@ int mbsys_swathplus_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int
 	/* get data kind */
 	kind = store->kind;
 	type = store->type;
+
+	int status = MB_SUCCESS;
 
 	/* insert data in ping structure */
 	if ((kind == MB_DATA_DATA) && ((type == SWPLS_ID_PROCESSED_PING) || (type == SWPLS_ID_PROCESSED_PING2))) {
@@ -1434,7 +1444,6 @@ int mbsys_swathplus_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbsys_swathplus_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_swathplus_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	struct mbsys_swathplus_struct *copy;
 	size_t points_alloc_save;
@@ -1490,6 +1499,9 @@ int mbsys_swathplus_copy(int verbose, void *mbio_ptr, void *store_ptr, void *cop
 	copy->sxp_ping.points_alloc = points_alloc_save;
 	copy->sxp_ping.points = points_save;
 	copy_len = (size_t)store->sxp_ping.points_alloc * sizeof(swpls_point);
+
+	int status = MB_SUCCESS;
+
 	if ((status == MB_SUCCESS) && (copy->sxp_ping.points_alloc < store->sxp_ping.points_alloc)) {
 		status = mb_reallocd(verbose, __FILE__, __LINE__, copy_len, (void **)&(copy->sxp_ping.points), error);
 		if (status == MB_SUCCESS) {
@@ -1627,7 +1639,6 @@ int mbsys_swathplus_copy(int verbose, void *mbio_ptr, void *store_ptr, void *cop
 /*-------------------------------------------------------------------*/
 int swpls_chk_header(int verbose, void *mbio_ptr, char *buffer, int *recordid, int *size, int *error) {
 	char *function_name = "swpls_chk_header";
-	int status = MB_SUCCESS;
 	int index;
 
 	if (verbose >= 2) {
@@ -1647,6 +1658,8 @@ int swpls_chk_header(int verbose, void *mbio_ptr, char *buffer, int *recordid, i
 	index += 4;
 	mb_get_binary_int(MB_YES, &buffer[index], size);
 	index += 4;
+
+	int status = MB_SUCCESS;
 
 	/* check recordid */
 	if ((*recordid != SWPLS_ID_SXP_HEADER_DATA) && (*recordid != SWPLS_ID_PROCESSED_PING) &&
@@ -1679,7 +1692,6 @@ int swpls_chk_header(int verbose, void *mbio_ptr, char *buffer, int *recordid, i
 /* --------------------------------------------------------------------*/
 int swpls_rd_sxpheader(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_sxpheader";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_header *header;
 	int index;
@@ -1702,6 +1714,8 @@ int swpls_rd_sxpheader(int verbose, char *buffer, void *store_ptr, int *error) {
 	index += 4;
 	mb_get_binary_int(MB_YES, &buffer[index], &(header->fmtver));
 	index += 4;
+
+	int status = MB_SUCCESS;
 
 	/* set kind */
 	if (status == MB_SUCCESS) {
@@ -1727,7 +1741,6 @@ int swpls_rd_sxpheader(int verbose, char *buffer, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int swpls_rd_sxpping(int verbose, char *buffer, void *store_ptr, int pingtype, int *error) {
 	char *function_name = "swpls_rd_sxpping";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *ping;
 	int index;
@@ -1835,6 +1848,8 @@ int swpls_rd_sxpping(int verbose, char *buffer, void *store_ptr, int pingtype, i
 		index += 8;
 	}
 
+	int status = MB_SUCCESS;
+
 	/* check that we have enough storage for the points stored in the file
 	 */
 	if (ping->points_alloc < ping->nosampsfile) {
@@ -1911,7 +1926,6 @@ int swpls_rd_sxpping(int verbose, char *buffer, void *store_ptr, int pingtype, i
 /*--------------------------------------------------------------------*/
 int swpls_rd_projection(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_projection";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_projection *projection;
 	int index;
@@ -1926,6 +1940,8 @@ int swpls_rd_projection(int verbose, char *buffer, void *store_ptr, int *error) 
 
 	/* get pointer to raw data structure */
 	store = (struct mbsys_swathplus_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* only read the projection if not previously set */
 	if (store->projection_set == MB_NO) {
@@ -1991,7 +2007,6 @@ int swpls_rd_projection(int verbose, char *buffer, void *store_ptr, int *error) 
 /*--------------------------------------------------------------------*/
 int swpls_rd_comment(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_comment";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_comment *comment;
 	int index;
@@ -2016,6 +2031,8 @@ int swpls_rd_comment(int verbose, char *buffer, void *store_ptr, int *error) {
 	index += 4;
 	mb_get_binary_int(MB_YES, &buffer[index], &(comment->nchars));
 	index += 4;
+
+	int status = MB_SUCCESS;
 
 	/* allocated memory to hold the message if necessary */
 	if (comment->message_alloc < comment->nchars) {
@@ -2060,7 +2077,6 @@ int swpls_rd_comment(int verbose, char *buffer, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int swpls_rd_sxiheader(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_sxiheader";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_header *header;
 	int index;
@@ -2083,6 +2099,8 @@ int swpls_rd_sxiheader(int verbose, char *buffer, void *store_ptr, int *error) {
 	index += 4;
 	mb_get_binary_int(MB_YES, &buffer[index], &(header->fmtver));
 	index += 4;
+
+	int status = MB_SUCCESS;
 
 	/* set kind */
 	if (status == MB_SUCCESS) {
@@ -2108,7 +2126,6 @@ int swpls_rd_sxiheader(int verbose, char *buffer, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int swpls_rd_sxiping(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_sxiping";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxiping *ping;
 	short short_val;
@@ -2160,6 +2177,8 @@ int swpls_rd_sxiping(int verbose, char *buffer, void *store_ptr, int *error) {
 	mb_get_binary_short(MB_YES, &buffer[index], &short_val);
 	index += 2;
 	ping->reserve1 = (unsigned short)short_val;
+
+	int status = MB_SUCCESS;
 
 	/* check that we have enough storage for the samples stored in the file
 	 */
@@ -2228,7 +2247,6 @@ int swpls_rd_sxiping(int verbose, char *buffer, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int swpls_rd_attitude(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_attitude";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_attitude *attitude;
 	int index;
@@ -2262,6 +2280,8 @@ int swpls_rd_attitude(int verbose, char *buffer, void *store_ptr, int *error) {
 	mb_get_binary_float(MB_YES, &buffer[index], &(attitude->height));
 	index += 4;
 
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS) {
 		/* set the date and time */
 		store->time_d = (double)attitude->time_d + (double)attitude->microsec * 1e6;
@@ -2288,7 +2308,6 @@ int swpls_rd_attitude(int verbose, char *buffer, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int swpls_rd_posll(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_posll";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_posll *posll;
 	int index;
@@ -2318,6 +2337,8 @@ int swpls_rd_posll(int verbose, char *buffer, void *store_ptr, int *error) {
 	mb_get_binary_double(MB_YES, &buffer[index], &(posll->longitude));
 	index += 8;
 
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS) {
 		/* set the date and time */
 		store->time_d = (double)posll->time_d + (double)posll->microsec * 1e6;
@@ -2344,7 +2365,6 @@ int swpls_rd_posll(int verbose, char *buffer, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int swpls_rd_posen(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_posen";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_posen *posen;
 	int index;
@@ -2374,6 +2394,8 @@ int swpls_rd_posen(int verbose, char *buffer, void *store_ptr, int *error) {
 	mb_get_binary_double(MB_YES, &buffer[index], &(posen->northing));
 	index += 8;
 
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS) {
 		/* set the date and time */
 		store->time_d = (double)posen->time_d + (double)posen->microsec * 1e6;
@@ -2400,7 +2422,6 @@ int swpls_rd_posen(int verbose, char *buffer, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int swpls_rd_ssv(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_ssv";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_ssv *ssv;
 	int index;
@@ -2428,6 +2449,8 @@ int swpls_rd_ssv(int verbose, char *buffer, void *store_ptr, int *error) {
 	mb_get_binary_float(MB_YES, &buffer[index], &(ssv->ssv));
 	index += 4;
 
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS) {
 		/* set the date and time */
 		store->time_d = (double)ssv->time_d + (double)ssv->microsec * 1e6;
@@ -2454,7 +2477,6 @@ int swpls_rd_ssv(int verbose, char *buffer, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int swpls_rd_tide(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_tide";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_tide *tide;
 	int index;
@@ -2482,6 +2504,8 @@ int swpls_rd_tide(int verbose, char *buffer, void *store_ptr, int *error) {
 	mb_get_binary_float(MB_YES, &buffer[index], &(tide->tide));
 	index += 4;
 
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS) {
 		/* set the date and time */
 		store->time_d = (double)tide->time_d + (double)tide->microsec * 1e6;
@@ -2508,7 +2532,6 @@ int swpls_rd_tide(int verbose, char *buffer, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int swpls_rd_echosounder(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_echosounder";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_echosounder *echosounder;
 	int index;
@@ -2536,6 +2559,8 @@ int swpls_rd_echosounder(int verbose, char *buffer, void *store_ptr, int *error)
 	mb_get_binary_float(MB_YES, &buffer[index], &(echosounder->altitude));
 	index += 4;
 
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS) {
 		/* set the date and time */
 		store->time_d = (double)echosounder->time_d + (double)echosounder->microsec * 1e6;
@@ -2562,7 +2587,6 @@ int swpls_rd_echosounder(int verbose, char *buffer, void *store_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int swpls_rd_agds(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_agds";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_agds *agds;
 	int index;
@@ -2592,6 +2616,8 @@ int swpls_rd_agds(int verbose, char *buffer, void *store_ptr, int *error) {
 	mb_get_binary_float(MB_YES, &buffer[index], &(agds->roughness));
 	index += 4;
 
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS) {
 		/* set the date and time */
 		store->time_d = (double)agds->time_d + (double)agds->microsec * 1e6;
@@ -2618,7 +2644,6 @@ int swpls_rd_agds(int verbose, char *buffer, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int swpls_rd_pos_offset(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_pos_offset";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_pos_offset *pos_offset;
 	int index;
@@ -2652,6 +2677,8 @@ int swpls_rd_pos_offset(int verbose, char *buffer, void *store_ptr, int *error) 
 	mb_get_binary_float(MB_YES, &buffer[index], &(pos_offset->time));
 	index += 4;
 
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS) {
 		/* set the date and time */
 		store->time_d = (double)pos_offset->time_d + (double)pos_offset->microsec * 1e6;
@@ -2678,7 +2705,6 @@ int swpls_rd_pos_offset(int verbose, char *buffer, void *store_ptr, int *error) 
 /*--------------------------------------------------------------------*/
 int swpls_rd_imu_offset(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_imu_offset";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_imu_offset *imu_offset;
 	int index;
@@ -2712,6 +2738,8 @@ int swpls_rd_imu_offset(int verbose, char *buffer, void *store_ptr, int *error) 
 	mb_get_binary_float(MB_YES, &buffer[index], &(imu_offset->time));
 	index += 4;
 
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS) {
 		/* set the date and time */
 		store->time_d = (double)imu_offset->time_d + (double)imu_offset->microsec * 1e6;
@@ -2738,7 +2766,6 @@ int swpls_rd_imu_offset(int verbose, char *buffer, void *store_ptr, int *error) 
 /*--------------------------------------------------------------------*/
 int swpls_rd_txer_offset(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_txer_offset";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_txer_offset *txer_offset;
 	int index;
@@ -2780,6 +2807,8 @@ int swpls_rd_txer_offset(int verbose, char *buffer, void *store_ptr, int *error)
 	mb_get_binary_float(MB_YES, &buffer[index], &(txer_offset->time));
 	index += 4;
 
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS) {
 		/* set the date and time */
 		store->time_d = (double)txer_offset->time_d + (double)txer_offset->microsec * 1e6;
@@ -2806,7 +2835,6 @@ int swpls_rd_txer_offset(int verbose, char *buffer, void *store_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int swpls_rd_wl_offset(int verbose, char *buffer, void *store_ptr, int *error) {
 	char *function_name = "swpls_rd_wl_offset";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_wl_offset *wl_offset;
 	int index;
@@ -2834,6 +2862,8 @@ int swpls_rd_wl_offset(int verbose, char *buffer, void *store_ptr, int *error) {
 	mb_get_binary_float(MB_YES, &buffer[index], &(wl_offset->height));
 	index += 4;
 
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS) {
 		/* set the date and time */
 		store->time_d = (double)wl_offset->time_d + (double)wl_offset->microsec * 1e6;
@@ -2860,7 +2890,6 @@ int swpls_rd_wl_offset(int verbose, char *buffer, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int swpls_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *function_name = "swpls_wr_data";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	FILE *mbfp;
 	char **bufferptr;
@@ -2890,6 +2919,8 @@ int swpls_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	bufferalloc = (int *)&mb_io_ptr->save6;
 
 	/* write the current data record */
+
+	int status = MB_SUCCESS;
 
 	/* write SWPLS_ID_SXP_HEADER_DATA record */
 	if ((store->kind == MB_DATA_HEADER) && (store->type == SWPLS_ID_SXP_HEADER_DATA)) {
@@ -3018,7 +3049,6 @@ int swpls_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*-------------------------------------------------------------------*/
 int swpls_wr_sxpheader(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_sxpheader";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_header *header;
 	char *buffer;
@@ -3045,6 +3075,8 @@ int swpls_wr_sxpheader(int verbose, int *bufferalloc, char **bufferptr, void *st
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_HEADER;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -3089,7 +3121,6 @@ int swpls_wr_sxpheader(int verbose, int *bufferalloc, char **bufferptr, void *st
 /*---------------------------------------------------------------------*/
 int swpls_wr_sxpping(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_sxpping";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxpping *ping;
 	char *buffer;
@@ -3116,6 +3147,8 @@ int swpls_wr_sxpping(int verbose, int *bufferalloc, char **bufferptr, void *stor
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_PROCESSED_PING2 + (ping->nosampsfile * SWPLS_SIZE_POINT2);
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -3259,7 +3292,6 @@ int swpls_wr_sxpping(int verbose, int *bufferalloc, char **bufferptr, void *stor
 /*------------------------------------------------------------*/
 int swpls_wr_projection(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_projection";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_projection *projection;
 	char *buffer;
@@ -3293,6 +3325,8 @@ int swpls_wr_projection(int verbose, int *bufferalloc, char **bufferptr, void *s
 	padding = 4 - (*size % 4);
 	*size = *size + padding;
 	projection->nchars = projection->nchars + padding;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -3339,7 +3373,6 @@ int swpls_wr_projection(int verbose, int *bufferalloc, char **bufferptr, void *s
 /*------------------------------------------------------------*/
 int swpls_wr_comment(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_comment";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_comment *comment;
 	char *buffer;
@@ -3373,6 +3406,8 @@ int swpls_wr_comment(int verbose, int *bufferalloc, char **bufferptr, void *stor
 	padding = 4 - (*size % 4);
 	*size = *size + padding;
 	comment->nchars = comment->nchars + padding;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -3419,7 +3454,6 @@ int swpls_wr_comment(int verbose, int *bufferalloc, char **bufferptr, void *stor
 /*-------------------------------------------------------------------*/
 int swpls_wr_sxiheader(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_sxiheader";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_header *header;
 	char *buffer;
@@ -3446,6 +3480,8 @@ int swpls_wr_sxiheader(int verbose, int *bufferalloc, char **bufferptr, void *st
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_HEADER;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -3490,7 +3526,6 @@ int swpls_wr_sxiheader(int verbose, int *bufferalloc, char **bufferptr, void *st
 /*-------------------------------------------------------------------*/
 int swpls_wr_sxiping(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_sxiping";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_sxiping *ping;
 	char *buffer;
@@ -3517,6 +3552,8 @@ int swpls_wr_sxiping(int verbose, int *bufferalloc, char **bufferptr, void *stor
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_PARSED_PING + (ping->nosamps * SWPLS_SIZE_PARSED_POINT);
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -3593,7 +3630,6 @@ int swpls_wr_sxiping(int verbose, int *bufferalloc, char **bufferptr, void *stor
 /*-------------------------------------------------------------------*/
 int swpls_wr_attitude(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_attitude";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_attitude *attitude;
 	char *buffer;
@@ -3620,6 +3656,8 @@ int swpls_wr_attitude(int verbose, int *bufferalloc, char **bufferptr, void *sto
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_ATTITUDE;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -3674,7 +3712,6 @@ int swpls_wr_attitude(int verbose, int *bufferalloc, char **bufferptr, void *sto
 /*-------------------------------------------------------------------*/
 int swpls_wr_posll(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_posll";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_posll *posll;
 	char *buffer;
@@ -3701,6 +3738,8 @@ int swpls_wr_posll(int verbose, int *bufferalloc, char **bufferptr, void *store_
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_POSITION_LL;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -3751,7 +3790,6 @@ int swpls_wr_posll(int verbose, int *bufferalloc, char **bufferptr, void *store_
 /*-------------------------------------------------------------------*/
 int swpls_wr_posen(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_posen";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_posen *posen;
 	char *buffer;
@@ -3778,6 +3816,8 @@ int swpls_wr_posen(int verbose, int *bufferalloc, char **bufferptr, void *store_
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_POSITION_EN;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -3828,7 +3868,6 @@ int swpls_wr_posen(int verbose, int *bufferalloc, char **bufferptr, void *store_
 /*-------------------------------------------------------------------*/
 int swpls_wr_ssv(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_ssv";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_ssv *ssv;
 	char *buffer;
@@ -3855,6 +3894,8 @@ int swpls_wr_ssv(int verbose, int *bufferalloc, char **bufferptr, void *store_pt
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_SSV;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -3903,7 +3944,6 @@ int swpls_wr_ssv(int verbose, int *bufferalloc, char **bufferptr, void *store_pt
 /*-------------------------------------------------------------------*/
 int swpls_wr_tide(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_tide";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_tide *tide;
 	char *buffer;
@@ -3930,6 +3970,8 @@ int swpls_wr_tide(int verbose, int *bufferalloc, char **bufferptr, void *store_p
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_TIDE;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -3978,7 +4020,6 @@ int swpls_wr_tide(int verbose, int *bufferalloc, char **bufferptr, void *store_p
 /*-------------------------------------------------------------------*/
 int swpls_wr_echosounder(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_echosounder";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_echosounder *echosounder;
 	char *buffer;
@@ -4004,6 +4045,8 @@ int swpls_wr_echosounder(int verbose, int *bufferalloc, char **bufferptr, void *
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_ECHOSOUNDER;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -4052,7 +4095,6 @@ int swpls_wr_echosounder(int verbose, int *bufferalloc, char **bufferptr, void *
 /*-------------------------------------------------------------------*/
 int swpls_wr_agds(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_agds";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_agds *agds;
 	char *buffer;
@@ -4079,6 +4121,8 @@ int swpls_wr_agds(int verbose, int *bufferalloc, char **bufferptr, void *store_p
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_AGDS;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -4129,7 +4173,6 @@ int swpls_wr_agds(int verbose, int *bufferalloc, char **bufferptr, void *store_p
 /*-------------------------------------------------------------------*/
 int swpls_wr_pos_offset(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_pos_offset";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_pos_offset *pos_offset;
 	char *buffer;
@@ -4156,6 +4199,8 @@ int swpls_wr_pos_offset(int verbose, int *bufferalloc, char **bufferptr, void *s
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_POS_OFFSET;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -4210,7 +4255,6 @@ int swpls_wr_pos_offset(int verbose, int *bufferalloc, char **bufferptr, void *s
 /*-------------------------------------------------------------------*/
 int swpls_wr_imu_offset(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_imu_offset";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_imu_offset *imu_offset;
 	char *buffer;
@@ -4237,6 +4281,8 @@ int swpls_wr_imu_offset(int verbose, int *bufferalloc, char **bufferptr, void *s
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_IMU_OFFSET;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -4291,7 +4337,6 @@ int swpls_wr_imu_offset(int verbose, int *bufferalloc, char **bufferptr, void *s
 /*-------------------------------------------------------------------*/
 int swpls_wr_txer_offset(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_txer_offset";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_txer_offset *txer_offset;
 	char *buffer;
@@ -4318,6 +4363,8 @@ int swpls_wr_txer_offset(int verbose, int *bufferalloc, char **bufferptr, void *
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_TXER_OFFSET;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -4380,7 +4427,6 @@ int swpls_wr_txer_offset(int verbose, int *bufferalloc, char **bufferptr, void *
 /*-------------------------------------------------------------------*/
 int swpls_wr_wl_offset(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
 	char *function_name = "swpls_wr_wl_offset";
-	int status = MB_SUCCESS;
 	struct mbsys_swathplus_struct *store;
 	swpls_wl_offset *wl_offset;
 	char *buffer;
@@ -4407,6 +4453,8 @@ int swpls_wr_wl_offset(int verbose, int *bufferalloc, char **bufferptr, void *st
 
 	/* figure out size of output record */
 	*size = SWPLS_SIZE_BLOCKHEADER + SWPLS_SIZE_WL_OFFSET;
+
+	int status = MB_SUCCESS;
 
 	/* allocate memory to write record if necessary */
 	if (*bufferalloc < *size) {
@@ -4455,7 +4503,6 @@ int swpls_wr_wl_offset(int verbose, int *bufferalloc, char **bufferptr, void *st
 /*----------------------------------------------------------------------*/
 int swpls_pr_sxpheader(int verbose, FILE *fout, swpls_header *header, int *error) {
 	char *function_name = "swpls_pr_sxpheader";
-	int status = MB_SUCCESS;
 	char starter[5];
 
 	if (verbose >= 2) {
@@ -4476,6 +4523,8 @@ int swpls_pr_sxpheader(int verbose, FILE *fout, swpls_header *header, int *error
 	fprintf(fout, "%s        swver:  %d\n", starter, header->swver);
 	fprintf(fout, "%s        fmtver: %d\n", starter, header->fmtver);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4489,7 +4538,6 @@ int swpls_pr_sxpheader(int verbose, FILE *fout, swpls_header *header, int *error
 /*----------------------------------------------------------------------*/
 int swpls_pr_sxpping(int verbose, FILE *fout, swpls_sxpping *ping, int *error) {
 	char *function_name = "swpls_pr_sxpping";
-	int status = MB_SUCCESS;
 	swpls_point *points;
 	char starter[5];
 	int size;
@@ -4559,6 +4607,8 @@ int swpls_pr_sxpping(int verbose, FILE *fout, swpls_sxpping *ping, int *error) {
 		        points[i].x, points[i].z, points[i].amp, points[i].procamp, points[i].status, points[i].tpu);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4572,7 +4622,6 @@ int swpls_pr_sxpping(int verbose, FILE *fout, swpls_sxpping *ping, int *error) {
 /*----------------------------------------------------------------------*/
 int swpls_pr_projection(int verbose, FILE *fout, swpls_projection *projection, int *error) {
 	char *function_name = "swpls_pr_projection";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 	int size;
@@ -4599,6 +4648,8 @@ int swpls_pr_projection(int verbose, FILE *fout, swpls_projection *projection, i
 	fprintf(fout, "%s        nchars:               %d\n", starter, projection->nchars);
 	fprintf(fout, "%s        projection_id:        %s\n", starter, projection->projection_id);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4612,7 +4663,6 @@ int swpls_pr_projection(int verbose, FILE *fout, swpls_projection *projection, i
 /*----------------------------------------------------------------------*/
 int swpls_pr_comment(int verbose, FILE *fout, swpls_comment *comment, int *error) {
 	char *function_name = "swpls_pr_comment";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 	int size;
@@ -4640,6 +4690,8 @@ int swpls_pr_comment(int verbose, FILE *fout, swpls_comment *comment, int *error
 	fprintf(fout, "%s        nchars:               %d\n", starter, comment->nchars);
 	fprintf(fout, "%s        message:              %s\n", starter, comment->message);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4653,7 +4705,6 @@ int swpls_pr_comment(int verbose, FILE *fout, swpls_comment *comment, int *error
 /*----------------------------------------------------------------------*/
 int swpls_pr_sxiheader(int verbose, FILE *fout, swpls_header *header, int *error) {
 	char *function_name = "swpls_pr_sxiheader";
-	int status = MB_SUCCESS;
 	char starter[5];
 
 	if (verbose >= 2) {
@@ -4674,6 +4725,8 @@ int swpls_pr_sxiheader(int verbose, FILE *fout, swpls_header *header, int *error
 	fprintf(fout, "%s        swver:        %d\n", starter, header->swver);
 	fprintf(fout, "%s        fmtver:       %d\n", starter, header->fmtver);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4687,7 +4740,6 @@ int swpls_pr_sxiheader(int verbose, FILE *fout, swpls_header *header, int *error
 /*----------------------------------------------------------------------*/
 int swpls_pr_sxiping(int verbose, FILE *fout, swpls_sxiping *ping, int *error) {
 	char *function_name = "swpls_pr_sxiping";
-	int status = MB_SUCCESS;
 	char starter[5];
 	int size;
 	time_t tm;
@@ -4729,6 +4781,8 @@ int swpls_pr_sxiping(int verbose, FILE *fout, swpls_sxiping *ping, int *error) {
 		        ping->amplitude[i], ping->quality[i]);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4742,7 +4796,6 @@ int swpls_pr_sxiping(int verbose, FILE *fout, swpls_sxiping *ping, int *error) {
 /*----------------------------------------------------------------------*/
 int swpls_pr_attitude(int verbose, FILE *fout, swpls_attitude *attitude, int *error) {
 	char *function_name = "swpls_pr_attitude";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 
@@ -4770,6 +4823,8 @@ int swpls_pr_attitude(int verbose, FILE *fout, swpls_attitude *attitude, int *er
 	fprintf(fout, "%s        heading:      %f\n", starter, attitude->heading);
 	fprintf(fout, "%s        height:       %f\n", starter, attitude->height);
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4783,7 +4838,6 @@ int swpls_pr_attitude(int verbose, FILE *fout, swpls_attitude *attitude, int *er
 /*----------------------------------------------------------------------*/
 int swpls_pr_posll(int verbose, FILE *fout, swpls_posll *posll, int *error) {
 	char *function_name = "swpls_pr_posll";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 
@@ -4810,6 +4864,8 @@ int swpls_pr_posll(int verbose, FILE *fout, swpls_posll *posll, int *error) {
 	fprintf(fout, "%s        latitude:     %lf\n", starter, posll->latitude);
 	fprintf(fout, "%s        longitude:    %lf\n", starter, posll->longitude);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4823,7 +4879,6 @@ int swpls_pr_posll(int verbose, FILE *fout, swpls_posll *posll, int *error) {
 /*----------------------------------------------------------------------*/
 int swpls_pr_posen(int verbose, FILE *fout, swpls_posen *posen, int *error) {
 	char *function_name = "swpls_pr_posen";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 
@@ -4851,6 +4906,8 @@ int swpls_pr_posen(int verbose, FILE *fout, swpls_posen *posen, int *error) {
 	fprintf(fout, "%s        easting:      %lf\n", starter, posen->easting);
 	fprintf(fout, "%s        northing:     %lf\n", starter, posen->northing);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4864,7 +4921,6 @@ int swpls_pr_posen(int verbose, FILE *fout, swpls_posen *posen, int *error) {
 /*----------------------------------------------------------------------*/
 int swpls_pr_ssv(int verbose, FILE *fout, swpls_ssv *ssv, int *error) {
 	char *function_name = "swpls_pr_ssv";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 
@@ -4890,6 +4946,8 @@ int swpls_pr_ssv(int verbose, FILE *fout, swpls_ssv *ssv, int *error) {
 	fprintf(fout, "%s        channel:      %u\n", starter, ssv->channel);
 	fprintf(fout, "%s        ssv:          %f\n", starter, ssv->ssv);
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4903,7 +4961,6 @@ int swpls_pr_ssv(int verbose, FILE *fout, swpls_ssv *ssv, int *error) {
 /*----------------------------------------------------------------------*/
 int swpls_pr_tide(int verbose, FILE *fout, swpls_tide *tide, int *error) {
 	char *function_name = "swpls_pr_tide";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 
@@ -4929,6 +4986,8 @@ int swpls_pr_tide(int verbose, FILE *fout, swpls_tide *tide, int *error) {
 	fprintf(fout, "%s        channel:      %u\n", starter, tide->channel);
 	fprintf(fout, "%s        tide:         %f\n", starter, tide->tide);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4942,7 +5001,6 @@ int swpls_pr_tide(int verbose, FILE *fout, swpls_tide *tide, int *error) {
 /*----------------------------------------------------------------------*/
 int swpls_pr_echosounder(int verbose, FILE *fout, swpls_echosounder *echosounder, int *error) {
 	char *function_name = "swpls_pr_echosounder";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 
@@ -4969,6 +5027,8 @@ int swpls_pr_echosounder(int verbose, FILE *fout, swpls_echosounder *echosounder
 	fprintf(fout, "%s        channel:      %u\n", starter, echosounder->channel);
 	fprintf(fout, "%s        altitude:     %f\n", starter, echosounder->altitude);
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -4982,7 +5042,6 @@ int swpls_pr_echosounder(int verbose, FILE *fout, swpls_echosounder *echosounder
 /*----------------------------------------------------------------------*/
 int swpls_pr_agds(int verbose, FILE *fout, swpls_agds *agds, int *error) {
 	char *function_name = "swpls_pr_agds";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 
@@ -5009,6 +5068,8 @@ int swpls_pr_agds(int verbose, FILE *fout, swpls_agds *agds, int *error) {
 	fprintf(fout, "%s        hardness:     %f\n", starter, agds->hardness);
 	fprintf(fout, "%s        roughness:    %f\n", starter, agds->roughness);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -5022,7 +5083,6 @@ int swpls_pr_agds(int verbose, FILE *fout, swpls_agds *agds, int *error) {
 /*----------------------------------------------------------------------*/
 int swpls_pr_pos_offset(int verbose, FILE *fout, swpls_pos_offset *pos_offset, int *error) {
 	char *function_name = "swpls_pr_pos_offset";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 
@@ -5051,6 +5111,8 @@ int swpls_pr_pos_offset(int verbose, FILE *fout, swpls_pos_offset *pos_offset, i
 	fprintf(fout, "%s        starboard:    %f\n", starter, pos_offset->starboard);
 	fprintf(fout, "%s        time:         %f\n", starter, pos_offset->time);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -5064,7 +5126,6 @@ int swpls_pr_pos_offset(int verbose, FILE *fout, swpls_pos_offset *pos_offset, i
 /*----------------------------------------------------------------------*/
 int swpls_pr_imu_offset(int verbose, FILE *fout, swpls_imu_offset *imu_offset, int *error) {
 	char *function_name = "swpls_pr_imu_offset";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 
@@ -5093,6 +5154,8 @@ int swpls_pr_imu_offset(int verbose, FILE *fout, swpls_imu_offset *imu_offset, i
 	fprintf(fout, "%s        starboard:    %f\n", starter, imu_offset->starboard);
 	fprintf(fout, "%s        time:         %f\n", starter, imu_offset->time);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -5106,7 +5169,6 @@ int swpls_pr_imu_offset(int verbose, FILE *fout, swpls_imu_offset *imu_offset, i
 /*----------------------------------------------------------------------*/
 int swpls_pr_txer_offset(int verbose, FILE *fout, swpls_txer_offset *txer_offset, int *error) {
 	char *function_name = "swpls_pr_txer_offset";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 
@@ -5139,6 +5201,8 @@ int swpls_pr_txer_offset(int verbose, FILE *fout, swpls_txer_offset *txer_offset
 	fprintf(fout, "%s        skew:         %f\n", starter, txer_offset->skew);
 	fprintf(fout, "%s        time:         %f\n", starter, txer_offset->time);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -5153,7 +5217,6 @@ int swpls_pr_txer_offset(int verbose, FILE *fout, swpls_txer_offset *txer_offset
 /*----------------------------------------------------------------------*/
 int swpls_pr_wl_offset(int verbose, FILE *fout, swpls_wl_offset *wl_offset, int *error) {
 	char *function_name = "swpls_pr_wl_offset";
-	int status = MB_SUCCESS;
 	char starter[5];
 	time_t tm;
 
@@ -5179,6 +5242,8 @@ int swpls_pr_wl_offset(int verbose, FILE *fout, swpls_wl_offset *wl_offset, int 
 	fprintf(fout, "%s        channel:      %u\n", starter, wl_offset->channel);
 	fprintf(fout, "%s        height:       %f\n", starter, wl_offset->height);
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -5196,7 +5261,6 @@ int swpls_pr_wl_offset(int verbose, FILE *fout, swpls_wl_offset *wl_offset, int 
  */
 static int get_sxp_heave(int verbose, swpls_sxpping *sxp_ping, double *heave, int *error) {
 	char *function_name = "get_sxp_heave";
-	int status = MB_SUCCESS;
 	swpls_vector txoffset;
 	swpls_matrix vtow;
 
@@ -5223,6 +5287,8 @@ static int get_sxp_heave(int verbose, swpls_sxpping *sxp_ping, double *heave, in
 
 	*heave = sxp_ping->height - (-txoffset.y);
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -5241,7 +5307,6 @@ static int get_sxp_heave(int verbose, swpls_sxpping *sxp_ping, double *heave, in
  */
 static int set_sxp_height(int verbose, double heave, swpls_sxpping *sxp_ping, int *error) {
 	char *function_name = "set_sxp_height";
-	int status = MB_SUCCESS;
 	swpls_vector txoffset;
 	swpls_matrix vtow;
 
@@ -5267,6 +5332,8 @@ static int set_sxp_height(int verbose, double heave, swpls_sxpping *sxp_ping, in
 	swpls_transform(verbose, &vtow, &txoffset, error);
 
 	sxp_ping->height = heave + (-txoffset.y);
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -5319,7 +5386,6 @@ static int set_sxp_height(int verbose, double heave, swpls_sxpping *sxp_ping, in
  */
 int swpls_init_transform(int verbose, swpls_matrix *m, int *error) {
 	char *function_name = "swpls_init_transform";
-	int status = MB_SUCCESS;
 
 	*error = MB_ERROR_NO_ERROR;
 
@@ -5330,7 +5396,7 @@ int swpls_init_transform(int verbose, swpls_matrix *m, int *error) {
 		fprintf(stderr, "dbg2       m:            %p\n", (void *)m);
 	}
 
-	status = set_identity(verbose, m, error);
+	const int status = set_identity(verbose, m, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -5350,7 +5416,6 @@ int swpls_init_transform(int verbose, swpls_matrix *m, int *error) {
  */
 int swpls_concat_translate(int verbose, swpls_matrix *m, double dx, double dy, double dz, int *error) {
 	char *function_name = "swpls_concat_translation";
-	int status = MB_SUCCESS;
 	swpls_matrix translate;
 
 	*error = MB_ERROR_NO_ERROR;
@@ -5365,7 +5430,7 @@ int swpls_concat_translate(int verbose, swpls_matrix *m, double dx, double dy, d
 		fprintf(stderr, "dbg2       dz:           %f.3\n", dz);
 	}
 
-	status = set_identity(verbose, &translate, error);
+	int status = set_identity(verbose, &translate, error);
 	if (status == MB_SUCCESS) {
 		translate.tx = dx;
 		translate.ty = dy;
@@ -5392,7 +5457,6 @@ int swpls_concat_translate(int verbose, swpls_matrix *m, double dx, double dy, d
  */
 int swpls_concat_rotate_x(int verbose, swpls_matrix *m, double pitch, int *error) {
 	char *function_name = "swpls_concat_rotate_x";
-	int status = MB_SUCCESS;
 	double sinp, cosp;
 	swpls_matrix rotate;
 
@@ -5409,7 +5473,7 @@ int swpls_concat_rotate_x(int verbose, swpls_matrix *m, double pitch, int *error
 	sinp = sin(pitch);
 	cosp = cos(pitch);
 
-	status = set_identity(verbose, &rotate, error);
+	const int status = set_identity(verbose, &rotate, error);
 	if (status == MB_SUCCESS) {
 		rotate.m22 = cosp;
 		rotate.m23 = sinp;
@@ -5434,7 +5498,6 @@ int swpls_concat_rotate_x(int verbose, swpls_matrix *m, double pitch, int *error
  */
 int swpls_concat_rotate_y(int verbose, swpls_matrix *m, double heading, int *error) {
 	char *function_name = "swpls_concat_rotate_y";
-	int status = MB_SUCCESS;
 	double sint, cost;
 	swpls_matrix rotate;
 
@@ -5451,7 +5514,7 @@ int swpls_concat_rotate_y(int verbose, swpls_matrix *m, double heading, int *err
 	sint = sin(heading);
 	cost = cos(heading);
 
-	status = set_identity(verbose, &rotate, error);
+	int status = set_identity(verbose, &rotate, error);
 	if (status == MB_SUCCESS) {
 		rotate.m11 = cost;
 		rotate.m13 = -sint;
@@ -5476,7 +5539,6 @@ int swpls_concat_rotate_y(int verbose, swpls_matrix *m, double heading, int *err
  */
 int swpls_concat_rotate_z(int verbose, swpls_matrix *m, double bank, int *error) {
 	char *function_name = "swpls_concat_rotate_z";
-	int status = MB_SUCCESS;
 	double sint, cost;
 	swpls_matrix rotate;
 
@@ -5493,7 +5555,7 @@ int swpls_concat_rotate_z(int verbose, swpls_matrix *m, double bank, int *error)
 	sint = sin(bank);
 	cost = cos(bank);
 
-	status = set_identity(verbose, &rotate, error);
+	int status = set_identity(verbose, &rotate, error);
 	if (status == MB_SUCCESS) {
 		rotate.m11 = cost;
 		rotate.m12 = sint;
@@ -5519,7 +5581,6 @@ int swpls_concat_rotate_z(int verbose, swpls_matrix *m, double bank, int *error)
  */
 int swpls_transform(int verbose, const swpls_matrix *m, swpls_vector *p, int *error) {
 	char *function_name = "swpls_transform";
-	int status = MB_SUCCESS;
 	double x, y, z;
 
 	*error = MB_ERROR_NO_ERROR;
@@ -5543,6 +5604,8 @@ int swpls_transform(int verbose, const swpls_matrix *m, swpls_vector *p, int *er
 	p->y = y;
 	p->z = z;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -5563,7 +5626,6 @@ int swpls_transform(int verbose, const swpls_matrix *m, swpls_vector *p, int *er
  */
 int swpls_angles_to_quat(int verbose, const swpls_angles *orientation, swpls_quaternion *q, int *error) {
 	char *function_name = "swpls_angles_to_quat";
-	int status = MB_SUCCESS;
 	double sp, sb, sh;
 	double cp, cb, ch;
 
@@ -5589,6 +5651,8 @@ int swpls_angles_to_quat(int verbose, const swpls_angles *orientation, swpls_qua
 	q->y = -ch * sp * sb + sh * cp * cb;
 	q->z = -sh * sp * cb + ch * cp * sb;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -5607,7 +5671,6 @@ int swpls_angles_to_quat(int verbose, const swpls_angles *orientation, swpls_qua
  */
 int swpls_quat_to_angles(int verbose, const swpls_quaternion *q, swpls_angles *orientation, int *error) {
 	char *function_name = "swpls_quat_to_angles";
-	int status = MB_SUCCESS;
 	double sp;
 
 	*error = MB_ERROR_NO_ERROR;
@@ -5633,6 +5696,8 @@ int swpls_quat_to_angles(int verbose, const swpls_quaternion *q, swpls_angles *o
 		orientation->bank = atan2(q->x * q->y + q->w * q->z, 0.5 - q->x * q->x - q->z * q->z);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -5653,7 +5718,6 @@ int swpls_quat_to_angles(int verbose, const swpls_quaternion *q, swpls_angles *o
  */
 int swpls_slerp(int verbose, const swpls_quaternion *q0, const swpls_quaternion *q1, double t, swpls_quaternion *q, int *error) {
 	char *function_name = "swpls_slerp";
-	int status = MB_SUCCESS;
 	double q1w, q1x, q1y, q1z;
 	double k0, k1;
 	double omega, cosOmega, sinOmega, oneOverSinOmega;
@@ -5719,6 +5783,8 @@ int swpls_slerp(int verbose, const swpls_quaternion *q0, const swpls_quaternion 
 		q->w = k0 * q0->w + k1 * q1w;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -5747,7 +5813,6 @@ static double wrap_pi(double theta) {
  */
 static int set_identity(int verbose, swpls_matrix *m, int *error) {
 	char *function_name = "set_identity";
-	int status = MB_SUCCESS;
 
 	*error = MB_ERROR_NO_ERROR;
 
@@ -5774,6 +5839,8 @@ static int set_identity(int verbose, swpls_matrix *m, int *error) {
 	m->ty = 0.0;
 	m->tz = 0.0;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -5792,7 +5859,6 @@ static int set_identity(int verbose, swpls_matrix *m, int *error) {
  */
 static int concat_transform(int verbose, swpls_matrix *a, swpls_matrix *b, int *error) {
 	char *function_name = "concat_transform";
-	int status = MB_SUCCESS;
 	swpls_matrix r;
 
 	*error = MB_ERROR_NO_ERROR;
@@ -5836,6 +5902,8 @@ static int concat_transform(int verbose, swpls_matrix *a, swpls_matrix *b, int *
 	a->tx = r.tx;
 	a->ty = r.ty;
 	a->tz = r.tz;
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_templatesystem.c
+++ b/src/mbio/mbsys_templatesystem.c
@@ -37,7 +37,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_templatesystem_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_templatesystem_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -66,6 +65,8 @@ int mbsys_templatesystem_alloc(int verbose, void *mbio_ptr, void **store_ptr, in
 
 	/* initialize everything else */
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -80,7 +81,6 @@ int mbsys_templatesystem_alloc(int verbose, void *mbio_ptr, void **store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbsys_templatesystem_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_templatesystem_deall";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -97,7 +97,7 @@ int mbsys_templatesystem_deall(int verbose, void *mbio_ptr, void **store_ptr, in
 	/* deallocate any arrays or structures contained within the store data structure */
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -114,7 +114,6 @@ int mbsys_templatesystem_deall(int verbose, void *mbio_ptr, void **store_ptr, in
 int mbsys_templatesystem_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                                     int *error) {
 	char *function_name = "mbsys_templatesystem_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -148,6 +147,8 @@ int mbsys_templatesystem_dimensions(int verbose, void *mbio_ptr, void *store_ptr
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -165,7 +166,6 @@ int mbsys_templatesystem_dimensions(int verbose, void *mbio_ptr, void *store_ptr
 /*--------------------------------------------------------------------*/
 int mbsys_templatesystem_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber, int *error) {
 	char *function_name = "mbsys_templatesystem_pingnumber";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -184,6 +184,8 @@ int mbsys_templatesystem_pingnumber(int verbose, void *mbio_ptr, unsigned int *p
 	/* extract data from structure */
 	*pingnumber = store->ping_number;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -198,7 +200,6 @@ int mbsys_templatesystem_pingnumber(int verbose, void *mbio_ptr, unsigned int *p
 /*--------------------------------------------------------------------*/
 int mbsys_templatesystem_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *sonartype, int *error) {
 	char *function_name = "mbsys_templatesystem_sonartype";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -218,6 +219,8 @@ int mbsys_templatesystem_sonartype(int verbose, void *mbio_ptr, void *store_ptr,
 	/* get sonar type */
 	*sonartype = MB_SONARTYPE_MULTIBEAM;
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -232,7 +235,6 @@ int mbsys_templatesystem_sonartype(int verbose, void *mbio_ptr, void *store_ptr,
 /*--------------------------------------------------------------------*/
 int mbsys_templatesystem_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int *ss_type, int *error) {
 	char *function_name = "mbsys_templatesystem_sidescantype";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -252,6 +254,8 @@ int mbsys_templatesystem_sidescantype(int verbose, void *mbio_ptr, void *store_p
 	/* get sidescan type */
 	*ss_type = MB_SIDESCAN_LINEAR;
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -269,7 +273,6 @@ int mbsys_templatesystem_extract(int verbose, void *mbio_ptr, void *store_ptr, i
                                  char *beamflag, double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack,
                                  double *ss, double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_templatesystem_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -503,6 +506,9 @@ int mbsys_templatesystem_extract(int verbose, void *mbio_ptr, void *store_ptr, i
 			fprintf(stderr, "dbg2        pixel:%d   ss:%f  acrosstrack:%f  alongtrack:%f\n", i, ss[i], ssacrosstrack[i],
 			        ssalongtrack[i]);
 	}
+
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -517,7 +523,6 @@ int mbsys_templatesystem_insert(int verbose, void *mbio_ptr, void *store_ptr, in
                                 char *beamflag, double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack,
                                 double *ss, double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_templatesystem_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -633,6 +638,8 @@ int mbsys_templatesystem_insert(int verbose, void *mbio_ptr, void *store_ptr, in
 		strncpy(store->comment, comment, MB_COMMENT_MAXLINE);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -648,7 +655,6 @@ int mbsys_templatesystem_ttimes(int verbose, void *mbio_ptr, void *store_ptr, in
                                 double *angles, double *angles_forward, double *angles_null, double *heave,
                                 double *alongtrack_offset, double *draft, double *ssv, int *error) {
 	char *function_name = "mbsys_templatesystem_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 	double heave_use, roll, pitch;
 	double alpha, beta, theta, phi;
@@ -675,6 +681,8 @@ int mbsys_templatesystem_ttimes(int verbose, void *mbio_ptr, void *store_ptr, in
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -740,7 +748,6 @@ int mbsys_templatesystem_ttimes(int verbose, void *mbio_ptr, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbsys_templatesystem_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_templatesystem_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -760,6 +767,8 @@ int mbsys_templatesystem_detects(int verbose, void *mbio_ptr, void *store_ptr, i
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -816,7 +825,6 @@ int mbsys_templatesystem_detects(int verbose, void *mbio_ptr, void *store_ptr, i
 int mbsys_templatesystem_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain,
                                double *pulse_length, double *receive_gain, int *error) {
 	char *function_name = "mbsys_templatesystem_gains";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -835,6 +843,8 @@ int mbsys_templatesystem_gains(int verbose, void *mbio_ptr, void *store_ptr, int
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -890,7 +900,6 @@ int mbsys_templatesystem_gains(int verbose, void *mbio_ptr, void *store_ptr, int
 int mbsys_templatesystem_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                           double *altitudev, int *error) {
 	char *function_name = "mbsys_templatesystem_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 	double heave, roll, pitch;
 	double xtrackmin;
@@ -912,6 +921,8 @@ int mbsys_templatesystem_extract_altitude(int verbose, void *mbio_ptr, void *sto
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -960,7 +971,6 @@ int mbsys_templatesystem_extract_nav(int verbose, void *mbio_ptr, void *store_pt
                                      double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                                      double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_templatesystem_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -979,6 +989,8 @@ int mbsys_templatesystem_extract_nav(int verbose, void *mbio_ptr, void *store_pt
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from survey record */
 	if (*kind == MB_DATA_DATA) {
@@ -1094,7 +1106,6 @@ int mbsys_templatesystem_extract_nnav(int verbose, void *mbio_ptr, void *store_p
                                       double *time_d, double *navlon, double *navlat, double *speed, double *heading,
                                       double *draft, double *roll, double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_templatesystem_extract_nnav";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 	int inav;
 
@@ -1115,6 +1126,8 @@ int mbsys_templatesystem_extract_nnav(int verbose, void *mbio_ptr, void *store_p
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from survey record */
 	if (*kind == MB_DATA_DATA) {
@@ -1235,7 +1248,6 @@ int mbsys_templatesystem_insert_nav(int verbose, void *mbio_ptr, void *store_ptr
                                     double navlat, double speed, double heading, double draft, double roll, double pitch,
                                     double heave, int *error) {
 	char *function_name = "mbsys_templatesystem_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -1324,6 +1336,8 @@ int mbsys_templatesystem_insert_nav(int verbose, void *mbio_ptr, void *store_ptr
 		store->roll = roll;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1338,7 +1352,6 @@ int mbsys_templatesystem_insert_nav(int verbose, void *mbio_ptr, void *store_ptr
 int mbsys_templatesystem_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth,
                                      double *velocity, int *error) {
 	char *function_name = "mbsys_templatesystem_extract_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 
 	if (verbose >= 2) {
@@ -1357,6 +1370,8 @@ int mbsys_templatesystem_extract_svp(int verbose, void *mbio_ptr, void *store_pt
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_VELOCITY_PROFILE) {
@@ -1404,7 +1419,6 @@ int mbsys_templatesystem_extract_svp(int verbose, void *mbio_ptr, void *store_pt
 int mbsys_templatesystem_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity,
                                     int *error) {
 	char *function_name = "mbsys_templatesystem_insert_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 	s7kr_svp *svp;
 
@@ -1424,6 +1438,8 @@ int mbsys_templatesystem_insert_svp(int verbose, void *mbio_ptr, void *store_ptr
 
 	/* get data structure pointer */
 	store = (struct mbsys_templatesystem_struct *)store_ptr;
+
+	int status = MB_SUCCESS;
 
 	/* insert data in structure */
 	if (store->kind == MB_DATA_VELOCITY_PROFILE) {
@@ -1450,7 +1466,6 @@ int mbsys_templatesystem_insert_svp(int verbose, void *mbio_ptr, void *store_ptr
 /*--------------------------------------------------------------------*/
 int mbsys_templatesystem_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_templatesystem_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_templatesystem_struct *store;
 	struct mbsys_templatesystem_struct *copy;
 
@@ -1473,6 +1488,8 @@ int mbsys_templatesystem_copy(int verbose, void *mbio_ptr, void *store_ptr, void
 	/* copy the data - for many formats memory must be allocated and
 	    sub-structures copied separately */
 	*copy = *store;
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);

--- a/src/mbio/mbsys_wassp.c
+++ b/src/mbio/mbsys_wassp.c
@@ -37,7 +37,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_wassp_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	const char *function_name = "mbsys_wassp_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -61,7 +60,7 @@ int mbsys_wassp_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error)
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_wassp_struct), (void **)store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_wassp_struct), (void **)store_ptr, error);
 
 	/* initialize allocated structure to zero */
 	if (status == MB_SUCCESS) {
@@ -95,7 +94,6 @@ int mbsys_wassp_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int mbsys_wassp_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_wassp_deall";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -128,6 +126,8 @@ int mbsys_wassp_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error)
 	sys_prop = (struct mbsys_wassp_sys_prop_struct *)&(store->sys_prop);
 	sys_cfg1 = (struct mbsys_wassp_sys_cfg1_struct *)&(store->sys_cfg1);
 	mcomment = (struct mbsys_wassp_mcomment_struct *)&(store->mcomment);
+
+	int status = MB_SUCCESS;
 
 	/* deallocate any arrays or structures contained within the store data structure */
 	if (rawsonar->rawdata_alloc > 0) {
@@ -166,7 +166,6 @@ int mbsys_wassp_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int mbsys_wassp_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss, int *error) {
 	char *function_name = "mbsys_wassp_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -220,6 +219,8 @@ int mbsys_wassp_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -237,7 +238,6 @@ int mbsys_wassp_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 /*--------------------------------------------------------------------*/
 int mbsys_wassp_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber, int *error) {
 	char *function_name = "mbsys_wassp_pingnumber";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -276,6 +276,8 @@ int mbsys_wassp_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber
 	/* extract data from structure */
 	*pingnumber = corbathy->ping_number;
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -290,7 +292,6 @@ int mbsys_wassp_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber
 /*--------------------------------------------------------------------*/
 int mbsys_wassp_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *sonartype, int *error) {
 	char *function_name = "mbsys_wassp_sonartype";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -330,6 +331,8 @@ int mbsys_wassp_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *son
 	/* get sonar type */
 	*sonartype = MB_TOPOGRAPHY_TYPE_MULTIBEAM;
 
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -347,7 +350,6 @@ int mbsys_wassp_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
                         double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                         double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_wassp_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -609,6 +611,9 @@ int mbsys_wassp_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 			fprintf(stderr, "dbg2        pixel:%d   ss:%f  acrosstrack:%f  alongtrack:%f\n", i, ss[i], ssacrosstrack[i],
 			        ssalongtrack[i]);
 	}
+
+	int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -623,7 +628,6 @@ int mbsys_wassp_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, i
                        double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                        double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_wassp_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -762,6 +766,8 @@ int mbsys_wassp_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, i
 		}
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -777,7 +783,6 @@ int mbsys_wassp_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
                        double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                        double *ssv, int *error) {
 	char *function_name = "mbsys_wassp_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -823,6 +828,8 @@ int mbsys_wassp_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -893,7 +900,6 @@ int mbsys_wassp_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 /*--------------------------------------------------------------------*/
 int mbsys_wassp_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_wassp_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -933,6 +939,8 @@ int mbsys_wassp_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -994,7 +1002,6 @@ int mbsys_wassp_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 int mbsys_wassp_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                       double *receive_gain, int *error) {
 	char *function_name = "mbsys_wassp_gains";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -1033,6 +1040,8 @@ int mbsys_wassp_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, d
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1088,7 +1097,6 @@ int mbsys_wassp_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, d
 int mbsys_wassp_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                  double *altitude, int *error) {
 	char *function_name = "mbsys_wassp_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -1127,6 +1135,8 @@ int mbsys_wassp_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, i
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1175,7 +1185,6 @@ int mbsys_wassp_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *k
                             double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                             double *pitch, double *heave, int *error) {
 	char *function_name = "mbsys_wassp_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -1214,6 +1223,8 @@ int mbsys_wassp_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *k
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from survey record */
 	if (*kind == MB_DATA_DATA) {
@@ -1327,7 +1338,6 @@ int mbsys_wassp_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int tim
                            double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                            int *error) {
 	char *function_name = "mbsys_wassp_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_genbathy_struct *genbathy;
 	struct mbsys_wassp_corbathy_struct *corbathy;
@@ -1427,6 +1437,8 @@ int mbsys_wassp_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int tim
 		nvupdate->roll = roll;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1440,7 +1452,6 @@ int mbsys_wassp_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int tim
 /*--------------------------------------------------------------------*/
 int mbsys_wassp_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_wassp_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_wassp_struct *store;
 	struct mbsys_wassp_struct *copy;
 	size_t rawdata_alloc_save;
@@ -1491,6 +1502,9 @@ int mbsys_wassp_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_pt
 	copy->rawsonar = store->rawsonar;
 	copy->rawsonar.rawdata_alloc = rawdata_alloc_save;
 	copy->rawsonar.rawdata = rawdata_save;
+
+	int status = MB_SUCCESS;
+
 	if (status == MB_SUCCESS && copy->rawsonar.rawdata_alloc < store->rawsonar.rawdata_alloc) {
 		status =
 		    mb_reallocd(verbose, __FILE__, __LINE__, store->rawsonar.rawdata_alloc, (void **)&(copy->rawsonar.rawdata), error);

--- a/src/mbio/mbsys_xse.c
+++ b/src/mbio/mbsys_xse.c
@@ -42,7 +42,6 @@
 /*--------------------------------------------------------------------*/
 int mbsys_xse_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_xse_alloc";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 
 	if (verbose >= 2) {
@@ -56,7 +55,7 @@ int mbsys_xse_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_xse_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_xse_struct), store_ptr, error);
 
 	/* get data structure pointer */
 	store = (struct mbsys_xse_struct *)*store_ptr;
@@ -435,7 +434,6 @@ int mbsys_xse_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_xse_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	char *function_name = "mbsys_xse_deall";
-	int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", function_name);
@@ -446,7 +444,7 @@ int mbsys_xse_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
@@ -461,7 +459,6 @@ int mbsys_xse_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbsys_xse_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss, int *error) {
 	char *function_name = "mbsys_xse_dimensions";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 
 	if (verbose >= 2) {
@@ -507,6 +504,8 @@ int mbsys_xse_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 		*nss = 0;
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -527,7 +526,6 @@ int mbsys_xse_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
                       double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                       double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_xse_extract";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 	double xtrackmin, xtrackmax;
 	int ixtrackmin, ixtrackmax;
@@ -750,6 +748,9 @@ int mbsys_xse_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 			        bathalongtrack[i]);
 		fprintf(stderr, "dbg2        nss:      %d\n", *nss);
 	}
+
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "dbg2       error:      %d\n", *error);
 		fprintf(stderr, "dbg2  Return status:\n");
@@ -764,7 +765,6 @@ int mbsys_xse_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int
                      double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                      double *ssalongtrack, char *comment, int *error) {
 	char *function_name = "mbsys_xse_insert";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 	double maxoffset, xtrackmin, xtrackmax;
 	int imaxoffset, ixtrackmin, ixtrackmax;
@@ -945,6 +945,8 @@ int mbsys_xse_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int
 		strncpy(store->comment, comment, 199);
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -960,7 +962,6 @@ int mbsys_xse_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
                      double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                      double *ssv, int *error) {
 	char *function_name = "mbsys_xse_ttimes";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 	double xtrackmin, xtrackmax;
 	int ixtrackmin, ixtrackmax;
@@ -989,6 +990,8 @@ int mbsys_xse_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1097,7 +1100,6 @@ int mbsys_xse_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
 /*--------------------------------------------------------------------*/
 int mbsys_xse_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
 	char *function_name = "mbsys_xse_detects";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 
 	if (verbose >= 2) {
@@ -1117,6 +1119,8 @@ int mbsys_xse_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1186,7 +1190,6 @@ int mbsys_xse_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 int mbsys_xse_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                double *altitude, int *error) {
 	char *function_name = "mbsys_xse_extract_altitude";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 	double bath_best;
 	double xtrack_min;
@@ -1207,6 +1210,8 @@ int mbsys_xse_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1281,7 +1286,6 @@ int mbsys_xse_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
                           double *navlat, double *speed, double *heading, double *draft, double *roll, double *pitch,
                           double *heave, int *error) {
 	char *function_name = "mbsys_xse_extract_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 
 	if (verbose >= 2) {
@@ -1300,6 +1304,8 @@ int mbsys_xse_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_DATA) {
@@ -1461,7 +1467,6 @@ int mbsys_xse_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 int mbsys_xse_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_i[7], double time_d, double navlon, double navlat,
                          double speed, double heading, double draft, double roll, double pitch, double heave, int *error) {
 	char *function_name = "mbsys_xse_insert_nav";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 
 	if (verbose >= 2) {
@@ -1554,6 +1559,8 @@ int mbsys_xse_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_
 		/* get roll pitch and heave */
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1568,7 +1575,6 @@ int mbsys_xse_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_
 int mbsys_xse_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                           int *error) {
 	char *function_name = "mbsys_xse_extract_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 
 	if (verbose >= 2) {
@@ -1587,6 +1593,8 @@ int mbsys_xse_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 
 	/* get data kind */
 	*kind = store->kind;
+
+	int status = MB_SUCCESS;
 
 	/* extract data from structure */
 	if (*kind == MB_DATA_VELOCITY_PROFILE) {
@@ -1633,7 +1641,6 @@ int mbsys_xse_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 /*--------------------------------------------------------------------*/
 int mbsys_xse_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity, int *error) {
 	char *function_name = "mbsys_xse_insert_svp";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 
 	if (verbose >= 2) {
@@ -1665,6 +1672,8 @@ int mbsys_xse_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp,
 		}
 	}
 
+	const int status = MB_SUCCESS;
+
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);
 		fprintf(stderr, "dbg2  Return value:\n");
@@ -1678,7 +1687,6 @@ int mbsys_xse_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp,
 /*--------------------------------------------------------------------*/
 int mbsys_xse_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
 	char *function_name = "mbsys_xse_copy";
-	int status = MB_SUCCESS;
 	struct mbsys_xse_struct *store;
 	struct mbsys_xse_struct *copy;
 
@@ -1700,6 +1708,8 @@ int mbsys_xse_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr,
 
 	/* copy the data */
 	*copy = *store;
+
+	const int status = MB_SUCCESS;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", function_name);


### PR DESCRIPTION
- Add `const` when possible
- `status &=` for some of the `status =` overwrite occurrences