### PR TITLE
mbaux/Makefile.am: Cleanup

### DIFF
--- a/src/mbaux/Makefile.am
+++ b/src/mbaux/Makefile.am
@@ -3,34 +3,36 @@ if BUILD_MOTIF
   XGRINC = mb_xgraphics.h
 endif
 
-if BUILD_MBTRN
-  MBTRNINCDIR = -I${top_srcdir}/src/mbtrn
-  MBTRNLIB = $(top_builddir)/src/mbtrn/libmbtrn.la
-endif
+lib_LTLIBRARIES = libmbaux.la ${XGRLIB}
+include_HEADERS = mb_aux.h ${XGRINC}
 
-lib_LTLIBRARIES = libmbaux.la $(XGRLIB)
-include_HEADERS = mb_aux.h $(XGRINC)
+AM_CPPFLAGS =
+AM_CPPFLAGS += -I${top_srcdir}/src/mbio
+AM_CPPFLAGS += ${libgmt_CPPFLAGS}
+AM_CPPFLAGS += ${libgdal_CPPFLAGS}
+AM_CPPFLAGS += ${libnetcdf_CPPFLAGS}
 
-AM_CPPFLAGS = -I${top_srcdir}/src/mbio \
-	      $(MBTRNINCDIR) \
-	      ${libgmt_CPPFLAGS} \
-	      ${libgdal_CPPFLAGS} \
-	      ${libnetcdf_CPPFLAGS}
 AM_CFLAGS = ${libgmt_CFLAGS} ${libgdal_CFLAGS} ${libnetcdf_CFLAGS}
 
 libmbaux_la_LDFLAGS = -no-undefined -version-info 0:0:0
-libmbaux_la_SOURCES = \
-		      mb_zgrid.c mb_surface.c mb_cheb.c \
-		      mb_delaun.c mb_track.c mb_truecont.c mb_readwritegrd.c \
-		      mb_intersectgrid.c
-libmbaux_la_LIBADD =  ${top_builddir}/src/mbio/libmbio.la \
-          $(MBTRNLIB) \
-			    ${libgmt_LIBS} \
-			    ${libgdal_LIBS} \
-			    ${libnetcdf_LIBS}
+libmbaux_la_SOURCES =
+libmbaux_la_SOURCES += mb_zgrid.c
+libmbaux_la_SOURCES += mb_surface.c
+libmbaux_la_SOURCES += mb_cheb.c
+libmbaux_la_SOURCES += mb_delaun.c
+libmbaux_la_SOURCES += mb_track.c
+libmbaux_la_SOURCES += mb_truecont.c
+libmbaux_la_SOURCES += mb_readwritegrd.c
+libmbaux_la_SOURCES += mb_intersectgrid.c
+
+libmbaux_la_LIBADD =
+libmbaux_la_LIBADD += ${top_builddir}/src/mbio/libmbio.la
+libmbaux_la_LIBADD += ${libgmt_LIBS}
+libmbaux_la_LIBADD += ${libgdal_LIBS}
+libmbaux_la_LIBADD += ${libnetcdf_LIBS}
 
 if BUILD_MOTIF
- libmbxgr_la_LDFLAGS = -no-undefined -version-info 0:0:0
- libmbxgr_la_SOURCES = mb_xgraphics.c
- libmbxgr_la_LIBADD = ${libmotif_LIBS}
+  libmbxgr_la_LDFLAGS = -no-undefined -version-info 0:0:0
+  libmbxgr_la_SOURCES = mb_xgraphics.c
+  libmbxgr_la_LIBADD = ${libmotif_LIBS}
 endif


### PR DESCRIPTION
- Remove unused TRN terrain navigation stuff (mbtrn is self contained)
- Change line continuations to `+=`
- Switch `()` to` {}` to be uniform