### PR TITLE
Avoid overwriting spline tension in mbgrid if "-T" is before "-C"

### DIFF
--- a/src/utilities/mbgrid.c
+++ b/src/utilities/mbgrid.c
@@ -391,13 +391,6 @@ int main(int argc, char **argv) {
 				clipmode = MBGRID_INTERP_GAP;
 			else if (clipmode >= 3)
 				clipmode = MBGRID_INTERP_ALL;
-			if (n < 3) {
-#ifdef USESURFACE
-				tension = 0.35;
-#else
-				tension = 0.0;
-#endif
-			}
 			flag++;
 			break;
 		case 'D':


### PR DESCRIPTION
At the moment, if option "-T" is before "-C", and spline tension isn't set as a third parameter to -C, spline tension is reset to the default value (0.0 or 0.35). This PR should fix this bug. The default tension is already set in lines 186-190, so the deleted code was redundant anyway.

It is still slightly odd (open to unexpected behavior?) that tension can be added as an option to -C and overwritten by -T or vice versa, depending on which order they are specified on the command line.