### PR TITLE
mbbs_tm.c: Cleanup

### DIFF
--- a/src/bsio/mbbs_tm.c
+++ b/src/bsio/mbbs_tm.c
@@ -27,19 +27,45 @@
  *	Copyright (c) 1993 by University of Hawaii.
  */
 
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 
+#include "mbbs.h"
 #include "mbbs_defines.h"
 
 static int tm_monthdays[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31, 31};
 static int tm_callertz = TM_TZ_UNKNOWN;
 
-static char *tm_newtzval, *tm_oldtzval;
-static int tm_rsttzval, tm_clrtzval;
+static char *tm_newtzval = NULL;
+static char *tm_oldtzval = NULL;
+static int tm_rsttzval;
+static int tm_clrtzval;
 
-int mbbs_tmparsegmttz(char *str, int tmmode, double *dtm)
+/*
+   Attempt to restore the original timezone that was replaced
+   by a preceding mbbs_setgmttz() call. If there was no original
+   timezone, just zero the value. This function is always called
+   from within a return statement, so always return the code
+   passed in as an argument regardless of whether the environment
+   is successfully restored to its original state.
+*/
+int mbbs_rsttz(int code)
+{
+	if (tm_callertz == TM_TZ_GMT)
+		return code;
+	if (tm_rsttzval)
+		(void)putenv(tm_oldtzval);
+	else if (tm_clrtzval) {
+		if ((tm_newtzval = (char *)calloc((size_t)(strlen("TZ=") + 1), sizeof(char))) == (char *)0)
+			return code;
+		(void)strcpy(tm_newtzval, "TZ=");
+		(void)putenv(tm_newtzval);
+	}
+
+	return code;
+}
+
 /*
    It turns out that making large numbers of calls to mbbs_tmparse()
    is very expensive memory-wise due to the repeated calloc() calls
@@ -49,28 +75,16 @@ int mbbs_tmparsegmttz(char *str, int tmmode, double *dtm)
    routine instead. This routine sets and restores a special flag
    that turns both mbbs_setgmttz() and mbbs_rsttz() into no-ops.
 */
+int mbbs_tmparsegmttz(char *str, int tmmode, double *dtm)
 {
-	int err;
-	int mbbs_tmparse(char *, int, double *);
-
 	tm_callertz = TM_TZ_GMT;
-	err = mbbs_tmparse(str, tmmode, dtm);
+	const int err = mbbs_tmparse(str, tmmode, dtm);
 	tm_callertz = TM_TZ_UNKNOWN;
 
 	return err;
 }
 
 int mbbs_tmparse(char *str, int tmmode, double *dtm) {
-	char tmstrcp[TM_MAXSTRLEN + 1];
-	struct tm ts;
-	char *token, *cp;
-	double seconds, fraction;
-	int err;
-	time_t tmt;
-	int mbbs_setgmttz();
-	int mbbs_rsttz(int);
-	void mbbs_jul2cal(struct tm *), mbbs_cal2jul(struct tm *);
-
 	switch (tmmode) {
 	case TM_JULIAN:
 	case TM_CALENDAR:
@@ -81,9 +95,11 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 
 	/* mktime() gives unreliable results unless
 	   the time zone is explicitly set to GMT */
+	int err;
 	if ((err = mbbs_setgmttz()) != BS_SUCCESS)
 		return err;
 
+	char tmstrcp[TM_MAXSTRLEN + 1];
 	if ((str == (char *)0) || (strlen(str) == 0))
 		return mbbs_rsttz(BS_BADARG);
 	else if (strlen(str) <= TM_MAXSTRLEN)
@@ -91,6 +107,7 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 	else
 		return mbbs_rsttz(BS_BADARG);
 
+	struct tm ts;
 	ts.tm_sec = 0;
 	ts.tm_min = 0;
 	ts.tm_hour = 0;
@@ -100,8 +117,10 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 	ts.tm_yday = 0;
 	ts.tm_isdst = 0;
 
+	char *token;
 	if ((token = strtok(tmstrcp, ":/- ")) == (char *)0)
 		return mbbs_rsttz(BS_BADARG);
+	char *cp;
 	ts.tm_year = (int)strtol(token, &cp, 10);
 	if ((cp == token) || (*cp != '\0'))
 		return mbbs_rsttz(BS_BADARG);
@@ -118,7 +137,8 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 	ts.tm_year -= 1900;
 
 	if ((token = strtok((char *)0, ":/- ")) == (char *)0) {
-		if ((tmt = mktime(&ts)) == (time_t)-1)
+		const time_t tmt = mktime(&ts);
+		if (tmt == (time_t)-1)
 			return mbbs_rsttz(BS_FAILURE);
 		*dtm = (double)tmt;
 		return mbbs_rsttz(BS_SUCCESS);
@@ -144,7 +164,8 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 
 		if ((token = strtok((char *)0, ":/- ")) == (char *)0) {
 			mbbs_cal2jul(&ts);
-			if ((tmt = mktime(&ts)) == (time_t)-1)
+			const time_t tmt = mktime(&ts);
+			if (tmt == (time_t)-1)
 				return mbbs_rsttz(BS_FAILURE);
 			*dtm = (double)tmt;
 			return mbbs_rsttz(BS_SUCCESS);
@@ -159,7 +180,8 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 	}
 
 	if ((token = strtok((char *)0, ":/- ")) == (char *)0) {
-		if ((tmt = mktime(&ts)) == (time_t)-1)
+		const time_t tmt = mktime(&ts);
+		if (tmt == (time_t)-1)
 			return mbbs_rsttz(BS_FAILURE);
 		*dtm = (double)tmt;
 		return mbbs_rsttz(BS_SUCCESS);
@@ -171,7 +193,8 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 		return mbbs_rsttz(BS_BADARG);
 
 	if ((token = strtok((char *)0, ":/- ")) == (char *)0) {
-		if ((tmt = mktime(&ts)) == (time_t)-1)
+		const time_t tmt = mktime(&ts);
+		if (tmt == (time_t)-1)
 			return mbbs_rsttz(BS_FAILURE);
 		*dtm = (double)tmt;
 		return mbbs_rsttz(BS_SUCCESS);
@@ -183,41 +206,42 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 		return mbbs_rsttz(BS_BADARG);
 
 	if ((token = strtok((char *)0, ":/- ")) == (char *)0) {
-		if ((tmt = mktime(&ts)) == (time_t)-1)
+		const time_t tmt = mktime(&ts);
+		if (tmt == (time_t)-1)
 			return mbbs_rsttz(BS_FAILURE);
 		*dtm = (double)tmt;
 		return mbbs_rsttz(BS_SUCCESS);
 	}
-	seconds = strtod(token, &cp);
+	const double seconds = strtod(token, &cp);
 	if ((cp == token) || (*cp != '\0'))
 		return mbbs_rsttz(BS_BADARG);
 	if ((seconds < 0.) || (seconds >= 60.))
 		return mbbs_rsttz(BS_BADARG);
 	ts.tm_sec = (int)seconds;
-	fraction = seconds - ((double)ts.tm_sec);
+	const double fraction = seconds - ((double)ts.tm_sec);
 
-	if ((tmt = mktime(&ts)) == (time_t)-1)
+	const time_t tmt = mktime(&ts);
+	if (tmt == (time_t)-1)
 		return mbbs_rsttz(BS_FAILURE);
 	*dtm = ((double)tmt) + fraction;
 
 	return mbbs_rsttz(BS_SUCCESS);
 }
 
-int mbbs_setgmttz()
 /*
    Set the timezone to GMT if necessary so that
    SYSV mktime() will work properly. A call to this
    function should always be followed by a call to
    mbbs_rsttz() to undo its effect, if any.
 */
+int mbbs_setgmttz()
 {
-	char *tz;
-
 	if (tm_callertz == TM_TZ_GMT)
 		return BS_SUCCESS;
 
 	tm_rsttzval = tm_clrtzval = 0;
-	if (((tz = getenv("TZ")) != (char *)0) && (strlen(tz) > 0)) {
+	const char *tz = getenv("TZ");
+	if ((tz != (char *)0) && (strlen(tz) > 0)) {
 		if (strcmp(tz, "GMT")) {
 			if ((tm_oldtzval = (char *)calloc((size_t)(strlen("TZ=") + strlen(tz) + 1), sizeof(char))) == (char *)0)
 				return BS_MEMALLOC;
@@ -250,83 +274,47 @@ int mbbs_setgmttz()
 	return BS_SUCCESS;
 }
 
-int mbbs_rsttz(int code)
-/*
-   Attempt to restore the original timezone that was replaced
-   by a preceding mbbs_setgmttz() call. If there was no original
-   timezone, just zero the value. This function is always called
-   from within a return statement, so always return the code
-   passed in as an argument regardless of whether the environment
-   is successfully restored to its original state.
-*/
-{
-	if (tm_callertz == TM_TZ_GMT)
-		return code;
-	if (tm_rsttzval)
-		(void)putenv(tm_oldtzval);
-	else if (tm_clrtzval) {
-		if ((tm_newtzval = (char *)calloc((size_t)(strlen("TZ=") + 1), sizeof(char))) == (char *)0)
-			return code;
-		(void)strcpy(tm_newtzval, "TZ=");
-		(void)putenv(tm_newtzval);
-	}
-
-	return code;
-}
-
-void mbbs_jul2cal(struct tm *ts)
 /*
    Derive Unix calendar month (0-11) and day (1-31)
    from Unix year (real year minus 1900) and julian day (0-365).
 */
+void mbbs_jul2cal(struct tm *ts)
 {
-	int mdays, leap;
-	int mbbs_leapyr(struct tm *);
-
-	leap = mbbs_leapyr(ts);
+	const int leap = mbbs_leapyr(ts);
 	ts->tm_mday = ts->tm_yday + 1;
 	for (ts->tm_mon = 0; ts->tm_mon < 12; ts->tm_mon++) {
-		mdays = tm_monthdays[ts->tm_mon];
+		int mdays = tm_monthdays[ts->tm_mon];
 		if (leap && (ts->tm_mon == 1))
 			mdays++;
 		if (ts->tm_mday <= mdays)
 			return;
 		ts->tm_mday -= mdays;
 	}
-
-	return;
 }
 
-void mbbs_cal2jul(struct tm *ts)
 /*
    Derive Unix julian day (0-365) from Unix year (real year
    minus 1900), calendar month (0-11) and day (1-31).
 */
+void mbbs_cal2jul(struct tm *ts)
 {
-	int leap, month, mdays;
-	int mbbs_leapyr(struct tm *);
-
-	leap = mbbs_leapyr(ts);
+	const int leap = mbbs_leapyr(ts);
 	ts->tm_yday = 0;
-	for (month = 0; month < ts->tm_mon; month++) {
-		mdays = tm_monthdays[month];
+	for (int month = 0; month < ts->tm_mon; month++) {
+		int mdays = tm_monthdays[month];
 		if (leap && (month == 1))
 			mdays++;
 		ts->tm_yday += mdays;
 	}
 	ts->tm_yday += ts->tm_mday - 1;
-
-	return;
 }
 
-int mbbs_leapyr(struct tm *ts)
 /*
    Returns 1 if leap year, 0 otherwise.
 */
+int mbbs_leapyr(struct tm *ts)
 {
-	int year;
-
-	year = ts->tm_year + 1900;
+	const int year = ts->tm_year + 1900;
 
 	return ((year % 4 == 0) && ((year % 100 != 0) || (year % 400 == 0)));
 }


### PR DESCRIPTION
- Order includes
- Add include of `mbbs.h`
- Define one variable per line
- Move `mbbs_rsttz()` to the top of the file to remove need for a prototype
- Remove prototypes from inside of functions
- Localize variables
- Add `const`
- Initialize global pointers to `NULL`
- Remove final `return` from void functions