### PR TITLE
Localize store variable: mbr_reson7k3.c mbr_reson7kr.c mbsys_reson7k.c mbsys_reson7k3.c.

### DIFF
--- a/src/mbio/mbr_reson7k3.c
+++ b/src/mbio/mbr_reson7k3.c
@@ -424,7 +424,6 @@ int mbr_reson7k3_wr_FileCatalog(int verbose, int *bufferalloc, char **bufferptr,
 /*--------------------------------------------------------------------*/
 int mbr_dem_reson7k3(int verbose, void *mbio_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   char **bufferptr = NULL;
   char *buffer = NULL;
   int *bufferalloc = NULL;
@@ -448,7 +447,7 @@ int mbr_dem_reson7k3(int verbose, void *mbio_ptr, int *error) {
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointers to buffers */
-  store = (struct mbsys_reson7k3_struct *) &mb_io_ptr->store_data;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *) &mb_io_ptr->store_data;
   bufferptr = (char **)&mb_io_ptr->saveptr1;
   buffer = (char *)*bufferptr;
   bufferalloc = (int *)&mb_io_ptr->save6;
@@ -1072,7 +1071,6 @@ int mbr_reson7k3_rd_header(int verbose, char *buffer, int *index, s7k3_header *h
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_ReferencePoint(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_ReferencePoint *ReferencePoint;
   int index;
@@ -1087,7 +1085,7 @@ int mbr_reson7k3_rd_ReferencePoint(int verbose, char *buffer, void *store_ptr, i
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   ReferencePoint = &(store->ReferencePoint);
   header = &(ReferencePoint->header);
 
@@ -1153,7 +1151,6 @@ int mbr_reson7k3_rd_ReferencePoint(int verbose, char *buffer, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_UncalibratedSensorOffset(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_UncalibratedSensorOffset *UncalibratedSensorOffset;
   int index;
@@ -1168,7 +1165,7 @@ int mbr_reson7k3_rd_UncalibratedSensorOffset(int verbose, char *buffer, void *st
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   UncalibratedSensorOffset = &(store->UncalibratedSensorOffset);
   header = &(UncalibratedSensorOffset->header);
 
@@ -1238,7 +1235,6 @@ int mbr_reson7k3_rd_UncalibratedSensorOffset(int verbose, char *buffer, void *st
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_CalibratedSensorOffset(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CalibratedSensorOffset *CalibratedSensorOffset;
   int index;
@@ -1253,7 +1249,7 @@ int mbr_reson7k3_rd_CalibratedSensorOffset(int verbose, char *buffer, void *stor
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CalibratedSensorOffset = &(store->CalibratedSensorOffset);
   header = &(CalibratedSensorOffset->header);
 
@@ -1323,7 +1319,6 @@ int mbr_reson7k3_rd_CalibratedSensorOffset(int verbose, char *buffer, void *stor
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Position(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Position *Position;
   int index;
@@ -1338,7 +1333,7 @@ int mbr_reson7k3_rd_Position(int verbose, char *buffer, void *store_ptr, int *er
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Position = &(store->Position);
   header = &(Position->header);
 
@@ -1416,7 +1411,6 @@ int mbr_reson7k3_rd_Position(int verbose, char *buffer, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_CustomAttitude(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CustomAttitude *CustomAttitude;
   int data_size;
@@ -1432,7 +1426,7 @@ int mbr_reson7k3_rd_CustomAttitude(int verbose, char *buffer, void *store_ptr, i
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CustomAttitude = &(store->CustomAttitude);
   header = &(CustomAttitude->header);
 
@@ -1566,7 +1560,6 @@ int mbr_reson7k3_rd_CustomAttitude(int verbose, char *buffer, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Tide(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Tide *Tide;
   int index;
@@ -1581,7 +1574,7 @@ int mbr_reson7k3_rd_Tide(int verbose, char *buffer, void *store_ptr, int *error)
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Tide = &(store->Tide);
   header = &(Tide->header);
 
@@ -1661,7 +1654,6 @@ int mbr_reson7k3_rd_Tide(int verbose, char *buffer, void *store_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Altitude(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Altitude *Altitude;
   int index;
@@ -1676,7 +1668,7 @@ int mbr_reson7k3_rd_Altitude(int verbose, char *buffer, void *store_ptr, int *er
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Altitude = &(store->Altitude);
   header = &(Altitude->header);
 
@@ -1736,7 +1728,6 @@ int mbr_reson7k3_rd_Altitude(int verbose, char *buffer, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_MotionOverGround(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_MotionOverGround *MotionOverGround;
   int data_size;
@@ -1752,7 +1743,7 @@ int mbr_reson7k3_rd_MotionOverGround(int verbose, char *buffer, void *store_ptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   MotionOverGround = &(store->MotionOverGround);
   header = &(MotionOverGround->header);
 
@@ -1870,7 +1861,6 @@ int mbr_reson7k3_rd_MotionOverGround(int verbose, char *buffer, void *store_ptr,
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Depth(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Depth *Depth;
   int index;
@@ -1885,7 +1875,7 @@ int mbr_reson7k3_rd_Depth(int verbose, char *buffer, void *store_ptr, int *error
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Depth = &(store->Depth);
   header = &(Depth->header);
 
@@ -1951,7 +1941,6 @@ int mbr_reson7k3_rd_Depth(int verbose, char *buffer, void *store_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SoundVelocityProfile(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SoundVelocityProfile *SoundVelocityProfile;
   int data_size;
@@ -1967,7 +1956,7 @@ int mbr_reson7k3_rd_SoundVelocityProfile(int verbose, char *buffer, void *store_
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SoundVelocityProfile = &(store->SoundVelocityProfile);
   header = &(SoundVelocityProfile->header);
 
@@ -2059,7 +2048,6 @@ int mbr_reson7k3_rd_SoundVelocityProfile(int verbose, char *buffer, void *store_
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_CTD(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CTD *CTD;
   int data_size;
@@ -2075,7 +2063,7 @@ int mbr_reson7k3_rd_CTD(int verbose, char *buffer, void *store_ptr, int *error) 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CTD = &(store->CTD);
   header = &(CTD->header);
 
@@ -2191,7 +2179,6 @@ int mbr_reson7k3_rd_CTD(int verbose, char *buffer, void *store_ptr, int *error) 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Geodesy(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Geodesy *Geodesy;
   int index;
@@ -2206,7 +2193,7 @@ int mbr_reson7k3_rd_Geodesy(int verbose, char *buffer, void *store_ptr, int *err
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Geodesy = &(store->Geodesy);
   header = &(Geodesy->header);
 
@@ -2326,7 +2313,6 @@ int mbr_reson7k3_rd_Geodesy(int verbose, char *buffer, void *store_ptr, int *err
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_RollPitchHeave(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RollPitchHeave *RollPitchHeave;
   int index;
@@ -2341,7 +2327,7 @@ int mbr_reson7k3_rd_RollPitchHeave(int verbose, char *buffer, void *store_ptr, i
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RollPitchHeave = &(store->RollPitchHeave);
   header = &(RollPitchHeave->header);
 
@@ -2405,7 +2391,6 @@ int mbr_reson7k3_rd_RollPitchHeave(int verbose, char *buffer, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Heading(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Heading *Heading;
   int index;
@@ -2420,7 +2405,7 @@ int mbr_reson7k3_rd_Heading(int verbose, char *buffer, void *store_ptr, int *err
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Heading = &(store->Heading);
   header = &(Heading->header);
 
@@ -2480,7 +2465,6 @@ int mbr_reson7k3_rd_Heading(int verbose, char *buffer, void *store_ptr, int *err
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SurveyLine(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SurveyLine *SurveyLine;
   int data_size;
@@ -2496,7 +2480,7 @@ int mbr_reson7k3_rd_SurveyLine(int verbose, char *buffer, void *store_ptr, int *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SurveyLine = &(store->SurveyLine);
   header = &(SurveyLine->header);
 
@@ -2586,7 +2570,6 @@ int mbr_reson7k3_rd_SurveyLine(int verbose, char *buffer, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Navigation(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Navigation *Navigation;
   int index;
@@ -2601,7 +2584,7 @@ int mbr_reson7k3_rd_Navigation(int verbose, char *buffer, void *store_ptr, int *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Navigation = &(store->Navigation);
   header = &(Navigation->header);
 
@@ -2677,7 +2660,6 @@ int mbr_reson7k3_rd_Navigation(int verbose, char *buffer, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Attitude(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Attitude *Attitude;
   int data_size;
@@ -2693,7 +2675,7 @@ int mbr_reson7k3_rd_Attitude(int verbose, char *buffer, void *store_ptr, int *er
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Attitude = &(store->Attitude);
   header = &(Attitude->header);
 
@@ -2789,7 +2771,6 @@ int mbr_reson7k3_rd_Attitude(int verbose, char *buffer, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_PanTilt(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_PanTilt *PanTilt;
   int index;
@@ -2803,7 +2784,7 @@ int mbr_reson7k3_rd_PanTilt(int verbose, char *buffer, void *store_ptr, int *err
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   PanTilt = &(store->PanTilt);
   header = &(PanTilt->header);
 
@@ -2828,7 +2809,6 @@ int mbr_reson7k3_rd_PanTilt(int verbose, char *buffer, void *store_ptr, int *err
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SonarInstallationIDs(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SonarInstallationIDs *SonarInstallationIDs;
   int index;
@@ -2842,7 +2822,7 @@ int mbr_reson7k3_rd_SonarInstallationIDs(int verbose, char *buffer, void *store_
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SonarInstallationIDs = &(store->SonarInstallationIDs);
   header = &(SonarInstallationIDs->header);
 
@@ -2867,7 +2847,6 @@ int mbr_reson7k3_rd_SonarInstallationIDs(int verbose, char *buffer, void *store_
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Mystery(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Mystery *Mystery;
   int index;
@@ -2882,7 +2861,7 @@ int mbr_reson7k3_rd_Mystery(int verbose, char *buffer, void *store_ptr, int *err
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Mystery = &(store->Mystery);
   header = &(Mystery->header);
 
@@ -2944,7 +2923,6 @@ int mbr_reson7k3_rd_Mystery(int verbose, char *buffer, void *store_ptr, int *err
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SonarPipeEnvironment(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SonarPipeEnvironment *SonarPipeEnvironment;
   int index;
@@ -2958,7 +2936,7 @@ int mbr_reson7k3_rd_SonarPipeEnvironment(int verbose, char *buffer, void *store_
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SonarPipeEnvironment = &(store->SonarPipeEnvironment);
   header = &(SonarPipeEnvironment->header);
 
@@ -2983,7 +2961,6 @@ int mbr_reson7k3_rd_SonarPipeEnvironment(int verbose, char *buffer, void *store_
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_ContactOutput(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_ContactOutput *ContactOutput;
   int index;
@@ -2997,7 +2974,7 @@ int mbr_reson7k3_rd_ContactOutput(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   ContactOutput = &(store->ContactOutput);
   header = &(ContactOutput->header);
 
@@ -3021,7 +2998,6 @@ int mbr_reson7k3_rd_ContactOutput(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_ProcessedSideScan(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_ProcessedSideScan *ProcessedSideScan;
   int index;
@@ -3036,7 +3012,7 @@ int mbr_reson7k3_rd_ProcessedSideScan(int verbose, char *buffer, void *store_ptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   ProcessedSideScan = &(store->ProcessedSideScan);
   header = &(ProcessedSideScan->header);
 
@@ -3125,7 +3101,6 @@ int mbr_reson7k3_rd_ProcessedSideScan(int verbose, char *buffer, void *store_ptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SonarSettings(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SonarSettings *SonarSettings;
   int index;
@@ -3140,7 +3115,7 @@ int mbr_reson7k3_rd_SonarSettings(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SonarSettings = &(store->SonarSettings);
   header = &(SonarSettings->header);
 
@@ -3276,7 +3251,6 @@ int mbr_reson7k3_rd_SonarSettings(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Configuration(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Configuration *Configuration;
   s7k3_device *device;
@@ -3293,7 +3267,7 @@ int mbr_reson7k3_rd_Configuration(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Configuration = &(store->Configuration);
   header = &(Configuration->header);
 
@@ -3390,7 +3364,6 @@ int mbr_reson7k3_rd_Configuration(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_MatchFilter(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_MatchFilter *MatchFilter;
   int index;
@@ -3405,7 +3378,7 @@ int mbr_reson7k3_rd_MatchFilter(int verbose, char *buffer, void *store_ptr, int 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   MatchFilter = &(store->MatchFilter);
   header = &(MatchFilter->header);
 
@@ -3483,7 +3456,6 @@ int mbr_reson7k3_rd_MatchFilter(int verbose, char *buffer, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_FirmwareHardwareConfiguration(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_FirmwareHardwareConfiguration *FirmwareHardwareConfiguration;
   int index;
@@ -3500,7 +3472,7 @@ int mbr_reson7k3_rd_FirmwareHardwareConfiguration(int verbose, char *buffer, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   FirmwareHardwareConfiguration = &(store->FirmwareHardwareConfiguration);
   header = &(FirmwareHardwareConfiguration->header);
 
@@ -3580,7 +3552,6 @@ int mbr_reson7k3_rd_FirmwareHardwareConfiguration(int verbose, char *buffer, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_BeamGeometry(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_BeamGeometry *BeamGeometry;
   int index;
@@ -3595,7 +3566,7 @@ int mbr_reson7k3_rd_BeamGeometry(int verbose, char *buffer, void *store_ptr, int
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   BeamGeometry = &(store->BeamGeometry);
   header = &(BeamGeometry->header);
 
@@ -3675,7 +3646,6 @@ int mbr_reson7k3_rd_BeamGeometry(int verbose, char *buffer, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Bathymetry(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Bathymetry *Bathymetry;
   int index;
@@ -3691,7 +3661,7 @@ int mbr_reson7k3_rd_Bathymetry(int verbose, char *buffer, void *store_ptr, int *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Bathymetry = &(store->Bathymetry);
   header = &(Bathymetry->header);
 
@@ -3857,7 +3827,6 @@ int mbr_reson7k3_rd_Bathymetry(int verbose, char *buffer, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SideScan(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SideScan *SideScan;
   int data_size;
@@ -3875,7 +3844,7 @@ int mbr_reson7k3_rd_SideScan(int verbose, char *buffer, void *store_ptr, int *er
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SideScan = &(store->SideScan);
   header = &(SideScan->header);
 
@@ -4037,7 +4006,6 @@ int mbr_reson7k3_rd_SideScan(int verbose, char *buffer, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_WaterColumn(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_WaterColumn *WaterColumn;
   s7k3_wcd *wcd;
@@ -4066,7 +4034,7 @@ int mbr_reson7k3_rd_WaterColumn(int verbose, char *buffer, void *store_ptr, int 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   WaterColumn = &(store->WaterColumn);
   header = &(WaterColumn->header);
 
@@ -4250,7 +4218,6 @@ int mbr_reson7k3_rd_WaterColumn(int verbose, char *buffer, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_VerticalDepth(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_VerticalDepth *VerticalDepth;
   int index;
@@ -4265,7 +4232,7 @@ int mbr_reson7k3_rd_VerticalDepth(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   VerticalDepth = &(store->VerticalDepth);
   header = &(VerticalDepth->header);
 
@@ -4341,7 +4308,6 @@ int mbr_reson7k3_rd_VerticalDepth(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_TVG(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_TVG *TVG;
   int index;
@@ -4357,7 +4323,7 @@ int mbr_reson7k3_rd_TVG(int verbose, char *buffer, void *store_ptr, int *error) 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   TVG = &(store->TVG);
   header = &(TVG->header);
 
@@ -4441,7 +4407,6 @@ int mbr_reson7k3_rd_TVG(int verbose, char *buffer, void *store_ptr, int *error) 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Image(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Image *Image;
   int index;
@@ -4460,7 +4425,7 @@ int mbr_reson7k3_rd_Image(int verbose, char *buffer, void *store_ptr, int *error
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Image = &(store->Image);
   header = &(Image->header);
 
@@ -4578,7 +4543,6 @@ int mbr_reson7k3_rd_Image(int verbose, char *buffer, void *store_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_PingMotion(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_PingMotion *PingMotion;
   int index;
@@ -4593,7 +4557,7 @@ int mbr_reson7k3_rd_PingMotion(int verbose, char *buffer, void *store_ptr, int *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   PingMotion = &(store->PingMotion);
   header = &(PingMotion->header);
 
@@ -4724,7 +4688,6 @@ int mbr_reson7k3_rd_PingMotion(int verbose, char *buffer, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_AdaptiveGate(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_AdaptiveGate *AdaptiveGate;
   int index;
@@ -4738,7 +4701,7 @@ int mbr_reson7k3_rd_AdaptiveGate(int verbose, char *buffer, void *store_ptr, int
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   AdaptiveGate = &(store->AdaptiveGate);
   header = &(AdaptiveGate->header);
 
@@ -4763,7 +4726,6 @@ int mbr_reson7k3_rd_AdaptiveGate(int verbose, char *buffer, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_DetectionDataSetup(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_DetectionDataSetup *DetectionDataSetup;
   int index;
@@ -4778,7 +4740,7 @@ int mbr_reson7k3_rd_DetectionDataSetup(int verbose, char *buffer, void *store_pt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   DetectionDataSetup = &(store->DetectionDataSetup);
   header = &(DetectionDataSetup->header);
 
@@ -4904,7 +4866,6 @@ int mbr_reson7k3_rd_DetectionDataSetup(int verbose, char *buffer, void *store_pt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Beamformed(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Beamformed *Beamformed;
   s7k3_amplitudephase *amplitudephase;
@@ -4920,7 +4881,7 @@ int mbr_reson7k3_rd_Beamformed(int verbose, char *buffer, void *store_ptr, int *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Beamformed = &(store->Beamformed);
   header = &(Beamformed->header);
 
@@ -5024,7 +4985,6 @@ int mbr_reson7k3_rd_Beamformed(int verbose, char *buffer, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_VernierProcessingDataRaw(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_VernierProcessingDataRaw *VernierProcessingDataRaw;
   int index;
@@ -5038,7 +4998,7 @@ int mbr_reson7k3_rd_VernierProcessingDataRaw(int verbose, char *buffer, void *st
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   VernierProcessingDataRaw = &(store->VernierProcessingDataRaw);
   header = &(VernierProcessingDataRaw->header);
 
@@ -5063,7 +5023,6 @@ int mbr_reson7k3_rd_VernierProcessingDataRaw(int verbose, char *buffer, void *st
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_BITE(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_BITE *BITE;
   s7k3_bitereport *bitereport;
@@ -5083,7 +5042,7 @@ int mbr_reson7k3_rd_BITE(int verbose, char *buffer, void *store_ptr, int *error)
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   BITE = &(store->BITE);
   header = &(BITE->header);
 
@@ -5234,7 +5193,6 @@ int mbr_reson7k3_rd_BITE(int verbose, char *buffer, void *store_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SonarSourceVersion(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SonarSourceVersion *SonarSourceVersion;
   int index;
@@ -5249,7 +5207,7 @@ int mbr_reson7k3_rd_SonarSourceVersion(int verbose, char *buffer, void *store_pt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SonarSourceVersion = &(store->SonarSourceVersion);
   header = &(SonarSourceVersion->header);
 
@@ -5311,7 +5269,6 @@ int mbr_reson7k3_rd_SonarSourceVersion(int verbose, char *buffer, void *store_pt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_WetEndVersion8k(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_WetEndVersion8k *WetEndVersion8k;
   int index;
@@ -5326,7 +5283,7 @@ int mbr_reson7k3_rd_WetEndVersion8k(int verbose, char *buffer, void *store_ptr, 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   WetEndVersion8k = &(store->WetEndVersion8k);
   header = &(WetEndVersion8k->header);
 
@@ -5388,7 +5345,6 @@ int mbr_reson7k3_rd_WetEndVersion8k(int verbose, char *buffer, void *store_ptr, 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_RawDetection(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RawDetection *RawDetection;
   s7k3_rawdetectiondata *rawdetectiondata;
@@ -5405,7 +5361,7 @@ int mbr_reson7k3_rd_RawDetection(int verbose, char *buffer, void *store_ptr, int
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RawDetection = &(store->RawDetection);
   header = &(RawDetection->header);
 
@@ -5574,7 +5530,6 @@ int mbr_reson7k3_rd_RawDetection(int verbose, char *buffer, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Snippet(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Snippet *Snippet;
   s7k3_snippetdata *snippetdata;
@@ -5594,7 +5549,7 @@ int mbr_reson7k3_rd_Snippet(int verbose, char *buffer, void *store_ptr, int *err
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Snippet = &(store->Snippet);
   header = &(Snippet->header);
 
@@ -5755,7 +5710,6 @@ int mbr_reson7k3_rd_Snippet(int verbose, char *buffer, void *store_ptr, int *err
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_VernierProcessingDataFiltered(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_VernierProcessingDataFiltered *VernierProcessingDataFiltered;
   int index;
@@ -5769,7 +5723,7 @@ int mbr_reson7k3_rd_VernierProcessingDataFiltered(int verbose, char *buffer, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   VernierProcessingDataFiltered = &(store->VernierProcessingDataFiltered);
   header = &(VernierProcessingDataFiltered->header);
 
@@ -5794,7 +5748,6 @@ int mbr_reson7k3_rd_VernierProcessingDataFiltered(int verbose, char *buffer, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_InstallationParameters(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_InstallationParameters *InstallationParameters;
   int index;
@@ -5809,7 +5762,7 @@ int mbr_reson7k3_rd_InstallationParameters(int verbose, char *buffer, void *stor
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   InstallationParameters = &(store->InstallationParameters);
   header = &(InstallationParameters->header);
 
@@ -5941,7 +5894,6 @@ int mbr_reson7k3_rd_InstallationParameters(int verbose, char *buffer, void *stor
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_BITESummary(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_BITESummary *BITESummary;
   int index;
@@ -5955,7 +5907,7 @@ int mbr_reson7k3_rd_BITESummary(int verbose, char *buffer, void *store_ptr, int 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   BITESummary = &(store->BITESummary);
   header = &(BITESummary->header);
 
@@ -5980,7 +5932,6 @@ int mbr_reson7k3_rd_BITESummary(int verbose, char *buffer, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_CompressedBeamformedMagnitude(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CompressedBeamformedMagnitude *CompressedBeamformedMagnitude;
   int index;
@@ -5994,7 +5945,7 @@ int mbr_reson7k3_rd_CompressedBeamformedMagnitude(int verbose, char *buffer, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CompressedBeamformedMagnitude = &(store->CompressedBeamformedMagnitude);
   header = &(CompressedBeamformedMagnitude->header);
 
@@ -6019,7 +5970,6 @@ int mbr_reson7k3_rd_CompressedBeamformedMagnitude(int verbose, char *buffer, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_CompressedWaterColumn(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_compressedwatercolumndata *compressedwatercolumndata;
   s7k3_CompressedWaterColumn *CompressedWaterColumn;
@@ -6035,7 +5985,7 @@ int mbr_reson7k3_rd_CompressedWaterColumn(int verbose, char *buffer, void *store
   int firstsamplerxdelay;
   int index;
   int time_j[5];
-char *first = "TEST";
+  char *first = "TEST";
 
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
@@ -6046,7 +5996,7 @@ char *first = "TEST";
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CompressedWaterColumn = &(store->CompressedWaterColumn);
   header = &(CompressedWaterColumn->header);
 
@@ -6242,7 +6192,6 @@ char *first = "TEST";
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SegmentedRawDetection(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SegmentedRawDetection *SegmentedRawDetection;
   s7k3_segmentedrawdetectiontxdata *segmentedrawdetectiontxdata;
@@ -6260,7 +6209,7 @@ int mbr_reson7k3_rd_SegmentedRawDetection(int verbose, char *buffer, void *store
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SegmentedRawDetection = &(store->SegmentedRawDetection);
   header = &(SegmentedRawDetection->header);
 
@@ -6457,7 +6406,6 @@ int mbr_reson7k3_rd_SegmentedRawDetection(int verbose, char *buffer, void *store
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_CalibratedBeam(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CalibratedBeam *CalibratedBeam;
   int index;
@@ -6471,7 +6419,7 @@ int mbr_reson7k3_rd_CalibratedBeam(int verbose, char *buffer, void *store_ptr, i
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CalibratedBeam = &(store->CalibratedBeam);
   header = &(CalibratedBeam->header);
 
@@ -6496,7 +6444,6 @@ int mbr_reson7k3_rd_CalibratedBeam(int verbose, char *buffer, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SystemEvents(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SystemEvents *SystemEvents;
   int index;
@@ -6510,7 +6457,7 @@ int mbr_reson7k3_rd_SystemEvents(int verbose, char *buffer, void *store_ptr, int
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SystemEvents = &(store->SystemEvents);
   header = &(SystemEvents->header);
 
@@ -6535,7 +6482,6 @@ int mbr_reson7k3_rd_SystemEvents(int verbose, char *buffer, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SystemEventMessage(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SystemEventMessage *SystemEventMessage;
   int data_size;
@@ -6551,7 +6497,7 @@ int mbr_reson7k3_rd_SystemEventMessage(int verbose, char *buffer, void *store_pt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SystemEventMessage = &(store->SystemEventMessage);
   header = &(SystemEventMessage->header);
 
@@ -6636,7 +6582,6 @@ int mbr_reson7k3_rd_SystemEventMessage(int verbose, char *buffer, void *store_pt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_RDRRecordingStatus(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RDRRecordingStatus *RDRRecordingStatus;
   int index;
@@ -6650,7 +6595,7 @@ int mbr_reson7k3_rd_RDRRecordingStatus(int verbose, char *buffer, void *store_pt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RDRRecordingStatus = &(store->RDRRecordingStatus);
   header = &(RDRRecordingStatus->header);
 
@@ -6675,7 +6620,6 @@ int mbr_reson7k3_rd_RDRRecordingStatus(int verbose, char *buffer, void *store_pt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_Subscriptions(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Subscriptions *Subscriptions;
   int index;
@@ -6689,7 +6633,7 @@ int mbr_reson7k3_rd_Subscriptions(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Subscriptions = &(store->Subscriptions);
   header = &(Subscriptions->header);
 
@@ -6714,7 +6658,6 @@ int mbr_reson7k3_rd_Subscriptions(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_RDRStorageRecording(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RDRStorageRecording *RDRStorageRecording;
   int index;
@@ -6728,7 +6671,7 @@ int mbr_reson7k3_rd_RDRStorageRecording(int verbose, char *buffer, void *store_p
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RDRStorageRecording = &(store->RDRStorageRecording);
   header = &(RDRStorageRecording->header);
 
@@ -6753,7 +6696,6 @@ int mbr_reson7k3_rd_RDRStorageRecording(int verbose, char *buffer, void *store_p
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_CalibrationStatus(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CalibrationStatus *CalibrationStatus;
   int index;
@@ -6767,7 +6709,7 @@ int mbr_reson7k3_rd_CalibrationStatus(int verbose, char *buffer, void *store_ptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CalibrationStatus = &(store->CalibrationStatus);
   header = &(CalibrationStatus->header);
 
@@ -6792,7 +6734,6 @@ int mbr_reson7k3_rd_CalibrationStatus(int verbose, char *buffer, void *store_ptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_CalibratedSideScan(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CalibratedSideScan *CalibratedSideScan;
   int index;
@@ -6806,7 +6747,7 @@ int mbr_reson7k3_rd_CalibratedSideScan(int verbose, char *buffer, void *store_pt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CalibratedSideScan = &(store->CalibratedSideScan);
   header = &(CalibratedSideScan->header);
 
@@ -6831,7 +6772,6 @@ int mbr_reson7k3_rd_CalibratedSideScan(int verbose, char *buffer, void *store_pt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SnippetBackscatteringStrength(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SnippetBackscatteringStrength *SnippetBackscatteringStrength;
   int index;
@@ -6845,7 +6785,7 @@ int mbr_reson7k3_rd_SnippetBackscatteringStrength(int verbose, char *buffer, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SnippetBackscatteringStrength = &(store->SnippetBackscatteringStrength);
   header = &(SnippetBackscatteringStrength->header);
 
@@ -6870,7 +6810,6 @@ int mbr_reson7k3_rd_SnippetBackscatteringStrength(int verbose, char *buffer, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_MB2Status(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_MB2Status *MB2Status;
   int index;
@@ -6884,7 +6823,7 @@ int mbr_reson7k3_rd_MB2Status(int verbose, char *buffer, void *store_ptr, int *e
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   MB2Status = &(store->MB2Status);
   header = &(MB2Status->header);
 
@@ -6909,7 +6848,6 @@ int mbr_reson7k3_rd_MB2Status(int verbose, char *buffer, void *store_ptr, int *e
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_FileHeader(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_FileHeader *FileHeader;
   s7k3_subsystem *subsystem;
@@ -6925,7 +6863,7 @@ int mbr_reson7k3_rd_FileHeader(int verbose, char *buffer, void *store_ptr, int *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   FileHeader = &(store->FileHeader);
   header = &(FileHeader->header);
 
@@ -7290,7 +7228,6 @@ int mbr_reson7k3_FileCatalog_compare(const void *a, const void *b) {
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_FileCatalog(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_FileCatalog *FileCatalog;
   s7k3_filecatalogdata *filecatalogdata;
@@ -7306,7 +7243,7 @@ int mbr_reson7k3_rd_FileCatalog(int verbose, char *buffer, void *store_ptr, int 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   FileCatalog = &(store->FileCatalog_read);
   header = &(FileCatalog->header);
 
@@ -7434,7 +7371,6 @@ int mbr_reson7k3_rd_FileCatalog(int verbose, char *buffer, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_TimeMessage(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_TimeMessage *TimeMessage;
   int index;
@@ -7448,7 +7384,7 @@ int mbr_reson7k3_rd_TimeMessage(int verbose, char *buffer, void *store_ptr, int 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   TimeMessage = &(store->TimeMessage);
   header = &(TimeMessage->header);
 
@@ -7473,7 +7409,6 @@ int mbr_reson7k3_rd_TimeMessage(int verbose, char *buffer, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_RemoteControl(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RemoteControl *RemoteControl;
   int index;
@@ -7487,7 +7422,7 @@ int mbr_reson7k3_rd_RemoteControl(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RemoteControl = &(store->RemoteControl);
   header = &(RemoteControl->header);
 
@@ -7512,7 +7447,6 @@ int mbr_reson7k3_rd_RemoteControl(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_RemoteControlAcknowledge(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RemoteControlAcknowledge *RemoteControlAcknowledge;
   int index;
@@ -7526,7 +7460,7 @@ int mbr_reson7k3_rd_RemoteControlAcknowledge(int verbose, char *buffer, void *st
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RemoteControlAcknowledge = &(store->RemoteControlAcknowledge);
   header = &(RemoteControlAcknowledge->header);
 
@@ -7551,7 +7485,6 @@ int mbr_reson7k3_rd_RemoteControlAcknowledge(int verbose, char *buffer, void *st
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_RemoteControlNotAcknowledge(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RemoteControlNotAcknowledge *RemoteControlNotAcknowledge;
   int index;
@@ -7565,7 +7498,7 @@ int mbr_reson7k3_rd_RemoteControlNotAcknowledge(int verbose, char *buffer, void 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RemoteControlNotAcknowledge = &(store->RemoteControlNotAcknowledge);
   header = &(RemoteControlNotAcknowledge->header);
 
@@ -7590,7 +7523,6 @@ int mbr_reson7k3_rd_RemoteControlNotAcknowledge(int verbose, char *buffer, void 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_RemoteControlSonarSettings(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RemoteControlSonarSettings *RemoteControlSonarSettings;
   int index;
@@ -7605,7 +7537,7 @@ int mbr_reson7k3_rd_RemoteControlSonarSettings(int verbose, char *buffer, void *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RemoteControlSonarSettings = &(store->RemoteControlSonarSettings);
   header = &(RemoteControlSonarSettings->header);
 
@@ -7804,7 +7736,6 @@ int mbr_reson7k3_rd_RemoteControlSonarSettings(int verbose, char *buffer, void *
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_CommonSystemSettings(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CommonSystemSettings *CommonSystemSettings;
   int index;
@@ -7819,7 +7750,7 @@ int mbr_reson7k3_rd_CommonSystemSettings(int verbose, char *buffer, void *store_
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CommonSystemSettings = &(store->CommonSystemSettings);
   header = &(CommonSystemSettings->header);
 
@@ -7999,7 +7930,6 @@ int mbr_reson7k3_rd_CommonSystemSettings(int verbose, char *buffer, void *store_
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SVFiltering(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SVFiltering *SVFiltering;
   int index;
@@ -8013,7 +7943,7 @@ int mbr_reson7k3_rd_SVFiltering(int verbose, char *buffer, void *store_ptr, int 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SVFiltering = &(store->SVFiltering);
   header = &(SVFiltering->header);
 
@@ -8038,7 +7968,6 @@ int mbr_reson7k3_rd_SVFiltering(int verbose, char *buffer, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SystemLockStatus(int verbose, char *buffer, void *store_ptr, int *error){
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SystemLockStatus *SystemLockStatus;
   int index;
@@ -8052,7 +7981,7 @@ int mbr_reson7k3_rd_SystemLockStatus(int verbose, char *buffer, void *store_ptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SystemLockStatus = &(store->SystemLockStatus);
   header = &(SystemLockStatus->header);
 
@@ -8077,7 +8006,6 @@ int mbr_reson7k3_rd_SystemLockStatus(int verbose, char *buffer, void *store_ptr,
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SoundVelocity(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SoundVelocity *SoundVelocity;
   int index;
@@ -8092,7 +8020,7 @@ int mbr_reson7k3_rd_SoundVelocity(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SoundVelocity = &(store->SoundVelocity);
   header = &(SoundVelocity->header);
 
@@ -8152,7 +8080,6 @@ int mbr_reson7k3_rd_SoundVelocity(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_AbsorptionLoss(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_AbsorptionLoss *AbsorptionLoss;
   int index;
@@ -8167,7 +8094,7 @@ int mbr_reson7k3_rd_AbsorptionLoss(int verbose, char *buffer, void *store_ptr, i
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   AbsorptionLoss = &(store->AbsorptionLoss);
   header = &(AbsorptionLoss->header);
 
@@ -8227,7 +8154,6 @@ int mbr_reson7k3_rd_AbsorptionLoss(int verbose, char *buffer, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_SpreadingLoss(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   struct mbsys_reson7k3_struct *ostore = NULL;
   s7k3_header *header = NULL;
   s7k3_SpreadingLoss *SpreadingLoss;
@@ -8243,7 +8169,7 @@ int mbr_reson7k3_rd_SpreadingLoss(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SpreadingLoss = &(store->SpreadingLoss);
   header = &(SpreadingLoss->header);
 
@@ -8303,7 +8229,6 @@ int mbr_reson7k3_rd_SpreadingLoss(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RawDetection *RawDetection;
   s7k3_SegmentedRawDetection *SegmentedRawDetection;
@@ -8345,7 +8270,7 @@ int mbr_reson7k3_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
 
   /* get saved values */
   save_flag = (int *)&mb_io_ptr->save_flag;
@@ -9459,7 +9384,6 @@ int mbr_rt_reson7k3(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
   int interp_status;
   int interp_error = MB_ERROR_NO_ERROR;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_Position *Position;
   s7k3_CustomAttitude *CustomAttitude;
   s7k3_Altitude *Altitude;
@@ -9501,7 +9425,7 @@ int mbr_rt_reson7k3(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
 
   /* read next data from file */
   status = mbr_reson7k3_rd_data(verbose, mbio_ptr, store_ptr, error);
@@ -9843,7 +9767,6 @@ int mbr_rt_reson7k3(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_FileCatalog_update(int verbose, void *mbio_ptr, void *store_ptr, int size, void *header_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_FileCatalog *FileCatalog = NULL;
   s7k3_filecatalogdata *filecatalogdata = NULL;
@@ -9869,7 +9792,7 @@ int mbr_reson7k3_FileCatalog_update(int verbose, void *mbio_ptr, void *store_ptr
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)mb_io_ptr->store_data;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)mb_io_ptr->store_data;
 
   /* get pointers to data structures */
   header = (s7k3_header *)header_ptr;
@@ -9932,7 +9855,6 @@ fprintf(stderr, "^^>Update FileCatalog list: File %s Line %d type:%d n:%d\n", __
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_ReferencePoint(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_ReferencePoint *ReferencePoint;
   unsigned int checksum;
@@ -9949,7 +9871,7 @@ int mbr_reson7k3_wr_ReferencePoint(int verbose, int *bufferalloc, char **bufferp
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   ReferencePoint = &(store->ReferencePoint);
   header = &(ReferencePoint->header);
 
@@ -10029,7 +9951,6 @@ int mbr_reson7k3_wr_ReferencePoint(int verbose, int *bufferalloc, char **bufferp
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_UncalibratedSensorOffset(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_UncalibratedSensorOffset *UncalibratedSensorOffset;
   unsigned int checksum;
@@ -10046,7 +9967,7 @@ int mbr_reson7k3_wr_UncalibratedSensorOffset(int verbose, int *bufferalloc, char
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   UncalibratedSensorOffset = &(store->UncalibratedSensorOffset);
   header = &(UncalibratedSensorOffset->header);
 
@@ -10131,7 +10052,6 @@ int mbr_reson7k3_wr_UncalibratedSensorOffset(int verbose, int *bufferalloc, char
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_CalibratedSensorOffset(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CalibratedSensorOffset *CalibratedSensorOffset;
   unsigned int checksum;
@@ -10148,7 +10068,7 @@ int mbr_reson7k3_wr_CalibratedSensorOffset(int verbose, int *bufferalloc, char *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CalibratedSensorOffset = &(store->CalibratedSensorOffset);
   header = &(CalibratedSensorOffset->header);
 
@@ -10233,7 +10153,6 @@ int mbr_reson7k3_wr_CalibratedSensorOffset(int verbose, int *bufferalloc, char *
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Position(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Position *Position;
   unsigned int checksum;
@@ -10250,7 +10169,7 @@ int mbr_reson7k3_wr_Position(int verbose, int *bufferalloc, char **bufferptr, vo
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Position = &(store->Position);
   header = &(Position->header);
 
@@ -10343,7 +10262,6 @@ int mbr_reson7k3_wr_Position(int verbose, int *bufferalloc, char **bufferptr, vo
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_CustomAttitude(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CustomAttitude *CustomAttitude;
   unsigned int checksum;
@@ -10360,7 +10278,7 @@ int mbr_reson7k3_wr_CustomAttitude(int verbose, int *bufferalloc, char **bufferp
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CustomAttitude = &(store->CustomAttitude);
   header = &(CustomAttitude->header);
 
@@ -10498,7 +10416,6 @@ int mbr_reson7k3_wr_CustomAttitude(int verbose, int *bufferalloc, char **bufferp
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Tide(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Tide *Tide;
   unsigned int checksum;
@@ -10515,7 +10432,7 @@ int mbr_reson7k3_wr_Tide(int verbose, int *bufferalloc, char **bufferptr, void *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Tide = &(store->Tide);
   header = &(Tide->header);
 
@@ -10610,7 +10527,6 @@ int mbr_reson7k3_wr_Tide(int verbose, int *bufferalloc, char **bufferptr, void *
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Altitude(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Altitude *Altitude;
   unsigned int checksum;
@@ -10627,7 +10543,7 @@ int mbr_reson7k3_wr_Altitude(int verbose, int *bufferalloc, char **bufferptr, vo
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Altitude = &(store->Altitude);
   header = &(Altitude->header);
 
@@ -10702,7 +10618,6 @@ int mbr_reson7k3_wr_Altitude(int verbose, int *bufferalloc, char **bufferptr, vo
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_MotionOverGround(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_MotionOverGround *MotionOverGround;
   unsigned int checksum;
@@ -10719,7 +10634,7 @@ int mbr_reson7k3_wr_MotionOverGround(int verbose, int *bufferalloc, char **buffe
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   MotionOverGround = &(store->MotionOverGround);
   header = &(MotionOverGround->header);
 
@@ -10833,7 +10748,6 @@ int mbr_reson7k3_wr_MotionOverGround(int verbose, int *bufferalloc, char **buffe
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Depth(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Depth *Depth;
   unsigned int checksum;
@@ -10850,7 +10764,7 @@ int mbr_reson7k3_wr_Depth(int verbose, int *bufferalloc, char **bufferptr, void 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Depth = &(store->Depth);
   header = &(Depth->header);
 
@@ -10931,7 +10845,6 @@ int mbr_reson7k3_wr_Depth(int verbose, int *bufferalloc, char **bufferptr, void 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SoundVelocityProfile(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SoundVelocityProfile *SoundVelocityProfile;
   unsigned int checksum;
@@ -10948,7 +10861,7 @@ int mbr_reson7k3_wr_SoundVelocityProfile(int verbose, int *bufferalloc, char **b
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SoundVelocityProfile = &(store->SoundVelocityProfile);
   header = &(SoundVelocityProfile->header);
 
@@ -11041,7 +10954,6 @@ int mbr_reson7k3_wr_SoundVelocityProfile(int verbose, int *bufferalloc, char **b
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_CTD(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CTD *CTD;
   unsigned int checksum;
@@ -11058,7 +10970,7 @@ int mbr_reson7k3_wr_CTD(int verbose, int *bufferalloc, char **bufferptr, void *s
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CTD = &(store->CTD);
   header = &(CTD->header);
 
@@ -11169,7 +11081,6 @@ int mbr_reson7k3_wr_CTD(int verbose, int *bufferalloc, char **bufferptr, void *s
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Geodesy(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Geodesy *Geodesy;
   unsigned int checksum;
@@ -11186,7 +11097,7 @@ int mbr_reson7k3_wr_Geodesy(int verbose, int *bufferalloc, char **bufferptr, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Geodesy = &(store->Geodesy);
   header = &(Geodesy->header);
 
@@ -11319,7 +11230,6 @@ int mbr_reson7k3_wr_Geodesy(int verbose, int *bufferalloc, char **bufferptr, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_RollPitchHeave(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RollPitchHeave *RollPitchHeave;
   unsigned int checksum;
@@ -11336,7 +11246,7 @@ int mbr_reson7k3_wr_RollPitchHeave(int verbose, int *bufferalloc, char **bufferp
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RollPitchHeave = &(store->RollPitchHeave);
   header = &(RollPitchHeave->header);
 
@@ -11413,7 +11323,6 @@ int mbr_reson7k3_wr_RollPitchHeave(int verbose, int *bufferalloc, char **bufferp
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Heading(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Heading *Heading;
   unsigned int checksum;
@@ -11430,7 +11339,7 @@ int mbr_reson7k3_wr_Heading(int verbose, int *bufferalloc, char **bufferptr, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Heading = &(store->Heading);
   header = &(Heading->header);
 
@@ -11503,7 +11412,6 @@ int mbr_reson7k3_wr_Heading(int verbose, int *bufferalloc, char **bufferptr, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SurveyLine(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SurveyLine *SurveyLine;
   unsigned int checksum;
@@ -11520,7 +11428,7 @@ int mbr_reson7k3_wr_SurveyLine(int verbose, int *bufferalloc, char **bufferptr, 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SurveyLine = &(store->SurveyLine);
   header = &(SurveyLine->header);
 
@@ -11608,7 +11516,6 @@ int mbr_reson7k3_wr_SurveyLine(int verbose, int *bufferalloc, char **bufferptr, 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Navigation(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Navigation *Navigation;
   unsigned int checksum;
@@ -11625,7 +11532,7 @@ int mbr_reson7k3_wr_Navigation(int verbose, int *bufferalloc, char **bufferptr, 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Navigation = &(store->Navigation);
   header = &(Navigation->header);
 
@@ -11714,7 +11621,6 @@ int mbr_reson7k3_wr_Navigation(int verbose, int *bufferalloc, char **bufferptr, 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Attitude(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Attitude *Attitude;
   unsigned int checksum;
@@ -11731,7 +11637,7 @@ int mbr_reson7k3_wr_Attitude(int verbose, int *bufferalloc, char **bufferptr, vo
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Attitude = &(store->Attitude);
   header = &(Attitude->header);
 
@@ -11817,7 +11723,6 @@ int mbr_reson7k3_wr_Attitude(int verbose, int *bufferalloc, char **bufferptr, vo
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_PanTilt(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_PanTilt *PanTilt;
   unsigned int checksum;
@@ -11834,7 +11739,7 @@ int mbr_reson7k3_wr_PanTilt(int verbose, int *bufferalloc, char **bufferptr, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   PanTilt = &(store->PanTilt);
   header = &(PanTilt->header);
 
@@ -11905,7 +11810,6 @@ int mbr_reson7k3_wr_PanTilt(int verbose, int *bufferalloc, char **bufferptr, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SonarInstallationIDs(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SonarInstallationIDs *SonarInstallationIDs;
   unsigned int checksum;
@@ -11922,7 +11826,7 @@ int mbr_reson7k3_wr_SonarInstallationIDs(int verbose, int *bufferalloc, char **b
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SonarInstallationIDs = &(store->SonarInstallationIDs);
   header = &(SonarInstallationIDs->header);
 
@@ -11993,7 +11897,6 @@ int mbr_reson7k3_wr_SonarInstallationIDs(int verbose, int *bufferalloc, char **b
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Mystery(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Mystery *Mystery;
   unsigned int checksum;
@@ -12010,7 +11913,7 @@ int mbr_reson7k3_wr_Mystery(int verbose, int *bufferalloc, char **bufferptr, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Mystery = &(store->Mystery);
   header = &(Mystery->header);
 
@@ -12085,7 +11988,6 @@ int mbr_reson7k3_wr_Mystery(int verbose, int *bufferalloc, char **bufferptr, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SonarPipeEnvironment(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SonarPipeEnvironment *SonarPipeEnvironment;
   unsigned int checksum;
@@ -12102,7 +12004,7 @@ int mbr_reson7k3_wr_SonarPipeEnvironment(int verbose, int *bufferalloc, char **b
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SonarPipeEnvironment = &(store->SonarPipeEnvironment);
   header = &(SonarPipeEnvironment->header);
 
@@ -12174,7 +12076,6 @@ int mbr_reson7k3_wr_SonarPipeEnvironment(int verbose, int *bufferalloc, char **b
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_ContactOutput(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_ContactOutput *ContactOutput;
   unsigned int checksum;
@@ -12191,7 +12092,7 @@ int mbr_reson7k3_wr_ContactOutput(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   ContactOutput = &(store->ContactOutput);
   header = &(ContactOutput->header);
 
@@ -12262,7 +12163,6 @@ int mbr_reson7k3_wr_ContactOutput(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_ProcessedSideScan(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_ProcessedSideScan *ProcessedSideScan;
   unsigned int checksum;
@@ -12279,7 +12179,7 @@ int mbr_reson7k3_wr_ProcessedSideScan(int verbose, int *bufferalloc, char **buff
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   ProcessedSideScan = &(store->ProcessedSideScan);
   header = &(ProcessedSideScan->header);
 
@@ -12382,7 +12282,6 @@ int mbr_reson7k3_wr_ProcessedSideScan(int verbose, int *bufferalloc, char **buff
 int mbr_reson7k3_wr_SonarSettings(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size,
                                           int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SonarSettings *SonarSettings;
   unsigned int checksum;
@@ -12399,7 +12298,7 @@ int mbr_reson7k3_wr_SonarSettings(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SonarSettings = &(store->SonarSettings);
   header = &(SonarSettings->header);
 
@@ -12550,7 +12449,6 @@ int mbr_reson7k3_wr_SonarSettings(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Configuration(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Configuration *Configuration;
   s7k3_device *device;
@@ -12568,7 +12466,7 @@ int mbr_reson7k3_wr_Configuration(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Configuration = &(store->Configuration);
   header = &(Configuration->header);
 
@@ -12672,7 +12570,6 @@ int mbr_reson7k3_wr_Configuration(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_MatchFilter(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_MatchFilter *MatchFilter;
   unsigned int checksum;
@@ -12689,7 +12586,7 @@ int mbr_reson7k3_wr_MatchFilter(int verbose, int *bufferalloc, char **bufferptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   MatchFilter = &(store->MatchFilter);
   header = &(MatchFilter->header);
 
@@ -12783,7 +12680,6 @@ int mbr_reson7k3_wr_MatchFilter(int verbose, int *bufferalloc, char **bufferptr,
 int mbr_reson7k3_wr_FirmwareHardwareConfiguration(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size,
                                                     int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_FirmwareHardwareConfiguration *FirmwareHardwareConfiguration;
   unsigned int checksum;
@@ -12800,7 +12696,7 @@ int mbr_reson7k3_wr_FirmwareHardwareConfiguration(int verbose, int *bufferalloc,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   FirmwareHardwareConfiguration = &(store->FirmwareHardwareConfiguration);
   header = &(FirmwareHardwareConfiguration->header);
 
@@ -12884,7 +12780,6 @@ int mbr_reson7k3_wr_FirmwareHardwareConfiguration(int verbose, int *bufferalloc,
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_BeamGeometry(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_BeamGeometry *BeamGeometry;
   unsigned int checksum;
@@ -12901,7 +12796,7 @@ int mbr_reson7k3_wr_BeamGeometry(int verbose, int *bufferalloc, char **bufferptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   BeamGeometry = &(store->BeamGeometry);
   header = &(BeamGeometry->header);
 
@@ -12997,7 +12892,6 @@ int mbr_reson7k3_wr_BeamGeometry(int verbose, int *bufferalloc, char **bufferptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Bathymetry(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Bathymetry *Bathymetry;
   unsigned int checksum;
@@ -13014,7 +12908,7 @@ int mbr_reson7k3_wr_Bathymetry(int verbose, int *bufferalloc, char **bufferptr, 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Bathymetry = &(store->Bathymetry);
   header = &(Bathymetry->header);
 
@@ -13174,7 +13068,6 @@ int mbr_reson7k3_wr_Bathymetry(int verbose, int *bufferalloc, char **bufferptr, 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SideScan(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SideScan *SideScan;
   int data_size;
@@ -13194,7 +13087,7 @@ int mbr_reson7k3_wr_SideScan(int verbose, int *bufferalloc, char **bufferptr, vo
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SideScan = &(store->SideScan);
   header = &(SideScan->header);
 
@@ -13376,7 +13269,6 @@ int mbr_reson7k3_wr_SideScan(int verbose, int *bufferalloc, char **bufferptr, vo
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_WaterColumn(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_WaterColumn *WaterColumn;
   s7k3_wcd *wcd;
@@ -13406,7 +13298,7 @@ int mbr_reson7k3_wr_WaterColumn(int verbose, int *bufferalloc, char **bufferptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   WaterColumn = &(store->WaterColumn);
   header = &(WaterColumn->header);
 
@@ -13591,7 +13483,6 @@ int mbr_reson7k3_wr_WaterColumn(int verbose, int *bufferalloc, char **bufferptr,
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_VerticalDepth(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_VerticalDepth *VerticalDepth;
   unsigned int checksum;
@@ -13608,7 +13499,7 @@ int mbr_reson7k3_wr_VerticalDepth(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   VerticalDepth = &(store->VerticalDepth);
   header = &(VerticalDepth->header);
 
@@ -13699,7 +13590,6 @@ int mbr_reson7k3_wr_VerticalDepth(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_TVG(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_TVG *TVG;
   unsigned int checksum;
@@ -13716,7 +13606,7 @@ int mbr_reson7k3_wr_TVG(int verbose, int *bufferalloc, char **bufferptr, void *s
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   TVG = &(store->TVG);
   header = &(TVG->header);
 
@@ -13806,7 +13696,6 @@ int mbr_reson7k3_wr_TVG(int verbose, int *bufferalloc, char **bufferptr, void *s
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Image(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Image *Image;
   unsigned int checksum;
@@ -13827,7 +13716,7 @@ int mbr_reson7k3_wr_Image(int verbose, int *bufferalloc, char **bufferptr, void 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Image = &(store->Image);
   header = &(Image->header);
 
@@ -13961,7 +13850,6 @@ int mbr_reson7k3_wr_Image(int verbose, int *bufferalloc, char **bufferptr, void 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_PingMotion(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_PingMotion *PingMotion;
   unsigned int checksum;
@@ -13978,7 +13866,7 @@ int mbr_reson7k3_wr_PingMotion(int verbose, int *bufferalloc, char **bufferptr, 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   PingMotion = &(store->PingMotion);
   header = &(PingMotion->header);
 
@@ -14093,7 +13981,6 @@ int mbr_reson7k3_wr_PingMotion(int verbose, int *bufferalloc, char **bufferptr, 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_AdaptiveGate(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_AdaptiveGate *AdaptiveGate;
   unsigned int checksum;
@@ -14110,7 +13997,7 @@ int mbr_reson7k3_wr_AdaptiveGate(int verbose, int *bufferalloc, char **bufferptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   AdaptiveGate = &(store->AdaptiveGate);
   header = &(AdaptiveGate->header);
 
@@ -14182,7 +14069,6 @@ int mbr_reson7k3_wr_AdaptiveGate(int verbose, int *bufferalloc, char **bufferptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_DetectionDataSetup(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_DetectionDataSetup *DetectionDataSetup;
   unsigned int checksum;
@@ -14199,7 +14085,7 @@ int mbr_reson7k3_wr_DetectionDataSetup(int verbose, int *bufferalloc, char **buf
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   DetectionDataSetup = &(store->DetectionDataSetup);
   header = &(DetectionDataSetup->header);
 
@@ -14333,7 +14219,6 @@ int mbr_reson7k3_wr_DetectionDataSetup(int verbose, int *bufferalloc, char **buf
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Beamformed(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Beamformed *Beamformed;
   s7k3_amplitudephase *amplitudephase;
@@ -14351,7 +14236,7 @@ int mbr_reson7k3_wr_Beamformed(int verbose, int *bufferalloc, char **bufferptr, 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Beamformed = &(store->Beamformed);
   header = &(Beamformed->header);
 
@@ -14448,7 +14333,6 @@ int mbr_reson7k3_wr_Beamformed(int verbose, int *bufferalloc, char **bufferptr, 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_VernierProcessingDataRaw(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_VernierProcessingDataRaw *VernierProcessingDataRaw;
   unsigned int checksum;
@@ -14465,7 +14349,7 @@ int mbr_reson7k3_wr_VernierProcessingDataRaw(int verbose, int *bufferalloc, char
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   VernierProcessingDataRaw = &(store->VernierProcessingDataRaw);
   header = &(VernierProcessingDataRaw->header);
 
@@ -14536,7 +14420,6 @@ int mbr_reson7k3_wr_VernierProcessingDataRaw(int verbose, int *bufferalloc, char
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_BITE(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_BITE *BITE;
   s7k3_bitereport *bitereport;
@@ -14557,7 +14440,7 @@ int mbr_reson7k3_wr_BITE(int verbose, int *bufferalloc, char **bufferptr, void *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   BITE = &(store->BITE);
   header = &(BITE->header);
 
@@ -14714,7 +14597,6 @@ int mbr_reson7k3_wr_BITE(int verbose, int *bufferalloc, char **bufferptr, void *
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SonarSourceVersion(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SonarSourceVersion *SonarSourceVersion;
   unsigned int checksum;
@@ -14731,7 +14613,7 @@ int mbr_reson7k3_wr_SonarSourceVersion(int verbose, int *bufferalloc, char **buf
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SonarSourceVersion = &(store->SonarSourceVersion);
   header = &(SonarSourceVersion->header);
 
@@ -14806,7 +14688,6 @@ int mbr_reson7k3_wr_SonarSourceVersion(int verbose, int *bufferalloc, char **buf
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_WetEndVersion8k(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_WetEndVersion8k *WetEndVersion8k;
   unsigned int checksum;
@@ -14823,7 +14704,7 @@ int mbr_reson7k3_wr_WetEndVersion8k(int verbose, int *bufferalloc, char **buffer
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   WetEndVersion8k = &(store->WetEndVersion8k);
   header = &(WetEndVersion8k->header);
 
@@ -14898,7 +14779,6 @@ int mbr_reson7k3_wr_WetEndVersion8k(int verbose, int *bufferalloc, char **buffer
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_RawDetection(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RawDetection *RawDetection;
   s7k3_rawdetectiondata *rawdetectiondata;
@@ -14917,7 +14797,7 @@ int mbr_reson7k3_wr_RawDetection(int verbose, int *bufferalloc, char **bufferptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RawDetection = &(store->RawDetection);
   header = &(RawDetection->header);
 
@@ -15099,7 +14979,6 @@ int mbr_reson7k3_wr_RawDetection(int verbose, int *bufferalloc, char **bufferptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Snippet(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Snippet *Snippet;
   s7k3_snippetdata *snippetdata;
@@ -15120,7 +14999,7 @@ int mbr_reson7k3_wr_Snippet(int verbose, int *bufferalloc, char **bufferptr, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Snippet = &(store->Snippet);
   header = &(Snippet->header);
 
@@ -15287,7 +15166,6 @@ int mbr_reson7k3_wr_Snippet(int verbose, int *bufferalloc, char **bufferptr, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_VernierProcessingDataFiltered(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_VernierProcessingDataFiltered *VernierProcessingDataFiltered;
   unsigned int checksum;
@@ -15304,7 +15182,7 @@ int mbr_reson7k3_wr_VernierProcessingDataFiltered(int verbose, int *bufferalloc,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   VernierProcessingDataFiltered = &(store->VernierProcessingDataFiltered);
   header = &(VernierProcessingDataFiltered->header);
 
@@ -15376,7 +15254,6 @@ int mbr_reson7k3_wr_VernierProcessingDataFiltered(int verbose, int *bufferalloc,
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_InstallationParameters(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_InstallationParameters *InstallationParameters;
   unsigned int checksum;
@@ -15393,7 +15270,7 @@ int mbr_reson7k3_wr_InstallationParameters(int verbose, int *bufferalloc, char *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   InstallationParameters = &(store->InstallationParameters);
   header = &(InstallationParameters->header);
 
@@ -15540,7 +15417,6 @@ int mbr_reson7k3_wr_InstallationParameters(int verbose, int *bufferalloc, char *
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_BITESummary(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_BITESummary *BITESummary;
   unsigned int checksum;
@@ -15557,7 +15433,7 @@ int mbr_reson7k3_wr_BITESummary(int verbose, int *bufferalloc, char **bufferptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   BITESummary = &(store->BITESummary);
   header = &(BITESummary->header);
 
@@ -15628,7 +15504,6 @@ int mbr_reson7k3_wr_BITESummary(int verbose, int *bufferalloc, char **bufferptr,
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_CompressedBeamformedMagnitude(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CompressedBeamformedMagnitude *CompressedBeamformedMagnitude;
   unsigned int checksum;
@@ -15645,7 +15520,7 @@ int mbr_reson7k3_wr_CompressedBeamformedMagnitude(int verbose, int *bufferalloc,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CompressedBeamformedMagnitude = &(store->CompressedBeamformedMagnitude);
   header = &(CompressedBeamformedMagnitude->header);
 
@@ -15717,7 +15592,6 @@ int mbr_reson7k3_wr_CompressedBeamformedMagnitude(int verbose, int *bufferalloc,
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_CompressedWaterColumn(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CompressedWaterColumn *CompressedWaterColumn;
   s7k3_compressedwatercolumndata *compressedwatercolumndata;
@@ -15737,7 +15611,7 @@ int mbr_reson7k3_wr_CompressedWaterColumn(int verbose, int *bufferalloc, char **
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CompressedWaterColumn = &(store->CompressedWaterColumn);
   header = &(CompressedWaterColumn->header);
 
@@ -15859,7 +15733,6 @@ int mbr_reson7k3_wr_CompressedWaterColumn(int verbose, int *bufferalloc, char **
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SegmentedRawDetection(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SegmentedRawDetection *SegmentedRawDetection;
   s7k3_segmentedrawdetectiontxdata *segmentedrawdetectiontxdata;
@@ -15879,7 +15752,7 @@ int mbr_reson7k3_wr_SegmentedRawDetection(int verbose, int *bufferalloc, char **
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SegmentedRawDetection = &(store->SegmentedRawDetection);
   header = &(SegmentedRawDetection->header);
 
@@ -16089,7 +15962,6 @@ int mbr_reson7k3_wr_SegmentedRawDetection(int verbose, int *bufferalloc, char **
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_CalibratedBeam(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CalibratedBeam *CalibratedBeam;
   unsigned int checksum;
@@ -16106,7 +15978,7 @@ int mbr_reson7k3_wr_CalibratedBeam(int verbose, int *bufferalloc, char **bufferp
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CalibratedBeam = &(store->CalibratedBeam);
   header = &(CalibratedBeam->header);
 
@@ -16178,7 +16050,6 @@ int mbr_reson7k3_wr_CalibratedBeam(int verbose, int *bufferalloc, char **bufferp
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SystemEvents(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SystemEvents *SystemEvents;
   unsigned int checksum;
@@ -16195,7 +16066,7 @@ int mbr_reson7k3_wr_SystemEvents(int verbose, int *bufferalloc, char **bufferptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SystemEvents = &(store->SystemEvents);
   header = &(SystemEvents->header);
 
@@ -16267,7 +16138,6 @@ int mbr_reson7k3_wr_SystemEvents(int verbose, int *bufferalloc, char **bufferptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SystemEventMessage(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SystemEventMessage *SystemEventMessage;
   unsigned int checksum;
@@ -16284,7 +16154,7 @@ int mbr_reson7k3_wr_SystemEventMessage(int verbose, int *bufferalloc, char **buf
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SystemEventMessage = &(store->SystemEventMessage);
   header = &(SystemEventMessage->header);
 
@@ -16372,7 +16242,6 @@ int mbr_reson7k3_wr_SystemEventMessage(int verbose, int *bufferalloc, char **buf
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_RDRRecordingStatus(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RDRRecordingStatus *RDRRecordingStatus;
   unsigned int checksum;
@@ -16389,7 +16258,7 @@ int mbr_reson7k3_wr_RDRRecordingStatus(int verbose, int *bufferalloc, char **buf
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RDRRecordingStatus = &(store->RDRRecordingStatus);
   header = &(RDRRecordingStatus->header);
 
@@ -16461,7 +16330,6 @@ int mbr_reson7k3_wr_RDRRecordingStatus(int verbose, int *bufferalloc, char **buf
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_Subscriptions(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_Subscriptions *Subscriptions;
   unsigned int checksum;
@@ -16478,7 +16346,7 @@ int mbr_reson7k3_wr_Subscriptions(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   Subscriptions = &(store->Subscriptions);
   header = &(Subscriptions->header);
 
@@ -16550,7 +16418,6 @@ int mbr_reson7k3_wr_Subscriptions(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_RDRStorageRecording(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RDRStorageRecording *RDRStorageRecording;
   unsigned int checksum;
@@ -16567,7 +16434,7 @@ int mbr_reson7k3_wr_RDRStorageRecording(int verbose, int *bufferalloc, char **bu
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RDRStorageRecording = &(store->RDRStorageRecording);
   header = &(RDRStorageRecording->header);
 
@@ -16638,7 +16505,6 @@ int mbr_reson7k3_wr_RDRStorageRecording(int verbose, int *bufferalloc, char **bu
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_CalibrationStatus(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CalibrationStatus *CalibrationStatus;
   unsigned int checksum;
@@ -16655,7 +16521,7 @@ int mbr_reson7k3_wr_CalibrationStatus(int verbose, int *bufferalloc, char **buff
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CalibrationStatus = &(store->CalibrationStatus);
   header = &(CalibrationStatus->header);
 
@@ -16726,7 +16592,6 @@ int mbr_reson7k3_wr_CalibrationStatus(int verbose, int *bufferalloc, char **buff
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_CalibratedSideScan(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CalibratedSideScan *CalibratedSideScan;
   unsigned int checksum;
@@ -16743,7 +16608,7 @@ int mbr_reson7k3_wr_CalibratedSideScan(int verbose, int *bufferalloc, char **buf
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CalibratedSideScan = &(store->CalibratedSideScan);
   header = &(CalibratedSideScan->header);
 
@@ -16815,7 +16680,6 @@ int mbr_reson7k3_wr_CalibratedSideScan(int verbose, int *bufferalloc, char **buf
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SnippetBackscatteringStrength(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SnippetBackscatteringStrength *SnippetBackscatteringStrength;
   unsigned int checksum;
@@ -16832,7 +16696,7 @@ int mbr_reson7k3_wr_SnippetBackscatteringStrength(int verbose, int *bufferalloc,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SnippetBackscatteringStrength = &(store->SnippetBackscatteringStrength);
   header = &(SnippetBackscatteringStrength->header);
 
@@ -16904,7 +16768,6 @@ int mbr_reson7k3_wr_SnippetBackscatteringStrength(int verbose, int *bufferalloc,
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_MB2Status(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_MB2Status *MB2Status;
   unsigned int checksum;
@@ -16921,7 +16784,7 @@ int mbr_reson7k3_wr_MB2Status(int verbose, int *bufferalloc, char **bufferptr, v
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   MB2Status = &(store->MB2Status);
   header = &(MB2Status->header);
 
@@ -16992,7 +16855,6 @@ int mbr_reson7k3_wr_MB2Status(int verbose, int *bufferalloc, char **bufferptr, v
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_FileHeader(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_FileHeader *FileHeader;
   s7k3_subsystem *subsystem;
@@ -17010,7 +16872,7 @@ int mbr_reson7k3_wr_FileHeader(int verbose, int *bufferalloc, char **bufferptr, 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   FileHeader = &(store->FileHeader);
   header = &(FileHeader->header);
 
@@ -17145,7 +17007,6 @@ int mbr_reson7k3_wr_FileHeader(int verbose, int *bufferalloc, char **bufferptr, 
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_TimeMessage(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_TimeMessage *TimeMessage;
   unsigned int checksum;
@@ -17162,7 +17023,7 @@ int mbr_reson7k3_wr_TimeMessage(int verbose, int *bufferalloc, char **bufferptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   TimeMessage = &(store->TimeMessage);
   header = &(TimeMessage->header);
 
@@ -17233,7 +17094,6 @@ int mbr_reson7k3_wr_TimeMessage(int verbose, int *bufferalloc, char **bufferptr,
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_RemoteControl(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RemoteControl *RemoteControl;
   unsigned int checksum;
@@ -17250,7 +17110,7 @@ int mbr_reson7k3_wr_RemoteControl(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RemoteControl = &(store->RemoteControl);
   header = &(RemoteControl->header);
 
@@ -17321,7 +17181,6 @@ int mbr_reson7k3_wr_RemoteControl(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_RemoteControlAcknowledge(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RemoteControlAcknowledge *RemoteControlAcknowledge;
   unsigned int checksum;
@@ -17338,7 +17197,7 @@ int mbr_reson7k3_wr_RemoteControlAcknowledge(int verbose, int *bufferalloc, char
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RemoteControlAcknowledge = &(store->RemoteControlAcknowledge);
   header = &(RemoteControlAcknowledge->header);
 
@@ -17409,7 +17268,6 @@ int mbr_reson7k3_wr_RemoteControlAcknowledge(int verbose, int *bufferalloc, char
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_RemoteControlNotAcknowledge(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RemoteControlNotAcknowledge *RemoteControlNotAcknowledge;
   unsigned int checksum;
@@ -17426,7 +17284,7 @@ int mbr_reson7k3_wr_RemoteControlNotAcknowledge(int verbose, int *bufferalloc, c
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RemoteControlNotAcknowledge = &(store->RemoteControlNotAcknowledge);
   header = &(RemoteControlNotAcknowledge->header);
 
@@ -17498,7 +17356,6 @@ int mbr_reson7k3_wr_RemoteControlNotAcknowledge(int verbose, int *bufferalloc, c
 int mbr_reson7k3_wr_RemoteControlSonarSettings(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size,
                                           int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_RemoteControlSonarSettings *RemoteControlSonarSettings;
   unsigned int checksum;
@@ -17515,7 +17372,7 @@ int mbr_reson7k3_wr_RemoteControlSonarSettings(int verbose, int *bufferalloc, ch
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   RemoteControlSonarSettings = &(store->RemoteControlSonarSettings);
   header = &(RemoteControlSonarSettings->header);
 
@@ -17729,7 +17586,6 @@ int mbr_reson7k3_wr_RemoteControlSonarSettings(int verbose, int *bufferalloc, ch
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_CommonSystemSettings(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_CommonSystemSettings *CommonSystemSettings;
   unsigned int checksum;
@@ -17746,7 +17602,7 @@ int mbr_reson7k3_wr_CommonSystemSettings(int verbose, int *bufferalloc, char **b
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CommonSystemSettings = &(store->CommonSystemSettings);
   header = &(CommonSystemSettings->header);
 
@@ -17937,7 +17793,6 @@ int mbr_reson7k3_wr_CommonSystemSettings(int verbose, int *bufferalloc, char **b
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SVFiltering(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SVFiltering *SVFiltering;
   unsigned int checksum;
@@ -17954,7 +17809,7 @@ int mbr_reson7k3_wr_SVFiltering(int verbose, int *bufferalloc, char **bufferptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SVFiltering = &(store->SVFiltering);
   header = &(SVFiltering->header);
 
@@ -18025,7 +17880,6 @@ int mbr_reson7k3_wr_SVFiltering(int verbose, int *bufferalloc, char **bufferptr,
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SystemLockStatus(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SystemLockStatus *SystemLockStatus;
   unsigned int checksum;
@@ -18042,7 +17896,7 @@ int mbr_reson7k3_wr_SystemLockStatus(int verbose, int *bufferalloc, char **buffe
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SystemLockStatus = &(store->SystemLockStatus);
   header = &(SystemLockStatus->header);
 
@@ -18113,7 +17967,6 @@ int mbr_reson7k3_wr_SystemLockStatus(int verbose, int *bufferalloc, char **buffe
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SoundVelocity(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SoundVelocity *SoundVelocity;
   unsigned int checksum;
@@ -18130,7 +17983,7 @@ int mbr_reson7k3_wr_SoundVelocity(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SoundVelocity = &(store->SoundVelocity);
   header = &(SoundVelocity->header);
 
@@ -18205,7 +18058,6 @@ int mbr_reson7k3_wr_SoundVelocity(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_AbsorptionLoss(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_AbsorptionLoss *AbsorptionLoss;
   unsigned int checksum;
@@ -18222,7 +18074,7 @@ int mbr_reson7k3_wr_AbsorptionLoss(int verbose, int *bufferalloc, char **bufferp
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   AbsorptionLoss = &(store->AbsorptionLoss);
   header = &(AbsorptionLoss->header);
 
@@ -18297,7 +18149,6 @@ int mbr_reson7k3_wr_AbsorptionLoss(int verbose, int *bufferalloc, char **bufferp
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_SpreadingLoss(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_header *header = NULL;
   s7k3_SpreadingLoss *SpreadingLoss;
   unsigned int checksum;
@@ -18314,7 +18165,7 @@ int mbr_reson7k3_wr_SpreadingLoss(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SpreadingLoss = &(store->SpreadingLoss);
   header = &(SpreadingLoss->header);
 
@@ -18389,7 +18240,6 @@ int mbr_reson7k3_wr_SpreadingLoss(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7k3_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
   struct mbsys_reson7k3_struct *ostore = NULL;
   FILE *mbfp = NULL;
   char **bufferptr = NULL;
@@ -18412,7 +18262,7 @@ int mbr_reson7k3_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   ostore = (struct mbsys_reson7k3_struct *)mb_io_ptr->store_data;
   mbfp = mb_io_ptr->mbfp;
 
@@ -19423,7 +19273,6 @@ int mbr_reson7k3_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbr_wt_reson7k3(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k3_struct *store = NULL;
 
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
@@ -19437,7 +19286,7 @@ int mbr_wt_reson7k3(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
 
   /* write next data to file */
   status = mbr_reson7k3_wr_data(verbose, mbio_ptr, store_ptr, error);

--- a/src/mbio/mbr_reson7kr.c
+++ b/src/mbio/mbr_reson7kr.c
@@ -723,7 +723,6 @@ int mbr_reson7kr_rd_header(int verbose, char *buffer, int *index, s7k_header *he
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_reference(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_reference *reference;
   int index;
@@ -738,7 +737,7 @@ int mbr_reson7kr_rd_reference(int verbose, char *buffer, void *store_ptr, int *e
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   reference = &(store->reference);
   header = &(reference->header);
 
@@ -804,7 +803,6 @@ int mbr_reson7kr_rd_reference(int verbose, char *buffer, void *store_ptr, int *e
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_sensoruncal(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_sensoruncal *sensoruncal;
   int index;
@@ -819,7 +817,7 @@ int mbr_reson7kr_rd_sensoruncal(int verbose, char *buffer, void *store_ptr, int 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   sensoruncal = &(store->sensoruncal);
   header = &(sensoruncal->header);
 
@@ -889,7 +887,6 @@ int mbr_reson7kr_rd_sensoruncal(int verbose, char *buffer, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_sensorcal(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_sensorcal *sensorcal;
   int index;
@@ -904,7 +901,7 @@ int mbr_reson7kr_rd_sensorcal(int verbose, char *buffer, void *store_ptr, int *e
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   sensorcal = &(store->sensorcal);
   header = &(sensorcal->header);
 
@@ -974,7 +971,6 @@ int mbr_reson7kr_rd_sensorcal(int verbose, char *buffer, void *store_ptr, int *e
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_position(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_position *position;
   int index;
@@ -989,7 +985,7 @@ int mbr_reson7kr_rd_position(int verbose, char *buffer, void *store_ptr, int *er
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   position = &(store->position);
   header = &(position->header);
 
@@ -1065,7 +1061,6 @@ int mbr_reson7kr_rd_position(int verbose, char *buffer, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_customattitude(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_customattitude *customattitude;
   int data_size;
@@ -1082,7 +1077,7 @@ int mbr_reson7kr_rd_customattitude(int verbose, char *buffer, void *store_ptr, i
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   customattitude = &(store->customattitude);
   header = &(customattitude->header);
 
@@ -1216,7 +1211,6 @@ int mbr_reson7kr_rd_customattitude(int verbose, char *buffer, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_tide(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_tide *tide;
   int index;
@@ -1231,7 +1225,7 @@ int mbr_reson7kr_rd_tide(int verbose, char *buffer, void *store_ptr, int *error)
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   tide = &(store->tide);
   header = &(tide->header);
 
@@ -1311,7 +1305,6 @@ int mbr_reson7kr_rd_tide(int verbose, char *buffer, void *store_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_altitude(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_altitude *altitude;
   int index;
@@ -1326,7 +1319,7 @@ int mbr_reson7kr_rd_altitude(int verbose, char *buffer, void *store_ptr, int *er
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   altitude = &(store->altitude);
   header = &(altitude->header);
 
@@ -1386,7 +1379,6 @@ int mbr_reson7kr_rd_altitude(int verbose, char *buffer, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_motion(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_motion *motion;
   int data_size;
@@ -1403,7 +1395,7 @@ int mbr_reson7kr_rd_motion(int verbose, char *buffer, void *store_ptr, int *erro
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   motion = &(store->motion);
   header = &(motion->header);
 
@@ -1521,7 +1513,6 @@ int mbr_reson7kr_rd_motion(int verbose, char *buffer, void *store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_depth(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_depth *depth;
   int index;
@@ -1536,7 +1527,7 @@ int mbr_reson7kr_rd_depth(int verbose, char *buffer, void *store_ptr, int *error
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   depth = &(store->depth);
   header = &(depth->header);
 
@@ -1602,7 +1593,6 @@ int mbr_reson7kr_rd_depth(int verbose, char *buffer, void *store_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_svp(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_svp *svp;
   int data_size;
@@ -1619,7 +1609,7 @@ int mbr_reson7kr_rd_svp(int verbose, char *buffer, void *store_ptr, int *error) 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   svp = &(store->svp);
   header = &(svp->header);
 
@@ -1711,7 +1701,6 @@ int mbr_reson7kr_rd_svp(int verbose, char *buffer, void *store_ptr, int *error) 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_ctd(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_ctd *ctd;
   int data_size;
@@ -1728,7 +1717,7 @@ int mbr_reson7kr_rd_ctd(int verbose, char *buffer, void *store_ptr, int *error) 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   ctd = &(store->ctd);
   header = &(ctd->header);
 
@@ -1844,7 +1833,6 @@ int mbr_reson7kr_rd_ctd(int verbose, char *buffer, void *store_ptr, int *error) 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_geodesy(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_geodesy *geodesy;
   int index;
@@ -1860,7 +1848,7 @@ int mbr_reson7kr_rd_geodesy(int verbose, char *buffer, void *store_ptr, int *err
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   geodesy = &(store->geodesy);
   header = &(geodesy->header);
 
@@ -1980,7 +1968,6 @@ int mbr_reson7kr_rd_geodesy(int verbose, char *buffer, void *store_ptr, int *err
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_rollpitchheave(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_rollpitchheave *rollpitchheave;
   int index;
@@ -1995,7 +1982,7 @@ int mbr_reson7kr_rd_rollpitchheave(int verbose, char *buffer, void *store_ptr, i
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   rollpitchheave = &(store->rollpitchheave);
   header = &(rollpitchheave->header);
 
@@ -2059,7 +2046,6 @@ int mbr_reson7kr_rd_rollpitchheave(int verbose, char *buffer, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_heading(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_heading *heading;
   int index;
@@ -2074,7 +2060,7 @@ int mbr_reson7kr_rd_heading(int verbose, char *buffer, void *store_ptr, int *err
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   heading = &(store->heading);
   header = &(heading->header);
 
@@ -2134,7 +2120,6 @@ int mbr_reson7kr_rd_heading(int verbose, char *buffer, void *store_ptr, int *err
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_surveyline(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_surveyline *surveyline;
   int data_size;
@@ -2151,7 +2136,7 @@ int mbr_reson7kr_rd_surveyline(int verbose, char *buffer, void *store_ptr, int *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   surveyline = &(store->surveyline);
   header = &(surveyline->header);
 
@@ -2241,7 +2226,6 @@ int mbr_reson7kr_rd_surveyline(int verbose, char *buffer, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_navigation(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_navigation *navigation;
   int index;
@@ -2256,7 +2240,7 @@ int mbr_reson7kr_rd_navigation(int verbose, char *buffer, void *store_ptr, int *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   navigation = &(store->navigation);
   header = &(navigation->header);
 
@@ -2332,7 +2316,6 @@ int mbr_reson7kr_rd_navigation(int verbose, char *buffer, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_attitude(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_attitude *attitude;
   int data_size;
@@ -2349,7 +2332,7 @@ int mbr_reson7kr_rd_attitude(int verbose, char *buffer, void *store_ptr, int *er
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   attitude = &(store->attitude);
   header = &(attitude->header);
 
@@ -2444,7 +2427,6 @@ int mbr_reson7kr_rd_attitude(int verbose, char *buffer, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_rec1022(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_rec1022 *rec1022;
   int index;
@@ -2460,7 +2442,7 @@ int mbr_reson7kr_rd_rec1022(int verbose, char *buffer, void *store_ptr, int *err
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   rec1022 = &(store->rec1022);
   header = &(rec1022->header);
 
@@ -2906,7 +2888,6 @@ int mbr_reson7kr_rd_fsdwsegyheader(int verbose, char *buffer, int *index, s7k_fs
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_fsdwsslo(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_fsdwss *fsdwsslo;
   s7k_fsdwchannel *fsdwchannel;
@@ -2927,7 +2908,7 @@ int mbr_reson7kr_rd_fsdwsslo(int verbose, char *buffer, void *store_ptr, int *er
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   fsdwsslo = &(store->fsdwsslo);
   header = &(fsdwsslo->header);
   bathymetry = &(store->bathymetry);
@@ -3209,7 +3190,6 @@ int mbr_reson7kr_rd_fsdwsslo(int verbose, char *buffer, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_fsdwsshi(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_fsdwss *fsdwsshi;
   s7k_fsdwchannel *fsdwchannel;
@@ -3229,7 +3209,7 @@ int mbr_reson7kr_rd_fsdwsshi(int verbose, char *buffer, void *store_ptr, int *er
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   fsdwsshi = &(store->fsdwsshi);
   header = &(fsdwsshi->header);
   bathymetry = &(store->bathymetry);
@@ -3373,7 +3353,6 @@ int mbr_reson7kr_rd_fsdwsshi(int verbose, char *buffer, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_fsdwsb(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_fsdwsb *fsdwsb;
   s7k_fsdwchannel *fsdwchannel;
@@ -3395,7 +3374,7 @@ int mbr_reson7kr_rd_fsdwsb(int verbose, char *buffer, void *store_ptr, int *erro
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   fsdwsb = &(store->fsdwsb);
   header = &(fsdwsb->header);
   bathymetry = &store->bathymetry;
@@ -3536,7 +3515,6 @@ int mbr_reson7kr_rd_fsdwsb(int verbose, char *buffer, void *store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_bluefin(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_bluefin *bluefin;
   int index;
@@ -3556,7 +3534,7 @@ int mbr_reson7kr_rd_bluefin(int verbose, char *buffer, void *store_ptr, int *err
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bluefin = &(store->bluefin);
   header = &(bluefin->header);
 
@@ -3956,7 +3934,6 @@ fprintf(stderr,"Bluefin nav[%d].depth_time:         %f\n",i,bluefin->nav[i].dept
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_processedsidescan(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_processedsidescan *processedsidescan;
   int index;
@@ -3972,7 +3949,7 @@ int mbr_reson7kr_rd_processedsidescan(int verbose, char *buffer, void *store_ptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   processedsidescan = &(store->processedsidescan);
   header = &(processedsidescan->header);
 
@@ -4060,7 +4037,6 @@ int mbr_reson7kr_rd_processedsidescan(int verbose, char *buffer, void *store_ptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_volatilesonarsettings(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_volatilesettings *volatilesettings;
   int index;
@@ -4075,7 +4051,7 @@ int mbr_reson7kr_rd_volatilesonarsettings(int verbose, char *buffer, void *store
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   volatilesettings = &(store->volatilesettings);
   header = &(volatilesettings->header);
 
@@ -4211,7 +4187,6 @@ int mbr_reson7kr_rd_volatilesonarsettings(int verbose, char *buffer, void *store
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_configuration(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_configuration *configuration;
   s7k_device *device;
@@ -4229,7 +4204,7 @@ int mbr_reson7kr_rd_configuration(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   configuration = &(store->configuration);
   header = &(configuration->header);
 
@@ -4324,7 +4299,6 @@ int mbr_reson7kr_rd_configuration(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_matchfilter(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_matchfilter *matchfilter;
   int index;
@@ -4339,7 +4313,7 @@ int mbr_reson7kr_rd_matchfilter(int verbose, char *buffer, void *store_ptr, int 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   matchfilter = &(store->matchfilter);
   header = &(matchfilter->header);
 
@@ -4407,7 +4381,6 @@ int mbr_reson7kr_rd_matchfilter(int verbose, char *buffer, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_v2firmwarehardwareconfiguration(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2firmwarehardwareconfiguration *v2firmwarehardwareconfiguration;
   int index;
@@ -4424,7 +4397,7 @@ int mbr_reson7kr_rd_v2firmwarehardwareconfiguration(int verbose, char *buffer, v
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2firmwarehardwareconfiguration = &(store->v2firmwarehardwareconfiguration);
   header = &(v2firmwarehardwareconfiguration->header);
 
@@ -4504,7 +4477,6 @@ int mbr_reson7kr_rd_v2firmwarehardwareconfiguration(int verbose, char *buffer, v
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_beamgeometry(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_beamgeometry *beamgeometry;
   int index;
@@ -4520,7 +4492,7 @@ int mbr_reson7kr_rd_beamgeometry(int verbose, char *buffer, void *store_ptr, int
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   beamgeometry = &(store->beamgeometry);
   header = &(beamgeometry->header);
 
@@ -4600,7 +4572,6 @@ int mbr_reson7kr_rd_beamgeometry(int verbose, char *buffer, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_calibration(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_calibration *calibration;
   int index;
@@ -4616,7 +4587,7 @@ int mbr_reson7kr_rd_calibration(int verbose, char *buffer, void *store_ptr, int 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   calibration = &(store->calibration);
   header = &(calibration->header);
 
@@ -4688,7 +4659,6 @@ int mbr_reson7kr_rd_calibration(int verbose, char *buffer, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_bathymetry(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_bathymetry *bathymetry;
   int index;
@@ -4705,7 +4675,7 @@ int mbr_reson7kr_rd_bathymetry(int verbose, char *buffer, void *store_ptr, int *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bathymetry = &(store->bathymetry);
   header = &(bathymetry->header);
 
@@ -4903,7 +4873,6 @@ int mbr_reson7kr_rd_bathymetry(int verbose, char *buffer, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_backscatter(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_backscatter *backscatter;
   int data_size;
@@ -4922,7 +4891,7 @@ int mbr_reson7kr_rd_backscatter(int verbose, char *buffer, void *store_ptr, int 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   backscatter = &(store->backscatter);
   header = &(backscatter->header);
 
@@ -5091,7 +5060,6 @@ int mbr_reson7kr_rd_backscatter(int verbose, char *buffer, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_beam(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_beam *beam;
   s7kr_snippet *snippet;
@@ -5121,7 +5089,7 @@ int mbr_reson7kr_rd_beam(int verbose, char *buffer, void *store_ptr, int *error)
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   beam = &(store->beam);
   header = &(beam->header);
 
@@ -5305,7 +5273,6 @@ int mbr_reson7kr_rd_beam(int verbose, char *buffer, void *store_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_verticaldepth(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_verticaldepth *verticaldepth;
   int index;
@@ -5320,7 +5287,7 @@ int mbr_reson7kr_rd_verticaldepth(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   verticaldepth = &(store->verticaldepth);
   header = &(verticaldepth->header);
 
@@ -5396,7 +5363,6 @@ int mbr_reson7kr_rd_verticaldepth(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_tvg(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_tvg *tvg;
   int index;
@@ -5413,7 +5379,7 @@ int mbr_reson7kr_rd_tvg(int verbose, char *buffer, void *store_ptr, int *error) 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   tvg = &(store->tvg);
   header = &(tvg->header);
 
@@ -5497,7 +5463,6 @@ int mbr_reson7kr_rd_tvg(int verbose, char *buffer, void *store_ptr, int *error) 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_image(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_image *image;
   int index;
@@ -5517,7 +5482,7 @@ int mbr_reson7kr_rd_image(int verbose, char *buffer, void *store_ptr, int *error
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   image = &(store->image);
   header = &(image->header);
 
@@ -5625,7 +5590,6 @@ int mbr_reson7kr_rd_image(int verbose, char *buffer, void *store_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_v2pingmotion(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2pingmotion *v2pingmotion;
   int index;
@@ -5641,7 +5605,7 @@ int mbr_reson7kr_rd_v2pingmotion(int verbose, char *buffer, void *store_ptr, int
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2pingmotion = &(store->v2pingmotion);
   header = &(v2pingmotion->header);
 
@@ -5772,7 +5736,6 @@ int mbr_reson7kr_rd_v2pingmotion(int verbose, char *buffer, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_v2detectionsetup(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2detectionsetup *v2detectionsetup;
   int index;
@@ -5788,7 +5751,7 @@ int mbr_reson7kr_rd_v2detectionsetup(int verbose, char *buffer, void *store_ptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2detectionsetup = &(store->v2detectionsetup);
   header = &(v2detectionsetup->header);
 
@@ -5909,7 +5872,6 @@ int mbr_reson7kr_rd_v2detectionsetup(int verbose, char *buffer, void *store_ptr,
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_v2beamformed(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2beamformed *v2beamformed;
   s7kr_v2amplitudephase *v2amplitudephase;
@@ -5926,7 +5888,7 @@ int mbr_reson7kr_rd_v2beamformed(int verbose, char *buffer, void *store_ptr, int
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2beamformed = &(store->v2beamformed);
   header = &(v2beamformed->header);
 
@@ -6030,7 +5992,6 @@ int mbr_reson7kr_rd_v2beamformed(int verbose, char *buffer, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_v2bite(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2bite *v2bite;
   s7kr_v2bitereport *report;
@@ -6049,7 +6010,7 @@ int mbr_reson7kr_rd_v2bite(int verbose, char *buffer, void *store_ptr, int *erro
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2bite = &(store->v2bite);
   header = &(v2bite->header);
 
@@ -6200,7 +6161,6 @@ int mbr_reson7kr_rd_v2bite(int verbose, char *buffer, void *store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_v27kcenterversion(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v27kcenterversion *v27kcenterversion;
   int index;
@@ -6216,7 +6176,7 @@ int mbr_reson7kr_rd_v27kcenterversion(int verbose, char *buffer, void *store_ptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v27kcenterversion = &(store->v27kcenterversion);
   header = &(v27kcenterversion->header);
 
@@ -6278,7 +6238,6 @@ int mbr_reson7kr_rd_v27kcenterversion(int verbose, char *buffer, void *store_ptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_v28kwetendversion(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v28kwetendversion *v28kwetendversion;
   int index;
@@ -6294,7 +6253,7 @@ int mbr_reson7kr_rd_v28kwetendversion(int verbose, char *buffer, void *store_ptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v28kwetendversion = &(store->v28kwetendversion);
   header = &(v28kwetendversion->header);
 
@@ -6356,7 +6315,6 @@ int mbr_reson7kr_rd_v28kwetendversion(int verbose, char *buffer, void *store_ptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_v2detection(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2detection *v2detection;
   int index;
@@ -6372,7 +6330,7 @@ int mbr_reson7kr_rd_v2detection(int verbose, char *buffer, void *store_ptr, int 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2detection = &(store->v2detection);
   header = &(v2detection->header);
 
@@ -6470,7 +6428,6 @@ int mbr_reson7kr_rd_v2detection(int verbose, char *buffer, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_v2rawdetection(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2rawdetection *v2rawdetection;
   s7kr_bathymetry *bathymetry;
@@ -6488,7 +6445,7 @@ int mbr_reson7kr_rd_v2rawdetection(int verbose, char *buffer, void *store_ptr, i
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2rawdetection = &(store->v2rawdetection);
   header = &(v2rawdetection->header);
   bathymetry = &(store->bathymetry);
@@ -6600,7 +6557,6 @@ int mbr_reson7kr_rd_v2rawdetection(int verbose, char *buffer, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_v2snippet(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2snippet *v2snippet;
   s7kr_v2snippettimeseries *snippettimeseries;
@@ -6617,7 +6573,7 @@ int mbr_reson7kr_rd_v2snippet(int verbose, char *buffer, void *store_ptr, int *e
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2snippet = &(store->v2snippet);
   header = &(v2snippet->header);
 
@@ -6728,7 +6684,6 @@ int mbr_reson7kr_rd_v2snippet(int verbose, char *buffer, void *store_ptr, int *e
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_calibratedsnippet(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_calibratedsnippet *calibratedsnippet;
   s7kr_calibratedsnippettimeseries *calibratedsnippettimeseries;
@@ -6745,7 +6700,7 @@ int mbr_reson7kr_rd_calibratedsnippet(int verbose, char *buffer, void *store_ptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   calibratedsnippet = &(store->calibratedsnippet);
   header = &(calibratedsnippet->header);
 
@@ -6858,7 +6813,6 @@ int mbr_reson7kr_rd_calibratedsnippet(int verbose, char *buffer, void *store_ptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_installation(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_installation *installation;
   int index;
@@ -6874,7 +6828,7 @@ int mbr_reson7kr_rd_installation(int verbose, char *buffer, void *store_ptr, int
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   installation = &(store->installation);
   header = &(installation->header);
 
@@ -7006,7 +6960,6 @@ int mbr_reson7kr_rd_installation(int verbose, char *buffer, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_fileheader(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_fileheader *fileheader;
   s7kr_subsystem *subsystem;
@@ -7023,7 +6976,7 @@ int mbr_reson7kr_rd_fileheader(int verbose, char *buffer, void *store_ptr, int *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   fileheader = &(store->fileheader);
   header = &(fileheader->header);
 
@@ -7123,7 +7076,6 @@ int mbr_reson7kr_rd_fileheader(int verbose, char *buffer, void *store_ptr, int *
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_systemeventmessage(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_systemeventmessage *systemeventmessage;
   int data_size;
@@ -7140,7 +7092,7 @@ int mbr_reson7kr_rd_systemeventmessage(int verbose, char *buffer, void *store_pt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   systemeventmessage = &(store->systemeventmessage);
   header = &(systemeventmessage->header);
 
@@ -7225,7 +7177,6 @@ int mbr_reson7kr_rd_systemeventmessage(int verbose, char *buffer, void *store_pt
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_remotecontrolsettings(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_remotecontrolsettings *remotecontrolsettings;
   int index;
@@ -7241,7 +7192,7 @@ int mbr_reson7kr_rd_remotecontrolsettings(int verbose, char *buffer, void *store
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   remotecontrolsettings = &(store->remotecontrolsettings);
   header = &(remotecontrolsettings->header);
 
@@ -7406,7 +7357,6 @@ int mbr_reson7kr_rd_remotecontrolsettings(int verbose, char *buffer, void *store
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_reserved(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_reserved *reserved;
   int index;
@@ -7422,7 +7372,7 @@ int mbr_reson7kr_rd_reserved(int verbose, char *buffer, void *store_ptr, int *er
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   reserved = &(store->reserved);
   header = &(reserved->header);
 
@@ -7484,7 +7434,6 @@ int mbr_reson7kr_rd_reserved(int verbose, char *buffer, void *store_ptr, int *er
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_roll(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_roll *roll;
   int index;
@@ -7499,7 +7448,7 @@ int mbr_reson7kr_rd_roll(int verbose, char *buffer, void *store_ptr, int *error)
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   roll = &(store->roll);
   header = &(roll->header);
 
@@ -7559,7 +7508,6 @@ int mbr_reson7kr_rd_roll(int verbose, char *buffer, void *store_ptr, int *error)
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_pitch(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_pitch *pitch;
   int index;
@@ -7574,7 +7522,7 @@ int mbr_reson7kr_rd_pitch(int verbose, char *buffer, void *store_ptr, int *error
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   pitch = &(store->pitch);
   header = &(pitch->header);
 
@@ -7634,7 +7582,6 @@ int mbr_reson7kr_rd_pitch(int verbose, char *buffer, void *store_ptr, int *error
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_soundvelocity(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_soundvelocity *soundvelocity;
   int index;
@@ -7649,7 +7596,7 @@ int mbr_reson7kr_rd_soundvelocity(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   soundvelocity = &(store->soundvelocity);
   header = &(soundvelocity->header);
 
@@ -7709,7 +7656,6 @@ int mbr_reson7kr_rd_soundvelocity(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_absorptionloss(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_absorptionloss *absorptionloss;
   int index;
@@ -7724,7 +7670,7 @@ int mbr_reson7kr_rd_absorptionloss(int verbose, char *buffer, void *store_ptr, i
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   absorptionloss = &(store->absorptionloss);
   header = &(absorptionloss->header);
 
@@ -7784,7 +7730,6 @@ int mbr_reson7kr_rd_absorptionloss(int verbose, char *buffer, void *store_ptr, i
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_spreadingloss(int verbose, char *buffer, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_spreadingloss *spreadingloss;
   int index;
@@ -7799,7 +7744,7 @@ int mbr_reson7kr_rd_spreadingloss(int verbose, char *buffer, void *store_ptr, in
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   spreadingloss = &(store->spreadingloss);
   header = &(spreadingloss->header);
 
@@ -7859,7 +7804,6 @@ int mbr_reson7kr_rd_spreadingloss(int verbose, char *buffer, void *store_ptr, in
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_fsdwss *fsdwsslo;
   s7kr_fsdwss *fsdwsshi;
@@ -7915,7 +7859,7 @@ int mbr_reson7kr_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   mbfp = mb_io_ptr->mbfp;
 
   /* get saved values */
@@ -9086,7 +9030,6 @@ int mbr_rt_reson7kr(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
   int interp_status;
   int interp_error = MB_ERROR_NO_ERROR;
-  struct mbsys_reson7k_struct *store;
   s7kr_position *position;
   s7kr_navigation *navigation;
   s7kr_attitude *attitude;
@@ -9131,7 +9074,7 @@ int mbr_rt_reson7kr(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   status = mbr_reson7kr_rd_data(verbose, mbio_ptr, store_ptr, error);
 
   /* get pointers to data structures */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   position = &store->position;
   attitude = &store->attitude;
   volatilesettings = &store->volatilesettings;
@@ -9669,7 +9612,6 @@ int mbr_reson7kr_wr_header(int verbose, char *buffer, int *index, s7k_header *he
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_reference(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_reference *reference;
   unsigned int checksum;
@@ -9687,7 +9629,7 @@ int mbr_reson7kr_wr_reference(int verbose, int *bufferalloc, char **bufferptr, v
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   reference = &(store->reference);
   header = &(reference->header);
 
@@ -9767,7 +9709,6 @@ int mbr_reson7kr_wr_reference(int verbose, int *bufferalloc, char **bufferptr, v
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_sensoruncal(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_sensoruncal *sensoruncal;
   unsigned int checksum;
@@ -9785,7 +9726,7 @@ int mbr_reson7kr_wr_sensoruncal(int verbose, int *bufferalloc, char **bufferptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   sensoruncal = &(store->sensoruncal);
   header = &(sensoruncal->header);
 
@@ -9870,7 +9811,6 @@ int mbr_reson7kr_wr_sensoruncal(int verbose, int *bufferalloc, char **bufferptr,
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_sensorcal(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_sensorcal *sensorcal;
   unsigned int checksum;
@@ -9888,7 +9828,7 @@ int mbr_reson7kr_wr_sensorcal(int verbose, int *bufferalloc, char **bufferptr, v
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   sensorcal = &(store->sensorcal);
   header = &(sensorcal->header);
 
@@ -9973,7 +9913,6 @@ int mbr_reson7kr_wr_sensorcal(int verbose, int *bufferalloc, char **bufferptr, v
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_position(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_position *position;
   unsigned int checksum;
@@ -9991,7 +9930,7 @@ int mbr_reson7kr_wr_position(int verbose, int *bufferalloc, char **bufferptr, vo
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   position = &(store->position);
   header = &(position->header);
 
@@ -10082,7 +10021,6 @@ int mbr_reson7kr_wr_position(int verbose, int *bufferalloc, char **bufferptr, vo
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_customattitude(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_customattitude *customattitude;
   unsigned int checksum;
@@ -10100,7 +10038,7 @@ int mbr_reson7kr_wr_customattitude(int verbose, int *bufferalloc, char **bufferp
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   customattitude = &(store->customattitude);
   header = &(customattitude->header);
 
@@ -10238,7 +10176,6 @@ int mbr_reson7kr_wr_customattitude(int verbose, int *bufferalloc, char **bufferp
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_tide(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_tide *tide;
   unsigned int checksum;
@@ -10256,7 +10193,7 @@ int mbr_reson7kr_wr_tide(int verbose, int *bufferalloc, char **bufferptr, void *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   tide = &(store->tide);
   header = &(tide->header);
 
@@ -10351,7 +10288,6 @@ int mbr_reson7kr_wr_tide(int verbose, int *bufferalloc, char **bufferptr, void *
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_altitude(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_altitude *altitude;
   unsigned int checksum;
@@ -10369,7 +10305,7 @@ int mbr_reson7kr_wr_altitude(int verbose, int *bufferalloc, char **bufferptr, vo
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   altitude = &(store->altitude);
   header = &(altitude->header);
 
@@ -10444,7 +10380,6 @@ int mbr_reson7kr_wr_altitude(int verbose, int *bufferalloc, char **bufferptr, vo
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_motion(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_motion *motion;
   unsigned int checksum;
@@ -10462,7 +10397,7 @@ int mbr_reson7kr_wr_motion(int verbose, int *bufferalloc, char **bufferptr, void
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   motion = &(store->motion);
   header = &(motion->header);
 
@@ -10576,7 +10511,6 @@ int mbr_reson7kr_wr_motion(int verbose, int *bufferalloc, char **bufferptr, void
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_depth(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_depth *depth;
   unsigned int checksum;
@@ -10594,7 +10528,7 @@ int mbr_reson7kr_wr_depth(int verbose, int *bufferalloc, char **bufferptr, void 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   depth = &(store->depth);
   header = &(depth->header);
 
@@ -10675,7 +10609,6 @@ int mbr_reson7kr_wr_depth(int verbose, int *bufferalloc, char **bufferptr, void 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_svp(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_svp *svp;
   unsigned int checksum;
@@ -10693,7 +10626,7 @@ int mbr_reson7kr_wr_svp(int verbose, int *bufferalloc, char **bufferptr, void *s
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   svp = &(store->svp);
   header = &(svp->header);
 
@@ -10786,7 +10719,6 @@ int mbr_reson7kr_wr_svp(int verbose, int *bufferalloc, char **bufferptr, void *s
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_ctd(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_ctd *ctd;
   unsigned int checksum;
@@ -10804,7 +10736,7 @@ int mbr_reson7kr_wr_ctd(int verbose, int *bufferalloc, char **bufferptr, void *s
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   ctd = &(store->ctd);
   header = &(ctd->header);
 
@@ -10915,7 +10847,6 @@ int mbr_reson7kr_wr_ctd(int verbose, int *bufferalloc, char **bufferptr, void *s
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_geodesy(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_geodesy *geodesy;
   unsigned int checksum;
@@ -10933,7 +10864,7 @@ int mbr_reson7kr_wr_geodesy(int verbose, int *bufferalloc, char **bufferptr, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   geodesy = &(store->geodesy);
   header = &(geodesy->header);
 
@@ -11066,7 +10997,6 @@ int mbr_reson7kr_wr_geodesy(int verbose, int *bufferalloc, char **bufferptr, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_rollpitchheave(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_rollpitchheave *rollpitchheave;
   unsigned int checksum;
@@ -11084,7 +11014,7 @@ int mbr_reson7kr_wr_rollpitchheave(int verbose, int *bufferalloc, char **bufferp
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   rollpitchheave = &(store->rollpitchheave);
   header = &(rollpitchheave->header);
 
@@ -11161,7 +11091,6 @@ int mbr_reson7kr_wr_rollpitchheave(int verbose, int *bufferalloc, char **bufferp
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_heading(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_heading *heading;
   unsigned int checksum;
@@ -11179,7 +11108,7 @@ int mbr_reson7kr_wr_heading(int verbose, int *bufferalloc, char **bufferptr, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   heading = &(store->heading);
   header = &(heading->header);
 
@@ -11252,7 +11181,6 @@ int mbr_reson7kr_wr_heading(int verbose, int *bufferalloc, char **bufferptr, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_surveyline(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_surveyline *surveyline;
   unsigned int checksum;
@@ -11270,7 +11198,7 @@ int mbr_reson7kr_wr_surveyline(int verbose, int *bufferalloc, char **bufferptr, 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   surveyline = &(store->surveyline);
   header = &(surveyline->header);
 
@@ -11358,7 +11286,6 @@ int mbr_reson7kr_wr_surveyline(int verbose, int *bufferalloc, char **bufferptr, 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_navigation(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_navigation *navigation;
   unsigned int checksum;
@@ -11376,7 +11303,7 @@ int mbr_reson7kr_wr_navigation(int verbose, int *bufferalloc, char **bufferptr, 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   navigation = &(store->navigation);
   header = &(navigation->header);
 
@@ -11465,7 +11392,6 @@ int mbr_reson7kr_wr_navigation(int verbose, int *bufferalloc, char **bufferptr, 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_attitude(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_attitude *attitude;
   unsigned int checksum;
@@ -11483,7 +11409,7 @@ int mbr_reson7kr_wr_attitude(int verbose, int *bufferalloc, char **bufferptr, vo
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   attitude = &(store->attitude);
   header = &(attitude->header);
 
@@ -11569,7 +11495,6 @@ int mbr_reson7kr_wr_attitude(int verbose, int *bufferalloc, char **bufferptr, vo
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_rec1022(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_rec1022 *rec1022;
   unsigned int checksum;
@@ -11587,7 +11512,7 @@ int mbr_reson7kr_wr_rec1022(int verbose, int *bufferalloc, char **bufferptr, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   rec1022 = &(store->rec1022);
   header = &(rec1022->header);
 
@@ -12034,7 +11959,6 @@ int mbr_reson7kr_wr_fsdwsegyheader(int verbose, char *buffer, int *index, s7k_fs
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_fsdwsslo(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_fsdwss *fsdwsslo;
   s7k_fsdwchannel *fsdwchannel;
@@ -12056,7 +11980,7 @@ int mbr_reson7kr_wr_fsdwsslo(int verbose, int *bufferalloc, char **bufferptr, vo
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   fsdwsslo = &(store->fsdwsslo);
   header = &(fsdwsslo->header);
   bathymetry = &(store->bathymetry);
@@ -12173,7 +12097,6 @@ int mbr_reson7kr_wr_fsdwsslo(int verbose, int *bufferalloc, char **bufferptr, vo
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_fsdwsshi(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_fsdwss *fsdwsshi;
   s7k_fsdwchannel *fsdwchannel;
@@ -12193,7 +12116,7 @@ int mbr_reson7kr_wr_fsdwsshi(int verbose, int *bufferalloc, char **bufferptr, vo
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   fsdwsshi = &(store->fsdwsshi);
   header = &(fsdwsshi->header);
 
@@ -12308,7 +12231,6 @@ int mbr_reson7kr_wr_fsdwsshi(int verbose, int *bufferalloc, char **bufferptr, vo
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_fsdwsb(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_fsdwsb *fsdwsb;
   s7k_fsdwchannel *fsdwchannel;
@@ -12328,7 +12250,7 @@ int mbr_reson7kr_wr_fsdwsb(int verbose, int *bufferalloc, char **bufferptr, void
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   fsdwsb = &(store->fsdwsb);
   header = &(fsdwsb->header);
 
@@ -12442,7 +12364,6 @@ int mbr_reson7kr_wr_fsdwsb(int verbose, int *bufferalloc, char **bufferptr, void
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_bluefin(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_bluefin *bluefin;
   unsigned int checksum;
@@ -12460,7 +12381,7 @@ int mbr_reson7kr_wr_bluefin(int verbose, int *bufferalloc, char **bufferptr, voi
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bluefin = &(store->bluefin);
   header = &(bluefin->header);
 
@@ -12688,7 +12609,6 @@ int mbr_reson7kr_wr_bluefin(int verbose, int *bufferalloc, char **bufferptr, voi
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_processedsidescan(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_processedsidescan *processedsidescan;
   unsigned int checksum;
@@ -12706,7 +12626,7 @@ int mbr_reson7kr_wr_processedsidescan(int verbose, int *bufferalloc, char **buff
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   processedsidescan = &(store->processedsidescan);
   header = &(processedsidescan->header);
 
@@ -12813,7 +12733,6 @@ int mbr_reson7kr_wr_processedsidescan(int verbose, int *bufferalloc, char **buff
 int mbr_reson7kr_wr_volatilesonarsettings(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size,
                                           int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_volatilesettings *volatilesettings;
   unsigned int checksum;
@@ -12831,7 +12750,7 @@ int mbr_reson7kr_wr_volatilesonarsettings(int verbose, int *bufferalloc, char **
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   volatilesettings = &(store->volatilesettings);
   header = &(volatilesettings->header);
 
@@ -12982,7 +12901,6 @@ int mbr_reson7kr_wr_volatilesonarsettings(int verbose, int *bufferalloc, char **
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_configuration(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_configuration *configuration;
   s7k_device *device;
@@ -13001,7 +12919,7 @@ int mbr_reson7kr_wr_configuration(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   configuration = &(store->configuration);
   header = &(configuration->header);
 
@@ -13103,7 +13021,6 @@ int mbr_reson7kr_wr_configuration(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_matchfilter(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_matchfilter *matchfilter;
   unsigned int checksum;
@@ -13121,7 +13038,7 @@ int mbr_reson7kr_wr_matchfilter(int verbose, int *bufferalloc, char **bufferptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   matchfilter = &(store->matchfilter);
   header = &(matchfilter->header);
 
@@ -13205,7 +13122,6 @@ int mbr_reson7kr_wr_matchfilter(int verbose, int *bufferalloc, char **bufferptr,
 int mbr_reson7kr_wr_v2firmwarehardwareconfiguration(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size,
                                                     int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2firmwarehardwareconfiguration *v2firmwarehardwareconfiguration;
   unsigned int checksum;
@@ -13223,7 +13139,7 @@ int mbr_reson7kr_wr_v2firmwarehardwareconfiguration(int verbose, int *bufferallo
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2firmwarehardwareconfiguration = &(store->v2firmwarehardwareconfiguration);
   header = &(v2firmwarehardwareconfiguration->header);
 
@@ -13307,7 +13223,6 @@ int mbr_reson7kr_wr_v2firmwarehardwareconfiguration(int verbose, int *bufferallo
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_beamgeometry(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_beamgeometry *beamgeometry;
   unsigned int checksum;
@@ -13325,7 +13240,7 @@ int mbr_reson7kr_wr_beamgeometry(int verbose, int *bufferalloc, char **bufferptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   beamgeometry = &(store->beamgeometry);
   header = &(beamgeometry->header);
 
@@ -13421,7 +13336,6 @@ int mbr_reson7kr_wr_beamgeometry(int verbose, int *bufferalloc, char **bufferptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_calibration(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_calibration *calibration;
   unsigned int checksum;
@@ -13439,7 +13353,7 @@ int mbr_reson7kr_wr_calibration(int verbose, int *bufferalloc, char **bufferptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   calibration = &(store->calibration);
   header = &(calibration->header);
 
@@ -13527,7 +13441,6 @@ int mbr_reson7kr_wr_calibration(int verbose, int *bufferalloc, char **bufferptr,
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_bathymetry(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_bathymetry *bathymetry;
   unsigned int checksum;
@@ -13545,7 +13458,7 @@ int mbr_reson7kr_wr_bathymetry(int verbose, int *bufferalloc, char **bufferptr, 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bathymetry = &(store->bathymetry);
   header = &(bathymetry->header);
 
@@ -13705,7 +13618,6 @@ int mbr_reson7kr_wr_bathymetry(int verbose, int *bufferalloc, char **bufferptr, 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_backscatter(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_backscatter *backscatter;
   int data_size;
@@ -13726,7 +13638,7 @@ int mbr_reson7kr_wr_backscatter(int verbose, int *bufferalloc, char **bufferptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   backscatter = &(store->backscatter);
   header = &(backscatter->header);
 
@@ -13914,7 +13826,6 @@ int mbr_reson7kr_wr_backscatter(int verbose, int *bufferalloc, char **bufferptr,
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_beam(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_beam *beam;
   s7kr_snippet *snippet;
@@ -13945,7 +13856,7 @@ int mbr_reson7kr_wr_beam(int verbose, int *bufferalloc, char **bufferptr, void *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   beam = &(store->beam);
   header = &(beam->header);
 
@@ -14129,7 +14040,6 @@ int mbr_reson7kr_wr_beam(int verbose, int *bufferalloc, char **bufferptr, void *
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_verticaldepth(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_verticaldepth *verticaldepth;
   unsigned int checksum;
@@ -14147,7 +14057,7 @@ int mbr_reson7kr_wr_verticaldepth(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   verticaldepth = &(store->verticaldepth);
   header = &(verticaldepth->header);
 
@@ -14238,7 +14148,6 @@ int mbr_reson7kr_wr_verticaldepth(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_tvg(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_tvg *tvg;
   unsigned int checksum;
@@ -14256,7 +14165,7 @@ int mbr_reson7kr_wr_tvg(int verbose, int *bufferalloc, char **bufferptr, void *s
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   tvg = &(store->tvg);
   header = &(tvg->header);
 
@@ -14346,7 +14255,6 @@ int mbr_reson7kr_wr_tvg(int verbose, int *bufferalloc, char **bufferptr, void *s
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_image(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_image *image;
   unsigned int checksum;
@@ -14368,7 +14276,7 @@ int mbr_reson7kr_wr_image(int verbose, int *bufferalloc, char **bufferptr, void 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   image = &(store->image);
   header = &(image->header);
 
@@ -14492,7 +14400,6 @@ int mbr_reson7kr_wr_image(int verbose, int *bufferalloc, char **bufferptr, void 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_v2pingmotion(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2pingmotion *v2pingmotion;
   unsigned int checksum;
@@ -14510,7 +14417,7 @@ int mbr_reson7kr_wr_v2pingmotion(int verbose, int *bufferalloc, char **bufferptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2pingmotion = &(store->v2pingmotion);
   header = &(v2pingmotion->header);
 
@@ -14625,7 +14532,6 @@ int mbr_reson7kr_wr_v2pingmotion(int verbose, int *bufferalloc, char **bufferptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_v2detectionsetup(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2detectionsetup *v2detectionsetup;
   unsigned int checksum;
@@ -14643,7 +14549,7 @@ int mbr_reson7kr_wr_v2detectionsetup(int verbose, int *bufferalloc, char **buffe
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2detectionsetup = &(store->v2detectionsetup);
   header = &(v2detectionsetup->header);
 
@@ -14773,7 +14679,6 @@ int mbr_reson7kr_wr_v2detectionsetup(int verbose, int *bufferalloc, char **buffe
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_v2beamformed(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2beamformed *v2beamformed;
   s7kr_v2amplitudephase *v2amplitudephase;
@@ -14792,7 +14697,7 @@ int mbr_reson7kr_wr_v2beamformed(int verbose, int *bufferalloc, char **bufferptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2beamformed = &(store->v2beamformed);
   header = &(v2beamformed->header);
 
@@ -14889,7 +14794,6 @@ int mbr_reson7kr_wr_v2beamformed(int verbose, int *bufferalloc, char **bufferptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_v2bite(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2bite *v2bite;
   s7kr_v2bitereport *report;
@@ -14910,7 +14814,7 @@ int mbr_reson7kr_wr_v2bite(int verbose, int *bufferalloc, char **bufferptr, void
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2bite = &(store->v2bite);
   header = &(v2bite->header);
 
@@ -15066,7 +14970,6 @@ int mbr_reson7kr_wr_v2bite(int verbose, int *bufferalloc, char **bufferptr, void
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_v27kcenterversion(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v27kcenterversion *v27kcenterversion;
   unsigned int checksum;
@@ -15084,7 +14987,7 @@ int mbr_reson7kr_wr_v27kcenterversion(int verbose, int *bufferalloc, char **buff
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v27kcenterversion = &(store->v27kcenterversion);
   header = &(v27kcenterversion->header);
 
@@ -15159,7 +15062,6 @@ int mbr_reson7kr_wr_v27kcenterversion(int verbose, int *bufferalloc, char **buff
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_v28kwetendversion(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v28kwetendversion *v28kwetendversion;
   unsigned int checksum;
@@ -15177,7 +15079,7 @@ int mbr_reson7kr_wr_v28kwetendversion(int verbose, int *bufferalloc, char **buff
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v28kwetendversion = &(store->v28kwetendversion);
   header = &(v28kwetendversion->header);
 
@@ -15252,7 +15154,6 @@ int mbr_reson7kr_wr_v28kwetendversion(int verbose, int *bufferalloc, char **buff
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_v2detection(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2detection *v2detection;
   unsigned int checksum;
@@ -15270,7 +15171,7 @@ int mbr_reson7kr_wr_v2detection(int verbose, int *bufferalloc, char **bufferptr,
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2detection = &(store->v2detection);
   header = &(v2detection->header);
 
@@ -15387,7 +15288,6 @@ int mbr_reson7kr_wr_v2detection(int verbose, int *bufferalloc, char **bufferptr,
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_v2rawdetection(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2rawdetection *v2rawdetection;
   unsigned int checksum;
@@ -15405,7 +15305,7 @@ int mbr_reson7kr_wr_v2rawdetection(int verbose, int *bufferalloc, char **bufferp
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2rawdetection = &(store->v2rawdetection);
   header = &(v2rawdetection->header);
 
@@ -15524,7 +15424,6 @@ int mbr_reson7kr_wr_v2rawdetection(int verbose, int *bufferalloc, char **bufferp
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_v2snippet(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_v2snippet *v2snippet;
   s7kr_v2snippettimeseries *snippettimeseries;
@@ -15543,7 +15442,7 @@ int mbr_reson7kr_wr_v2snippet(int verbose, int *bufferalloc, char **bufferptr, v
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   v2snippet = &(store->v2snippet);
   header = &(v2snippet->header);
 
@@ -15664,7 +15563,6 @@ int mbr_reson7kr_wr_v2snippet(int verbose, int *bufferalloc, char **bufferptr, v
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_calibratedsnippet(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_calibratedsnippet *calibratedsnippet;
   s7kr_calibratedsnippettimeseries *snippettimeseries;
@@ -15683,7 +15581,7 @@ int mbr_reson7kr_wr_calibratedsnippet(int verbose, int *bufferalloc, char **buff
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   calibratedsnippet = &(store->calibratedsnippet);
   header = &(calibratedsnippet->header);
 
@@ -15803,7 +15701,6 @@ int mbr_reson7kr_wr_calibratedsnippet(int verbose, int *bufferalloc, char **buff
 } /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_installation(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_installation *installation;
   unsigned int checksum;
@@ -15821,7 +15718,7 @@ int mbr_reson7kr_wr_installation(int verbose, int *bufferalloc, char **bufferptr
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   installation = &(store->installation);
   header = &(installation->header);
 
@@ -15968,7 +15865,6 @@ int mbr_reson7kr_wr_installation(int verbose, int *bufferalloc, char **bufferptr
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_fileheader(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_fileheader *fileheader;
   s7kr_subsystem *subsystem;
@@ -15987,7 +15883,7 @@ int mbr_reson7kr_wr_fileheader(int verbose, int *bufferalloc, char **bufferptr, 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   fileheader = &(store->fileheader);
   header = &(fileheader->header);
 
@@ -16133,7 +16029,6 @@ int mbr_reson7kr_wr_fileheader(int verbose, int *bufferalloc, char **bufferptr, 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_systemeventmessage(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_systemeventmessage *systemeventmessage;
   unsigned int checksum;
@@ -16151,7 +16046,7 @@ int mbr_reson7kr_wr_systemeventmessage(int verbose, int *bufferalloc, char **buf
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   systemeventmessage = &(store->systemeventmessage);
   header = &(systemeventmessage->header);
 
@@ -16240,7 +16135,6 @@ int mbr_reson7kr_wr_systemeventmessage(int verbose, int *bufferalloc, char **buf
 int mbr_reson7kr_wr_remotecontrolsettings(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size,
                                           int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_remotecontrolsettings *remotecontrolsettings;
   unsigned int checksum;
@@ -16258,7 +16152,7 @@ int mbr_reson7kr_wr_remotecontrolsettings(int verbose, int *bufferalloc, char **
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   remotecontrolsettings = &(store->remotecontrolsettings);
   header = &(remotecontrolsettings->header);
 
@@ -16435,7 +16329,6 @@ int mbr_reson7kr_wr_remotecontrolsettings(int verbose, int *bufferalloc, char **
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_reserved(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_reserved *reserved;
   unsigned int checksum;
@@ -16453,7 +16346,7 @@ int mbr_reson7kr_wr_reserved(int verbose, int *bufferalloc, char **bufferptr, vo
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   reserved = &(store->reserved);
   header = &(reserved->header);
 
@@ -16530,7 +16423,6 @@ int mbr_reson7kr_wr_reserved(int verbose, int *bufferalloc, char **bufferptr, vo
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_roll(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_roll *roll;
   unsigned int checksum;
@@ -16548,7 +16440,7 @@ int mbr_reson7kr_wr_roll(int verbose, int *bufferalloc, char **bufferptr, void *
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   roll = &(store->roll);
   header = &(roll->header);
 
@@ -16623,7 +16515,6 @@ int mbr_reson7kr_wr_roll(int verbose, int *bufferalloc, char **bufferptr, void *
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_pitch(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_pitch *pitch;
   unsigned int checksum;
@@ -16641,7 +16532,7 @@ int mbr_reson7kr_wr_pitch(int verbose, int *bufferalloc, char **bufferptr, void 
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   pitch = &(store->pitch);
   header = &(pitch->header);
 
@@ -16716,7 +16607,6 @@ int mbr_reson7kr_wr_pitch(int verbose, int *bufferalloc, char **bufferptr, void 
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_soundvelocity(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_soundvelocity *soundvelocity;
   unsigned int checksum;
@@ -16734,7 +16624,7 @@ int mbr_reson7kr_wr_soundvelocity(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   soundvelocity = &(store->soundvelocity);
   header = &(soundvelocity->header);
 
@@ -16809,7 +16699,6 @@ int mbr_reson7kr_wr_soundvelocity(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_absorptionloss(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_absorptionloss *absorptionloss;
   unsigned int checksum;
@@ -16827,7 +16716,7 @@ int mbr_reson7kr_wr_absorptionloss(int verbose, int *bufferalloc, char **bufferp
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   absorptionloss = &(store->absorptionloss);
   header = &(absorptionloss->header);
 
@@ -16902,7 +16791,6 @@ int mbr_reson7kr_wr_absorptionloss(int verbose, int *bufferalloc, char **bufferp
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_spreadingloss(int verbose, int *bufferalloc, char **bufferptr, void *store_ptr, int *size, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_spreadingloss *spreadingloss;
   unsigned int checksum;
@@ -16920,7 +16808,7 @@ int mbr_reson7kr_wr_spreadingloss(int verbose, int *bufferalloc, char **bufferpt
   }
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   spreadingloss = &(store->spreadingloss);
   header = &(spreadingloss->header);
 
@@ -16995,7 +16883,6 @@ int mbr_reson7kr_wr_spreadingloss(int verbose, int *bufferalloc, char **bufferpt
 /*--------------------------------------------------------------------*/
 int mbr_reson7kr_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
   FILE *mbfp;
   char **bufferptr;
   char *buffer;
@@ -17016,7 +16903,7 @@ int mbr_reson7kr_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   mbfp = mb_io_ptr->mbfp;
 
   /* get saved values */
@@ -17619,7 +17506,6 @@ int mbr_reson7kr_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 /*--------------------------------------------------------------------*/
 int mbr_wt_reson7kr(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   int status = MB_SUCCESS;
-  struct mbsys_reson7k_struct *store;
 
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
@@ -17633,7 +17519,7 @@ int mbr_wt_reson7kr(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
 
   /* write next data to file */
   status = mbr_reson7kr_wr_data(verbose, mbio_ptr, store_ptr, error);

--- a/src/mbio/mbsys_reson7k.c
+++ b/src/mbio/mbsys_reson7k.c
@@ -97,7 +97,6 @@ int mbsys_reson7k_zero7kheader(int verbose, s7k_header *header, int *error) {
 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_reference *reference;
   s7kr_sensoruncal *sensoruncal;
   s7kr_sensorcal *sensorcal;
@@ -166,7 +165,7 @@ int mbsys_reson7k_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *erro
   const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_reson7k_struct), (void **)store_ptr, error);
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)*store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)*store_ptr;
 
   /* initialize everything */
 
@@ -1150,7 +1149,6 @@ int mbsys_reson7k_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 }
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_customattitude *customattitude;
   s7kr_motion *motion;
   s7kr_svp *svp;
@@ -1186,7 +1184,7 @@ int mbsys_reson7k_deall(int verbose, void *mbio_ptr, void **store_ptr, int *erro
   }
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)*store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)*store_ptr;
 
   int status = MB_SUCCESS;
 
@@ -4665,7 +4663,6 @@ int mbsys_reson7k_print_spreadingloss(int verbose, s7kr_spreadingloss *spreading
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss,
                              int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
 
   if (verbose >= 2) {
@@ -4680,7 +4677,7 @@ int mbsys_reson7k_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
 
   /* get data kind */
   *kind = store->kind;
@@ -4718,7 +4715,6 @@ int mbsys_reson7k_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *
 }
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumber, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
 
   if (verbose >= 2) {
@@ -4732,7 +4728,7 @@ int mbsys_reson7k_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumb
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)mb_io_ptr->store_data;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)mb_io_ptr->store_data;
 
   /* extract data from structure */
   bathymetry = (s7kr_bathymetry *)&store->bathymetry;
@@ -4753,8 +4749,6 @@ int mbsys_reson7k_pingnumber(int verbose, void *mbio_ptr, unsigned int *pingnumb
 }
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *sonartype, int *error) {
-  struct mbsys_reson7k_struct *store;
-
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
     fprintf(stderr, "dbg2  Input arguments:\n");
@@ -4767,7 +4761,7 @@ int mbsys_reson7k_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *s
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
 
   /* get sonar type */
   *sonartype = MB_TOPOGRAPHY_TYPE_MULTIBEAM;
@@ -4787,8 +4781,6 @@ int mbsys_reson7k_sonartype(int verbose, void *mbio_ptr, void *store_ptr, int *s
 }
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int *ss_type, int *error) {
-  struct mbsys_reson7k_struct *store;
-
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
     fprintf(stderr, "dbg2  Input arguments:\n");
@@ -4801,7 +4793,7 @@ int mbsys_reson7k_sidescantype(int verbose, void *mbio_ptr, void *store_ptr, int
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
 
   /* get sidescan type */
   *ss_type = MB_SIDESCAN_LINEAR;
@@ -4824,7 +4816,6 @@ int mbsys_reson7k_preprocess(int verbose,     /* in: verbosity level set on comm
                              void *mbio_ptr,  /* in: see mb_io.h:/^struct mb_io_struct/ */
                              void *store_ptr, /* in: see mbsys_reson7k.h:/^struct mbsys_reson7k_struct/ */
                              void *platform_ptr, void *preprocess_pars_ptr, int *error) {
-  struct mbsys_reson7k_struct *store;
   struct mb_platform_struct *platform;
   struct mb_preprocess_struct *pars;
 
@@ -4953,7 +4944,7 @@ int mbsys_reson7k_preprocess(int verbose,     /* in: verbosity level set on comm
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointers */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   platform = (struct mb_platform_struct *)platform_ptr;
   pars = (struct mb_preprocess_struct *)preprocess_pars_ptr;
 
@@ -6079,7 +6070,6 @@ int mbsys_reson7k_preprocess(int verbose,     /* in: verbosity level set on comm
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_extract_platform(int verbose, void *mbio_ptr, void *store_ptr, int *kind, void **platform_ptr, int *error) {
   struct mb_platform_struct *platform;
-  struct mbsys_reson7k_struct *store;
   s7kr_installation *installation;
   int sensor_multibeam, sensor_position, sensor_attitude;
   int ntimelag = 0;
@@ -6097,7 +6087,7 @@ int mbsys_reson7k_extract_platform(int verbose, void *mbio_ptr, void *store_ptr,
 
   /* get mbio descriptor */
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   installation = (s7kr_installation *)&store->installation;
 
   int status = MB_SUCCESS;
@@ -6253,7 +6243,6 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
                           double *navlat, double *speed, double *heading, int *nbath, int *namp, int *nss, char *beamflag,
                           double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                           double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_bluefin *bluefin;
   s7kr_processedsidescan *processedsidescan;
   s7kr_volatilesettings *volatilesettings;
@@ -6284,7 +6273,7 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bluefin = (s7kr_bluefin *)&store->bluefin;
   processedsidescan = (s7kr_processedsidescan *)&store->processedsidescan;
   volatilesettings = (s7kr_volatilesettings *)&(store->volatilesettings);
@@ -6808,7 +6797,6 @@ int mbsys_reson7k_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
                          double navlat, double speed, double heading, int nbath, int namp, int nss, char *beamflag, double *bath,
                          double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                          double *ssalongtrack, char *comment, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_bluefin *bluefin;
   s7kr_processedsidescan *processedsidescan;
   s7kr_volatilesettings *volatilesettings;
@@ -6872,7 +6860,7 @@ int mbsys_reson7k_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bluefin = (s7kr_bluefin *)&store->bluefin;
   volatilesettings = (s7kr_volatilesettings *)&store->volatilesettings;
   bathymetry = (s7kr_bathymetry *)&store->bathymetry;
@@ -7115,7 +7103,6 @@ int mbsys_reson7k_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
 int mbsys_reson7k_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, double *ttimes, double *angles,
                          double *angles_forward, double *angles_null, double *heave, double *alongtrack_offset, double *draft,
                          double *ssv, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   s7kr_depth *depth;
   s7kr_beamgeometry *beamgeometry;
@@ -7144,7 +7131,7 @@ int mbsys_reson7k_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bathymetry = (s7kr_bathymetry *)&store->bathymetry;
   depth = (s7kr_depth *)&store->depth;
   attitude = (s7kr_attitude *)&store->attitude;
@@ -7255,7 +7242,6 @@ int mbsys_reson7k_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 }
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   mb_u_char detect;
   int i;
@@ -7273,7 +7259,7 @@ int mbsys_reson7k_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kin
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bathymetry = (s7kr_bathymetry *)&store->bathymetry;
 
   /* get data kind */
@@ -7339,7 +7325,6 @@ int mbsys_reson7k_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                         double *receive_gain, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_volatilesettings *volatilesettings;
 
@@ -7355,7 +7340,7 @@ int mbsys_reson7k_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
 
   /* get data kind */
   *kind = store->kind;
@@ -7419,7 +7404,6 @@ int mbsys_reson7k_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                    double *altitudev, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   s7kr_depth *depth;
   s7kr_altitude *altitude;
@@ -7443,7 +7427,7 @@ int mbsys_reson7k_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr,
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bathymetry = (s7kr_bathymetry *)&store->bathymetry;
   depth = (s7kr_depth *)&store->depth;
   attitude = (s7kr_attitude *)&store->attitude;
@@ -7560,7 +7544,6 @@ int mbsys_reson7k_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr,
 int mbsys_reson7k_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int time_i[7], double *time_d,
                               double *navlon, double *navlat, double *speed, double *heading, double *draft, double *roll,
                               double *pitch, double *heave, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   s7kr_bluefin *bluefin;
   s7kr_position *position;
@@ -7587,7 +7570,7 @@ int mbsys_reson7k_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bathymetry = (s7kr_bathymetry *)&store->bathymetry;
   bluefin = (s7kr_bluefin *)&store->bluefin;
   position = (s7kr_position *)&store->position;
@@ -7928,7 +7911,6 @@ int mbsys_reson7k_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 int mbsys_reson7k_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr, int nmax, int *kind, int *n, int *time_i,
                                double *time_d, double *navlon, double *navlat, double *speed, double *heading, double *draft,
                                double *roll, double *pitch, double *heave, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   s7kr_bluefin *bluefin;
   s7kr_position *position;
@@ -7952,7 +7934,7 @@ int mbsys_reson7k_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr, int
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bathymetry = (s7kr_bathymetry *)&store->bathymetry;
   bluefin = (s7kr_bluefin *)&store->bluefin;
   position = (s7kr_position *)&store->position;
@@ -8242,7 +8224,6 @@ int mbsys_reson7k_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr, int
 int mbsys_reson7k_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_i[7], double time_d, double navlon,
                              double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                              int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_bathymetry *bathymetry;
   s7kr_position *position;
   s7kr_depth *depth;
@@ -8278,7 +8259,7 @@ int mbsys_reson7k_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   bathymetry = (s7kr_bathymetry *)&store->bathymetry;
   position = (s7kr_position *)&store->position;
   depth = (s7kr_depth *)&store->depth;
@@ -8345,7 +8326,6 @@ int mbsys_reson7k_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int t
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                               int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_svp *svp;
   int i;
 
@@ -8361,7 +8341,7 @@ int mbsys_reson7k_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   svp = (s7kr_svp *)&store->svp;
 
   /* get data kind */
@@ -8414,7 +8394,6 @@ int mbsys_reson7k_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity,
                              int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_svp *svp;
   int i;
 
@@ -8433,7 +8412,7 @@ int mbsys_reson7k_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   svp = (s7kr_svp *)&store->svp;
 
   int status = MB_SUCCESS;
@@ -8476,7 +8455,6 @@ int mbsys_reson7k_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int n
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_extract_segytraceheader(int verbose, void *mbio_ptr, void *store_ptr, int *kind, void *segytraceheader_ptr,
                                           int *error) {
-  struct mbsys_reson7k_struct *store;
   struct mb_segytraceheader_struct *mb_segytraceheader_ptr;
   s7k_header *header;
   s7kr_bathymetry *bathymetry;
@@ -8510,7 +8488,7 @@ int mbsys_reson7k_extract_segytraceheader(int verbose, void *mbio_ptr, void *sto
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
 
   /* get data kind */
   *kind = store->kind;
@@ -8735,7 +8713,6 @@ int mbsys_reson7k_extract_segytraceheader(int verbose, void *mbio_ptr, void *sto
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_extract_segy(int verbose, void *mbio_ptr, void *store_ptr, int *sampleformat, int *kind, void *segyheader_ptr,
                                float *segydata, int *error) {
-  struct mbsys_reson7k_struct *store;
   struct mb_segytraceheader_struct *mb_segytraceheader_ptr;
   s7k_header *header;
   s7kr_fsdwsb *fsdwsb;
@@ -8762,7 +8739,7 @@ int mbsys_reson7k_extract_segy(int verbose, void *mbio_ptr, void *store_ptr, int
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
 
   /* get data kind */
   *kind = store->kind;
@@ -8941,7 +8918,6 @@ int mbsys_reson7k_extract_segy(int verbose, void *mbio_ptr, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_insert_segy(int verbose, void *mbio_ptr, void *store_ptr, int kind, void *segyheader_ptr, float *segydata,
                               int *error) {
-  struct mbsys_reson7k_struct *store;
   struct mb_segytraceheader_struct *mb_segytraceheader_ptr;
   s7k_header *header;
   s7kr_bathymetry *bathymetry;
@@ -8975,7 +8951,7 @@ int mbsys_reson7k_insert_segy(int verbose, void *mbio_ptr, void *store_ptr, int 
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
 
   /* get data kind */
   store->kind = kind;
@@ -9185,7 +9161,6 @@ int mbsys_reson7k_insert_segy(int verbose, void *mbio_ptr, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_ctd(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nctd, double *time_d, double *conductivity,
                       double *temperature, double *depth, double *salinity, double *soundspeed, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_bluefin *bluefin;
   s7k_bluefin_environmental *environmental;
@@ -9206,7 +9181,7 @@ int mbsys_reson7k_ctd(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
 
   /* get data kind */
   *kind = store->kind;
@@ -9307,7 +9282,6 @@ int mbsys_reson7k_ctd(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 int mbsys_reson7k_ancilliarysensor(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsamples, double *time_d,
                                    double *sensor1, double *sensor2, double *sensor3, double *sensor4, double *sensor5,
                                    double *sensor6, double *sensor7, double *sensor8, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7k_header *header;
   s7kr_bluefin *bluefin;
   s7k_bluefin_environmental *environmental;
@@ -9325,7 +9299,7 @@ int mbsys_reson7k_ancilliarysensor(int verbose, void *mbio_ptr, void *store_ptr,
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
 
   /* get data kind */
   *kind = store->kind;
@@ -9388,7 +9362,6 @@ int mbsys_reson7k_ancilliarysensor(int verbose, void *mbio_ptr, void *store_ptr,
 }
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
-  struct mbsys_reson7k_struct *store;
   struct mbsys_reson7k_struct *copy;
   s7kr_attitude *attitude;
   s7kr_motion *motion;
@@ -9420,7 +9393,7 @@ int mbsys_reson7k_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointers */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   copy = (struct mbsys_reson7k_struct *)copy_ptr;
 
   /* copy over structures, allocating memory where necessary */
@@ -9856,7 +9829,6 @@ int mbsys_reson7k_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k_makess(int verbose, void *mbio_ptr, void *store_ptr, int source, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error) {
-  struct mbsys_reson7k_struct *store;
   s7kr_reference *reference;
   s7kr_volatilesettings *volatilesettings;
   s7kr_beamgeometry *beamgeometry;
@@ -9920,7 +9892,7 @@ int mbsys_reson7k_makess(int verbose, void *mbio_ptr, void *store_ptr, int sourc
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k_struct *)store_ptr;
+  struct mbsys_reson7k_struct *store = (struct mbsys_reson7k_struct *)store_ptr;
   reference = (s7kr_reference *)&store->reference;
   volatilesettings = (s7kr_volatilesettings *)&store->volatilesettings;
   beamgeometry = (s7kr_beamgeometry *)&store->beamgeometry;

--- a/src/mbio/mbsys_reson7k3.c
+++ b/src/mbio/mbsys_reson7k3.c
@@ -7244,7 +7244,6 @@ int mbsys_reson7k3_extract_nnav(int verbose, void *mbio_ptr, void *store_ptr,
 int mbsys_reson7k3_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int time_i[7], double time_d, double navlon,
                              double navlat, double speed, double heading, double draft, double roll, double pitch, double heave,
                              int *error) {
-  struct mbsys_reson7k3_struct *store;
   s7k3_SonarSettings *SonarSettings;
   s7k3_BeamGeometry *BeamGeometry;
   s7k3_RawDetection *RawDetection;
@@ -7279,7 +7278,7 @@ int mbsys_reson7k3_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SonarSettings = (s7k3_SonarSettings *)&(store->SonarSettings);
   BeamGeometry = (s7k3_BeamGeometry *)&(store->BeamGeometry);
   RawDetection = (s7k3_RawDetection *)&store->RawDetection;
@@ -7367,7 +7366,6 @@ int mbsys_reson7k3_insert_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nsvp, double *depth, double *velocity,
                               int *error) {
-  struct mbsys_reson7k3_struct *store;
   s7k3_SoundVelocityProfile *SoundVelocityProfile;
 
   if (verbose >= 2) {
@@ -7382,7 +7380,7 @@ int mbsys_reson7k3_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SoundVelocityProfile = (s7k3_SoundVelocityProfile *)&(store->SoundVelocityProfile);
 
   /* get data kind */
@@ -7435,7 +7433,6 @@ int mbsys_reson7k3_extract_svp(int verbose, void *mbio_ptr, void *store_ptr, int
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int nsvp, double *depth, double *velocity,
                              int *error) {
-  struct mbsys_reson7k3_struct *store;
   s7k3_SoundVelocityProfile *SoundVelocityProfile;
 
   if (verbose >= 2) {
@@ -7453,7 +7450,7 @@ int mbsys_reson7k3_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SoundVelocityProfile = (s7k3_SoundVelocityProfile *)&(store->SoundVelocityProfile);
 
   int status = MB_SUCCESS;
@@ -7496,7 +7493,6 @@ int mbsys_reson7k3_insert_svp(int verbose, void *mbio_ptr, void *store_ptr, int 
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_ctd(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nctd, double *time_d, double *conductivity,
                       double *temperature, double *depth, double *salinity, double *soundspeed, int *error) {
-  struct mbsys_reson7k3_struct *store;
   s7k3_header *header;
   s7k3_CTD *CTD;
   int time_j[5];
@@ -7514,7 +7510,7 @@ int mbsys_reson7k3_ctd(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get pointer to raw data structure */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   CTD = (s7k3_CTD *)&(store->CTD);
 
   /* get data kind */
@@ -7635,8 +7631,6 @@ int mbsys_reson7k3_ancilliarysensor(int verbose, void *mbio_ptr, void *store_ptr
 }
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy_ptr, int *error) {
-  struct mbsys_reson7k3_struct *store;
-  struct mbsys_reson7k3_struct *copy;
 
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
@@ -7651,8 +7645,8 @@ int mbsys_reson7k3_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointers */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
-  copy = (struct mbsys_reson7k3_struct *)copy_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *copy = (struct mbsys_reson7k3_struct *)copy_ptr;
 
   /* copy over structures, allocating memory where necessary */
 
@@ -8293,7 +8287,6 @@ int mbsys_reson7k3_copy(int verbose, void *mbio_ptr, void *store_ptr, void *copy
 /*--------------------------------------------------------------------*/
 int mbsys_reson7k3_makess(int verbose, void *mbio_ptr, void *store_ptr, int source, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error) {
-  struct mbsys_reson7k3_struct *store = NULL;
   s7k3_SonarSettings *SonarSettings = NULL;
   s7k3_BeamGeometry *BeamGeometry = NULL;
   s7k3_bathydata *bathydata = NULL;
@@ -8359,7 +8352,7 @@ int mbsys_reson7k3_makess(int verbose, void *mbio_ptr, void *store_ptr, int sour
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
   /* get data structure pointer */
-  store = (struct mbsys_reson7k3_struct *)store_ptr;
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
   SonarSettings = (s7k3_SonarSettings *)&store->SonarSettings;
   BeamGeometry = (s7k3_BeamGeometry *)&store->BeamGeometry;
   RawDetection = (s7k3_RawDetection *)&store->RawDetection;


### PR DESCRIPTION
Found with: `egrep '^[[:space:]]+store[[:space:]]*=.*;' *.c`