### PR TITLE
mbbs_io.c: Remove check for sizeof(int) less than 4.

### DIFF
--- a/src/bsio/mbbs_io.c
+++ b/src/bsio/mbbs_io.c
@@ -79,12 +79,9 @@ int mbbs_rdbsfhdr(BSFile *bsf, XDR *xdrs)
    to by xdrs and returns this header in the structure bsf.
    xdrs is assumed to be positioned at the next header,
    and does not search.
-   Returns BS_SUCCESS, BS_BADARCH or BS_READ.
+   Returns BS_SUCCESS or BS_READ.
 */
 {
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
-
 	if (mbbs_xdrbsfhdr(bsf, xdrs))
 		return BS_SUCCESS;
 	else
@@ -95,12 +92,9 @@ int mbbs_wrbsfhdr(BSFile *bsf, XDR *xdrs)
 /*
    User-callable routine.
    Writes the BSFile header bsf onto the XDR stream pointed to by xdrs.
-   Returns BS_SUCCESS, BS_BADARCH or BS_READ.
+   Returns BS_SUCCESS or BS_READ.
 */
 {
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
-
 	if (mbbs_xdrbsfhdr(bsf, xdrs))
 		return BS_SUCCESS;
 	else
@@ -131,12 +125,9 @@ int mbbs_rdpnghdr(Ping *png, XDR *xdrs, int version)
    xdrs is assumed to be positioned at the next header,
    and does not search. version should be the bs_version value
    from the file header which indicates the version of the file.
-   Returns BS_SUCCESS, BS_BADARCH, BS_BADARG or BS_READ.
+   Returns BS_SUCCESS, BS_BADARG or BS_READ.
 */
 {
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
-
 	switch (version) {
 	case MR1_VERSION_1_0:
 		if (mbbs_mr1_xdrpnghdrv1(png, xdrs))
@@ -166,12 +157,9 @@ int mbbs_wrpnghdr(Ping *png, XDR *xdrs)
 /*
    User-callable routine.
    Writes the Ping header png onto the XDR stream pointed to by xdrs.
-   Returns BS_SUCCESS, BS_BADARCH or BS_WRITE.
+   Returns BS_SUCCESS or BS_WRITE.
 */
 {
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
-
 	if (mbbs_xdrpnghdr(png, xdrs, (int)BS_VERSION_CURR))
 		return BS_SUCCESS;
 	else
@@ -185,12 +173,9 @@ int mbbs_rdpngdata(Ping *png, MemType *data, XDR *xdrs)
    the memory pointed to by data argument. It assumes that
    the stream is positioned correctly (i.e., right after the
    header), and does not search.
-   Returns BS_SUCCESS, BS_BADARCH or BS_READ.
+   Returns BS_SUCCESS or BS_READ.
 */
 {
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
-
 	if (mbbs_xdrpngdata(png, data, xdrs))
 		return BS_SUCCESS;
 	else
@@ -201,12 +186,9 @@ int mbbs_wrpngdata(Ping *png, MemType *data, XDR *xdrs)
 /*
    User-callable routine.
    Writes sample data to the XDR stream pointed to by xdrs.
-   Returns BS_SUCCESS, BS_BADARCH or BS_WRITE.
+   Returns BS_SUCCESS or BS_WRITE.
 */
 {
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
-
 	if (mbbs_xdrpngdata(png, data, xdrs))
 		return BS_SUCCESS;
 	else
@@ -217,12 +199,9 @@ int mbbs_rdpngpddata(Ping *png, PingData *pddata, XDR *xdrs)
 /*
    User-callable routine.
    Reads sample data from the XDR stream pointed to by xdrs.
-   Returns BS_SUCCESS, BS_BADARCH or BS_WRITE.
+   Returns BS_SUCCESS or BS_WRITE.
 */
 {
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
-
 	if (mbbs_xdrpngpddata(png, pddata, xdrs))
 		return BS_SUCCESS;
 	else
@@ -233,12 +212,9 @@ int mbbs_wrpngpddata(Ping *png, PingData *pddata, XDR *xdrs)
 /*
    User-callable routine.
    Writes sample data to the XDR stream pointed to by xdrs.
-   Returns BS_SUCCESS, BS_BADARCH or BS_WRITE.
+   Returns BS_SUCCESS or BS_WRITE.
 */
 {
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
-
 	if (mbbs_xdrpngpddata(png, pddata, xdrs))
 		return BS_SUCCESS;
 	else
@@ -254,13 +230,10 @@ int mbbs_rdpng(Ping *png, MemType **data, XDR *xdrs, int version)
    it does some error checking). Memory for the actual sample
    data is allocated. version should be the bs_version value
    from the file header which indicates the version of the file.
-   Returns BS_SUCCESS, BS_BADARCH, BS_BADARG, BS_MEMALLOC or BS_READ.
+   Returns BS_SUCCESS, BS_BADARG, BS_MEMALLOC or BS_READ.
 */
 {
 	unsigned long ibcsv;
-
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
 
 	bs_iobytecnt = 0;
 
@@ -296,13 +269,10 @@ int mbbs_wrpng(Ping *png, MemType *data, XDR *xdrs)
    User-callable routine.
    Writes ping header and data to the
    XDR stream pointed to by xdrs.
-   Returns BS_SUCCESS, BS_BADARCH or BS_WRITE.
+   Returns BS_SUCCESS or BS_WRITE.
 */
 {
 	unsigned long ibcsv;
-
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
 
 	bs_iobytecnt = 0;
 
@@ -323,7 +293,7 @@ int mbbs_seekpng(int count, XDR *xdrs, int version)
    Seeks past the next n pings in the XDR stream pointed to by xdrs.
    version should be the bs_version value from the file header which
    indicates the version of the file.
-   Returns BS_SUCCESS, BS_BADARCH, BS_BADARG or BS_READ.
+   Returns BS_SUCCESS, BS_BADARG or BS_READ.
 */
 {
 	Ping png;
@@ -333,9 +303,6 @@ int mbbs_seekpng(int count, XDR *xdrs, int version)
 	float f;
 	char *cp;
 	unsigned long ibcsv;
-
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
 
 	bs_iobytecnt = 0;
 
@@ -456,7 +423,7 @@ int mbbs_seekpngdata(Ping *png, XDR *xdrs)
    Seeks past a single ping data segment
    to the beginning of the next ping header
    in the XDR stream pointed to by xdrs.
-   Returns BS_SUCCESS, BS_BADARCH or BS_READ.
+   Returns BS_SUCCESS or BS_READ.
 */
 {
 	int j, bsi, side, err, n, ii, rem;
@@ -464,9 +431,6 @@ int mbbs_seekpngdata(Ping *png, XDR *xdrs)
 	u_int ui1;
 	float f;
 	char *cp;
-
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
 
 	bs_iobytecnt = 0;
 
@@ -570,7 +534,7 @@ int mbbs_copypng(int count, XDR *xdris, XDR *xdros, int version)
    from the file header which indicates the version of the file.
    Note that this routine will set bs_iobytecnt to the count
    of bytes written, not bytes read!
-   Returns BS_SUCCESS, BS_BADARCH, BS_BADARG, BS_READ or BS_WRITE.
+   Returns BS_SUCCESS, BS_BADARG, BS_READ or BS_WRITE.
 */
 {
 	Ping png;
@@ -580,9 +544,6 @@ int mbbs_copypng(int count, XDR *xdris, XDR *xdros, int version)
 	float f;
 	char *cp;
 	unsigned int ibcsv;
-
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
 
 	bs_iobytecnt = 0;
 
@@ -1362,9 +1323,6 @@ int mbbs_xdrstring(XDR *xdrs, char **cpp, unsigned long *bytecnt)
 
 int mbbs_rdversion(FILE *fp, int *version) {
 	XDR xdrs;
-
-	if (sizeof(int) < 4)
-		return BS_BADARCH;
 
 	bs_iobytecnt = 0;
 


### PR DESCRIPTION
```c
if (sizeof(int) < 4)
  return BS_BADARCH;
```

The world is going to come apart if int is less than 4 bytes.

This should be a check at configure time, not runtime.