### PR TITLE
Need to include Winsock2.h before windows.h

### DIFF
--- a/src/mbedit/mbedit_callbacks.c
+++ b/src/mbedit/mbedit_callbacks.c
@@ -44,6 +44,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbedit/mbedit_prog.c
+++ b/src/mbedit/mbedit_prog.c
@@ -41,6 +41,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -26,7 +26,15 @@
 extern "C" {
 #endif
 
+
 #ifdef _WIN32
+	/* https://www.zachburlingame.com/2011/05/resolving-redefinition-errors-betwen-ws2def-h-and-winsock-h/ */
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
+#	include <Windows.h>
+
 #	include <mb_config.h>
 #else
 #	ifdef HAVE_CONFIG_H

--- a/src/mbnavadjust/mbnavadjust.c
+++ b/src/mbnavadjust/mbnavadjust.c
@@ -26,6 +26,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbnavadjust/mbnavadjust_callbacks.c
+++ b/src/mbnavadjust/mbnavadjust_callbacks.c
@@ -34,6 +34,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbnavadjust/mbnavadjust_prog.c
+++ b/src/mbnavadjust/mbnavadjust_prog.c
@@ -38,6 +38,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 #include <X11/Intrinsic.h>

--- a/src/mbnavadjust/mbnavadjust_util.c
+++ b/src/mbnavadjust/mbnavadjust_util.c
@@ -41,6 +41,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbnavedit/mbnavedit_callbacks.c
+++ b/src/mbnavedit/mbnavedit_callbacks.c
@@ -31,6 +31,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbnavedit/mbnavedit_prog.c
+++ b/src/mbnavedit/mbnavedit_prog.c
@@ -31,6 +31,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbnavedit/mbnavedit_util.c
+++ b/src/mbnavedit/mbnavedit_util.c
@@ -41,6 +41,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbvelocitytool/mbvelocity.c
+++ b/src/mbvelocitytool/mbvelocity.c
@@ -24,6 +24,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbvelocitytool/mbvelocity_callbacks.c
+++ b/src/mbvelocitytool/mbvelocity_callbacks.c
@@ -49,6 +49,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbvelocitytool/mbvelocity_prog.c
+++ b/src/mbvelocitytool/mbvelocity_prog.c
@@ -39,6 +39,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mb3dsoundings_callbacks.c
+++ b/src/mbview/mb3dsoundings_callbacks.c
@@ -36,6 +36,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mb_glwdrawa.c
+++ b/src/mbview/mb_glwdrawa.c
@@ -70,6 +70,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbpingedit_callbacks.c
+++ b/src/mbview/mbpingedit_callbacks.c
@@ -37,6 +37,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbview_callbacks.c
+++ b/src/mbview/mbview_callbacks.c
@@ -57,6 +57,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbview_nav.c
+++ b/src/mbview/mbview_nav.c
@@ -29,6 +29,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbview_pick.c
+++ b/src/mbview/mbview_pick.c
@@ -33,6 +33,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbview_plot.c
+++ b/src/mbview/mbview_plot.c
@@ -32,6 +32,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbview_primary.c
+++ b/src/mbview/mbview_primary.c
@@ -31,6 +31,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbview_process.c
+++ b/src/mbview/mbview_process.c
@@ -32,6 +32,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbview_profile.c
+++ b/src/mbview/mbview_profile.c
@@ -29,6 +29,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbview_route.c
+++ b/src/mbview/mbview_route.c
@@ -32,6 +32,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbview_secondary.c
+++ b/src/mbview/mbview_secondary.c
@@ -31,6 +31,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbview_site.c
+++ b/src/mbview/mbview_site.c
@@ -32,6 +32,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 

--- a/src/mbview/mbview_vector.c
+++ b/src/mbview/mbview_vector.c
@@ -28,6 +28,10 @@
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#	ifndef WIN32
+#		define WIN32
+#	endif
+#	include <WinSock2.h>
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
Something changed meanwhile and now I have to include WinSock2.h before Windows.h otherwise there are macro conflicts when building with MSVC.