### PR TITLE
Fix mbbs_tm.c

### DIFF
--- a/src/bsio/mbbs_tm.c
+++ b/src/bsio/mbbs_tm.c
@@ -27,6 +27,7 @@
  *	Copyright (c) 1993 by University of Hawaii.
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>


### PR DESCRIPTION
Fix mbbs_tm.c - the
#include <stdio.h>
statement was inadvertently deleted.