### PR TITLE
mbio: Remove redundant "print debug statements".

### DIFF
--- a/src/mbio/mb_check_info.c
+++ b/src/mbio/mb_check_info.c
@@ -56,7 +56,6 @@ int mb_check_info(int verbose, char *file, int lonflip, double bounds[4], int *f
 	if (strncmp(file, stdin_string, 5) == 0) {
 		*file_in_bounds = MB_YES;
 
-		/*print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "dbg4  Cannot check bounds if input is stdin...\n");
 		}
@@ -165,7 +164,6 @@ int mb_check_info(int verbose, char *file, int lonflip, double bounds[4], int *f
 						*file_in_bounds = MB_NO;
 				}
 
-				/*print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "dbg4  Bounds from inf file:\n");
 					fprintf(stderr, "dbg4      lon_min: %f\n", lon_min);
@@ -180,7 +178,6 @@ int mb_check_info(int verbose, char *file, int lonflip, double bounds[4], int *f
 			else if (nrecords == 0) {
 				*file_in_bounds = MB_NO;
 
-				/*print debug statements */
 				if (verbose >= 4)
 					fprintf(stderr, "dbg4  The inf file shows zero records so out of bounds...\n");
 			}
@@ -190,7 +187,6 @@ int mb_check_info(int verbose, char *file, int lonflip, double bounds[4], int *f
 			else {
 				*file_in_bounds = MB_YES;
 
-				/*print debug statements */
 				if (verbose >= 4)
 					fprintf(stderr, "dbg4  No data listed in inf file so cannot check bounds...\n");
 			}
@@ -203,7 +199,6 @@ int mb_check_info(int verbose, char *file, int lonflip, double bounds[4], int *f
 		else {
 			*file_in_bounds = MB_YES;
 
-			/*print debug statements */
 			if (verbose >= 4)
 				fprintf(stderr, "dbg4  Cannot open inf file so cannot check bounds...\n");
 		}
@@ -251,7 +246,6 @@ int mb_get_info(int verbose, char *file, struct mb_info_struct *mb_info, int lon
 		*error = MB_ERROR_OPEN_FAIL;
 		status = MB_FAILURE;
 
-		/*print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "dbg2  Cannot open requested inf file: %s\n", file_inf);
 		}

--- a/src/mbio/mb_get.c
+++ b/src/mbio/mb_get.c
@@ -82,7 +82,6 @@ int mb_get(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], do
 	int done = MB_NO;
 	while (done == MB_NO) {
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg2  About to read ping in function <%s>\n", __func__);
 			fprintf(stderr, "dbg2       need_new_ping: %d\n", mb_io_ptr->need_new_ping);
@@ -182,7 +181,6 @@ int mb_get(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], do
 			mb_io_ptr->old_lat = mb_io_ptr->new_lat;
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg2  New ping read in function <%s>\n", __func__);
 			fprintf(stderr, "dbg2       need_new_ping: %d\n", mb_io_ptr->need_new_ping);
@@ -230,7 +228,6 @@ int mb_get(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], do
 		if (*error < MB_ERROR_NO_ERROR)
 			mb_notice_log_error(verbose, mbio_ptr, *error);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping checked by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -347,7 +344,6 @@ int mb_get(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], do
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 4 && mb_io_ptr->new_kind == MB_DATA_DATA &&
 		    (status == MB_SUCCESS || (*error<MB_ERROR_NO_ERROR && * error> MB_ERROR_COMMENT && mb_io_ptr->pings_read == 1))) {
 			fprintf(stderr, "\ndbg4  New ping binned by MBIO function <%s>\n", __func__);
@@ -445,7 +441,6 @@ int mb_get(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], do
 			mb_io_ptr->last_lat = mb_io_ptr->new_lat;
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  End of reading loop in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Current status values:\n");
@@ -543,7 +538,6 @@ int mb_get(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], do
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Distance and Speed Calculated in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Speed and Distance Related Values:\n");

--- a/src/mbio/mb_get_all.c
+++ b/src/mbio/mb_get_all.c
@@ -51,14 +51,12 @@ int mb_get_all(int verbose, void *mbio_ptr, void **store_ptr, int *kind, int tim
 	/* reset status */
 	*error = MB_ERROR_NO_ERROR;
 
-	/* print debug statements */
 	if (verbose >= 4) {
 		fprintf(stderr, "\ndbg2  About to read ping in function <%s>\n", __func__);
 		fprintf(stderr, "dbg2       ping_count:    %d\n", mb_io_ptr->ping_count);
 		fprintf(stderr, "dbg2       error:         %d\n", *error);
 	}
 
-	/* get next ping */
 	int status = mb_read_ping(verbose, mbio_ptr, *store_ptr, kind, error);
 
 	/* if io arrays have been reallocated, update the
@@ -137,7 +135,6 @@ int mb_get_all(int verbose, void *mbio_ptr, void **store_ptr, int *kind, int tim
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 4) {
 		fprintf(stderr, "\ndbg2  New ping read in function <%s>\n", __func__);
 		fprintf(stderr, "dbg2       status:        %d\n", status);
@@ -200,7 +197,6 @@ int mb_get_all(int verbose, void *mbio_ptr, void **store_ptr, int *kind, int tim
 		else if (*speed < 0.0)
 			*speed = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Distance and Speed Calculated in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Speed and Distance Related Values:\n");
@@ -251,7 +247,6 @@ int mb_get_all(int verbose, void *mbio_ptr, void **store_ptr, int *kind, int tim
 		else if (*speed < 0.0)
 			*speed = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Distance and Speed Calculated in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Speed and Distance Related Values:\n");
@@ -325,7 +320,6 @@ int mb_get_all(int verbose, void *mbio_ptr, void **store_ptr, int *kind, int tim
 	if (*error < MB_ERROR_NO_ERROR)
 		mb_notice_log_error(verbose, mbio_ptr, *error);
 
-	/* print debug statements */
 	if (verbose >= 4) {
 		fprintf(stderr, "\ndbg4  New ping checked by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg4  New ping values:\n");

--- a/src/mbio/mb_mem.c
+++ b/src/mbio/mb_mem.c
@@ -56,7 +56,6 @@ int mb_mem_debug_on(int verbose, int *error) {
 		fprintf(stderr, "dbg2       verbose:    %d\n", verbose);
 	}
 
-	/* print debug statements */
 	if (verbose >= 6 || mb_mem_debug) {
 		fprintf(stderr, "\ndbg6  Allocated memory list in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < n_mb_alloc; i++)
@@ -89,7 +88,6 @@ int mb_mem_debug_off(int verbose, int *error) {
 		fprintf(stderr, "dbg2       verbose:    %d\n", verbose);
 	}
 
-	/* print debug statements */
 	if (verbose >= 6 || mb_mem_debug) {
 		fprintf(stderr, "\ndbg6  Allocated memory list in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < n_mb_alloc; i++)
@@ -140,7 +138,6 @@ int mb_malloc(int verbose, size_t size, void **ptr, int *error) {
 		status = MB_SUCCESS;
 	}
 
-	/* print debug statements */
 	if ((verbose >= 5 || mb_mem_debug) && size > 0) {
 		fprintf(stderr, "\ndbg5  Memory allocated in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       i:%d  ptr:%p  size:%zu\n", n_mb_alloc, (void *)*ptr, size);
@@ -161,7 +158,6 @@ int mb_malloc(int verbose, size_t size, void **ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 6 || mb_mem_debug) {
 		fprintf(stderr, "\ndbg6  Allocated memory list in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < n_mb_alloc; i++)
@@ -212,7 +208,6 @@ int mb_mallocd(int verbose, const char *sourcefile, int sourceline, size_t size,
 		status = MB_SUCCESS;
 	}
 
-	/* print debug statements */
 	if ((verbose >= 5 || mb_mem_debug) && size > 0) {
 		fprintf(stderr, "\ndbg5  Memory allocated in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       i:%d  ptr:%p  size:%zu\n", n_mb_alloc, (void *)*ptr, size);
@@ -235,7 +230,6 @@ int mb_mallocd(int verbose, const char *sourcefile, int sourceline, size_t size,
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 6 || mb_mem_debug) {
 		fprintf(stderr, "\ndbg6  Allocated memory list in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < n_mb_alloc; i++)
@@ -323,13 +317,11 @@ int mb_realloc(int verbose, size_t size, void **ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if ((verbose >= 5 || mb_mem_debug) && size > 0) {
 		fprintf(stderr, "\ndbg5  Memory reallocated in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       i:%d  ptr:%p  size:%zu\n", n_mb_alloc, (void *)*ptr, size);
 	}
 
-	/* print debug statements */
 	if (verbose >= 6 || mb_mem_debug) {
 		fprintf(stderr, "\ndbg6  Allocated memory list in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < n_mb_alloc; i++)
@@ -429,14 +421,12 @@ int mb_reallocd(int verbose, const char *sourcefile, int sourceline, size_t size
 		}
 	}
 
-	/* print debug statements */
 	if ((verbose >= 5 || mb_mem_debug) && size > 0) {
 		fprintf(stderr, "\ndbg5  Memory reallocated in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       i:%d  ptr:%p  size:%zu source:%s line:%d\n", n_mb_alloc, (void *)*ptr, size, sourcefile,
 		        sourceline);
 	}
 
-	/* print debug statements */
 	if (verbose >= 6 || mb_mem_debug) {
 		fprintf(stderr, "\ndbg6  Allocated memory list in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < n_mb_alloc; i++)
@@ -506,13 +496,11 @@ int mb_free(int verbose, void **ptr, int *error) {
 		*ptr = NULL;
 	}
 
-	/* print debug statements */
 	if ((verbose >= 5 || mb_mem_debug) && iptr > -1) {
 		fprintf(stderr, "\ndbg5  Allocated memory freed in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       i:%d  ptr:%p  size:%zu\n", iptr, ptrvalue, ptrsize);
 	}
 
-	/* print debug statements */
 	if (verbose >= 6 || mb_mem_debug) {
 		fprintf(stderr, "\ndbg6  Allocated memory list in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < n_mb_alloc; i++)
@@ -583,13 +571,11 @@ int mb_freed(int verbose, const char *sourcefile, int sourceline, void **ptr, in
 		*ptr = NULL;
 	}
 
-	/* print debug statements */
 	if ((verbose >= 5 || mb_mem_debug) && iptr > -1) {
 		fprintf(stderr, "\ndbg5  Allocated memory freed in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       i:%d  ptr:%p  size:%zu\n", iptr, (void *)ptrvalue, ptrsize);
 	}
 
-	/* print debug statements */
 	if (verbose >= 6 || mb_mem_debug) {
 		fprintf(stderr, "\ndbg6  Allocated memory list in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < n_mb_alloc; i++)
@@ -621,7 +607,6 @@ int mb_memory_clear(int verbose, int *error) {
 
 	/* loop over all allocated memory */
 	for (int i = 0; i < n_mb_alloc; i++) {
-		/* print debug statements */
 		if (verbose >= 5 || mb_mem_debug) {
 			fprintf(stderr, "\ndbg5  Allocated memory freed in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4       i:%d  ptr:%12p  size:%zu\n", i, (void *)mb_alloc_ptr[i], mb_alloc_size[i]);
@@ -693,7 +678,6 @@ int mb_memory_list(int verbose, int *error) {
 		fprintf(stderr, "dbg2       verbose:    %d\n", verbose);
 	}
 
-	/* print debug statements */
 	if (verbose >= 4 || mb_mem_debug) {
 		if (n_mb_alloc > 0) {
 			fprintf(stderr, "\ndbg4  Allocated memory list in MBIO function <%s>\n", __func__);

--- a/src/mbio/mb_navint.c
+++ b/src/mbio/mb_navint.c
@@ -80,7 +80,6 @@ int mb_navint_add(int verbose, void *mbio_ptr, double time_d, double lon_easting
 		fprintf(stderr, "mb_navint_add:    Nav fix %d %f %f added\n", mb_io_ptr->nfix, lon_easting, lat_northing);
 #endif
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Nav fix added to list by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New fix values:\n");
@@ -450,7 +449,6 @@ int mb_attint_add(int verbose, void *mbio_ptr, double time_d, double heave, doub
 		        time_d, roll, pitch, heave);
 #endif
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Attitude fix added to list by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New fix values:\n");
@@ -522,7 +520,6 @@ int mb_attint_nadd(int verbose, void *mbio_ptr, int nsamples, double *time_d, do
 #endif
 		mb_io_ptr->nattitude++;
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Attitude fixes added to list by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New fix values:\n");
@@ -681,7 +678,6 @@ int mb_hedint_add(int verbose, void *mbio_ptr, double time_d, double heading, in
 		fprintf(stderr, "mb_hedint_add:    Heading fix %d %f added\n", mb_io_ptr->nheading, heading);
 #endif
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Heading fix added to list by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New fix values:\n");
@@ -745,7 +741,6 @@ int mb_hedint_nadd(int verbose, void *mbio_ptr, int nsamples, double *time_d, do
 #endif
 		mb_io_ptr->nheading++;
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Heading fixes added to list by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New fix values:\n");
@@ -897,7 +892,6 @@ int mb_depint_add(int verbose, void *mbio_ptr, double time_d, double sonardepth,
 		fprintf(stderr, "mb_depint_add:    sonardepth fix %d %f added\n", mb_io_ptr->nsonardepth, sonardepth);
 #endif
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Sonar depth fix added to list by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New fix values:\n");
@@ -1042,7 +1036,6 @@ int mb_altint_add(int verbose, void *mbio_ptr, double time_d, double altitude, i
 		fprintf(stderr, "mb_altint_add:    altitude fix %d %f added\n", mb_io_ptr->naltitude, altitude);
 #endif
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Altitude fix added to list by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New fix values:\n");

--- a/src/mbio/mb_read.c
+++ b/src/mbio/mb_read.c
@@ -84,7 +84,6 @@ int mb_read(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], d
 	int done = MB_NO;
 	while (done == MB_NO) {
 
-		/* print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "\ndbg2  About to read ping in function <%s>\n", __func__);
 			fprintf(stderr, "dbg2       need_new_ping: %d\n", mb_io_ptr->need_new_ping);
@@ -184,7 +183,6 @@ int mb_read(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], d
 			mb_io_ptr->old_lat = mb_io_ptr->new_lat;
 		}
 
-		/* print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "\ndbg2  New ping read in function <%s>\n", __func__);
 			fprintf(stderr, "dbg2       need_new_ping: %d\n", mb_io_ptr->need_new_ping);
@@ -228,7 +226,6 @@ int mb_read(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], d
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping checked by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -345,7 +342,6 @@ int mb_read(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], d
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 4 && mb_io_ptr->new_kind == MB_DATA_DATA &&
 		    (status == MB_SUCCESS || (*error<MB_ERROR_NO_ERROR && * error> MB_ERROR_COMMENT && mb_io_ptr->pings_read == 1))) {
 			fprintf(stderr, "\ndbg4  New ping binned by MBIO function <%s>\n", __func__);
@@ -443,7 +439,6 @@ int mb_read(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], d
 			mb_io_ptr->last_lat = mb_io_ptr->new_lat;
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  End of reading loop in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Current status values:\n");
@@ -539,7 +534,6 @@ int mb_read(int verbose, void *mbio_ptr, int *kind, int *pings, int time_i[7], d
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Distance and Speed Calculated in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Speed and Distance Related Values:\n");

--- a/src/mbio/mb_rt.c
+++ b/src/mbio/mb_rt.c
@@ -897,7 +897,6 @@ int mb_rt(int verbose, void *modelptr, double source_depth, double source_angle,
 		model->number_plot++;
 	}
 
-	/* print debug statements */
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  About to trace ray in MB_RT function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2       xx:               %f\n", model->xx);
@@ -932,7 +931,6 @@ int mb_rt(int verbose, void *modelptr, double source_depth, double source_angle,
 		if (model->tt_left <= 0.0)
 			model->done = MB_YES;
 
-		/* print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "\ndbg2  model->done with ray iteration in MB_RT function <%s>\n", __func__);
 			fprintf(stderr, "dbg2       xx:               %f\n", model->xx);

--- a/src/mbio/mbr_bchrtunb.c
+++ b/src/mbio/mbr_bchrtunb.c
@@ -330,7 +330,6 @@ int mbr_bchrtunb_rd_comment(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct 
 		strncpy(data->comment, line, MBF_BCHRTUNB_COMMENT_LENGTH - 1);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -479,7 +478,6 @@ int mbr_bchrtunb_rd_parameter(int verbose, FILE *mbfp, struct mbf_bchrtunb_struc
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->par_year);
@@ -603,7 +601,6 @@ int mbr_bchrtunb_rd_pos(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct *dat
 	if (data->pos_year == 96 && data->pos_month >= 6 && data->pos_month <= 8)
 		data->pos_longitude = -data->pos_longitude;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->pos_year);
@@ -696,7 +693,6 @@ int mbr_bchrtunb_rd_svp(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct *dat
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -837,7 +833,6 @@ int mbr_bchrtunb_rd_bath56(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct *
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);
@@ -1000,7 +995,6 @@ int mbr_bchrtunb_rd_bath40(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct *
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);
@@ -1163,7 +1157,6 @@ int mbr_bchrtunb_rd_bath32(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct *
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);
@@ -1529,7 +1522,6 @@ int mbr_bchrtunb_wr_comment(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct 
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -1598,7 +1590,6 @@ int mbr_bchrtunb_wr_parameter(int verbose, FILE *mbfp, struct mbf_bchrtunb_struc
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->par_year);
@@ -1797,7 +1788,6 @@ int mbr_bchrtunb_wr_pos(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct *dat
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->pos_year);
@@ -1923,7 +1913,6 @@ int mbr_bchrtunb_wr_svp(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct *dat
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -2034,7 +2023,6 @@ int mbr_bchrtunb_wr_bath56(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct *
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);
@@ -2214,7 +2202,6 @@ int mbr_bchrtunb_wr_bath40(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct *
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);
@@ -2394,7 +2381,6 @@ int mbr_bchrtunb_wr_bath32(int verbose, FILE *mbfp, struct mbf_bchrtunb_struct *
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);

--- a/src/mbio/mbr_bchrxunb.c
+++ b/src/mbio/mbr_bchrxunb.c
@@ -331,7 +331,6 @@ int mbr_bchrxunb_rd_comment(int verbose, FILE *mbfp, struct mbf_bchrxunb_struct 
 		strncpy(data->comment, line, MBF_BCHRXUNB_COMMENT_LENGTH - 1);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -477,7 +476,6 @@ int mbr_bchrxunb_rd_parameter(int verbose, FILE *mbfp, struct mbf_bchrxunb_struc
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->par_year);
@@ -602,7 +600,6 @@ int mbr_bchrxunb_rd_pos(int verbose, FILE *mbfp, struct mbf_bchrxunb_struct *dat
 	if (data->pos_year == 96 && data->pos_month >= 6 && data->pos_month <= 8)
 		data->pos_longitude = -data->pos_longitude;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->pos_year);
@@ -698,7 +695,6 @@ int mbr_bchrxunb_rd_svp(int verbose, FILE *mbfp, struct mbf_bchrxunb_struct *dat
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -841,7 +837,6 @@ int mbr_bchrxunb_rd_bath56(int verbose, FILE *mbfp, struct mbf_bchrxunb_struct *
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);
@@ -1006,7 +1001,6 @@ int mbr_bchrxunb_rd_bath40(int verbose, FILE *mbfp, struct mbf_bchrxunb_struct *
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);
@@ -1171,7 +1165,6 @@ int mbr_bchrxunb_rd_bath32(int verbose, FILE *mbfp, struct mbf_bchrxunb_struct *
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);
@@ -1539,7 +1532,6 @@ int mbr_bchrxunb_wr_comment(int verbose, FILE *mbfp, void *data_ptr, int *error)
 	/* get pointer to raw data structure */
 	struct mbf_bchrxunb_struct *data = (struct mbf_bchrxunb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -1611,7 +1603,6 @@ int mbr_bchrxunb_wr_parameter(int verbose, FILE *mbfp, void *data_ptr, int *erro
 	/* get pointer to raw data structure */
 	struct mbf_bchrxunb_struct *data = (struct mbf_bchrxunb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->par_year);
@@ -1810,7 +1801,6 @@ int mbr_bchrxunb_wr_pos(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbf_bchrxunb_struct *data = (struct mbf_bchrxunb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->pos_year);
@@ -1942,7 +1932,6 @@ int mbr_bchrxunb_wr_svp(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbf_bchrxunb_struct *data = (struct mbf_bchrxunb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -2058,7 +2047,6 @@ int mbr_bchrxunb_wr_bath56(int verbose, FILE *mbfp, void *data_ptr, int *error) 
 	/* get pointer to raw data structure */
 	struct mbf_bchrxunb_struct *data = (struct mbf_bchrxunb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);
@@ -2243,7 +2231,6 @@ int mbr_bchrxunb_wr_bath40(int verbose, FILE *mbfp, void *data_ptr, int *error) 
 	/* get pointer to raw data structure */
 	struct mbf_bchrxunb_struct *data = (struct mbf_bchrxunb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);
@@ -2428,7 +2415,6 @@ int mbr_bchrxunb_wr_bath32(int verbose, FILE *mbfp, void *data_ptr, int *error) 
 	/* get pointer to raw data structure */
 	struct mbf_bchrxunb_struct *data = (struct mbf_bchrxunb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       ping_num:         %d\n", data->ping_num);

--- a/src/mbio/mbr_cbat8101.c
+++ b/src/mbio/mbr_cbat8101.c
@@ -327,7 +327,6 @@ int mbr_cbat8101_rd_comment(int verbose, FILE *mbfp, int swap, struct mbf_cbat81
 		strncpy(data->comment, line, MBF_CBAT8101_COMMENT_LENGTH - 1);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -455,7 +454,6 @@ int mbr_cbat8101_rd_parameter(int verbose, FILE *mbfp, int swap, struct mbf_cbat
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->par_year);
@@ -573,7 +571,6 @@ int mbr_cbat8101_rd_nav(int verbose, FILE *mbfp, int swap, struct mbf_cbat8101_s
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->pos_year);
@@ -672,7 +669,6 @@ int mbr_cbat8101_rd_svp(int verbose, FILE *mbfp, int swap, struct mbf_cbat8101_s
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -765,7 +761,6 @@ int mbr_cbat8101_rd_short_svp(int verbose, FILE *mbfp, int swap, struct mbf_cbat
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -911,7 +906,6 @@ int mbr_cbat8101_rd_bath(int verbose, FILE *mbfp, int swap, struct mbf_cbat8101_
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -996,7 +990,6 @@ int mbr_cbat8101_rd_heading(int verbose, FILE *mbfp, int swap, struct mbf_cbat81
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -1072,7 +1065,6 @@ int mbr_cbat8101_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbf_cbat8
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -1457,7 +1449,6 @@ int mbr_cbat8101_wr_comment(int verbose, FILE *mbfp, int swap, void *data_ptr, i
 	/* get pointer to raw data structure */
 	struct mbf_cbat8101_struct *data = (struct mbf_cbat8101_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -1529,7 +1520,6 @@ int mbr_cbat8101_wr_parameter(int verbose, FILE *mbfp, int swap, void *data_ptr,
 	/* get pointer to raw data structure */
 	struct mbf_cbat8101_struct *data = (struct mbf_cbat8101_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->par_year);
@@ -1704,7 +1694,6 @@ int mbr_cbat8101_wr_nav(int verbose, FILE *mbfp, int swap, void *data_ptr, int *
 	/* get pointer to raw data structure */
 	struct mbf_cbat8101_struct *data = (struct mbf_cbat8101_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->pos_year);
@@ -1840,7 +1829,6 @@ int mbr_cbat8101_wr_svp(int verbose, FILE *mbfp, int swap, void *data_ptr, int *
 	/* get pointer to raw data structure */
 	struct mbf_cbat8101_struct *data = (struct mbf_cbat8101_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -1969,7 +1957,6 @@ int mbr_cbat8101_wr_bath(int verbose, FILE *mbfp, int swap, void *data_ptr, int 
 	/* get pointer to raw data structure */
 	struct mbf_cbat8101_struct *data = (struct mbf_cbat8101_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -2146,7 +2133,6 @@ int mbr_cbat8101_wr_heading(int verbose, FILE *mbfp, int swap, void *data_ptr, i
 	/* get pointer to raw data structure */
 	struct mbf_cbat8101_struct *data = (struct mbf_cbat8101_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -2235,7 +2221,6 @@ int mbr_cbat8101_wr_attitude(int verbose, FILE *mbfp, int swap, void *data_ptr, 
 	/* get pointer to raw data structure */
 	struct mbf_cbat8101_struct *data = (struct mbf_cbat8101_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);

--- a/src/mbio/mbr_cbat9001.c
+++ b/src/mbio/mbr_cbat9001.c
@@ -335,7 +335,6 @@ int mbr_cbat9001_rd_comment(int verbose, FILE *mbfp, int swap, struct mbf_cbat90
 		strncpy(data->comment, line, MBF_CBAT9001_COMMENT_LENGTH - 1);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -464,7 +463,6 @@ int mbr_cbat9001_rd_parameter(int verbose, FILE *mbfp, int swap, struct mbf_cbat
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->par_year);
@@ -583,7 +581,6 @@ int mbr_cbat9001_rd_nav(int verbose, FILE *mbfp, int swap, struct mbf_cbat9001_s
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->pos_year);
@@ -683,7 +680,6 @@ int mbr_cbat9001_rd_svp(int verbose, FILE *mbfp, int swap, struct mbf_cbat9001_s
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -777,7 +773,6 @@ int mbr_cbat9001_rd_short_svp(int verbose, FILE *mbfp, int swap, struct mbf_cbat
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -924,7 +919,6 @@ int mbr_cbat9001_rd_bath(int verbose, FILE *mbfp, int swap, struct mbf_cbat9001_
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -1315,7 +1309,6 @@ int mbr_cbat9001_wr_comment(int verbose, FILE *mbfp, int swap, void *data_ptr, i
 	/* get pointer to raw data structure */
 	struct mbf_cbat9001_struct *data = (struct mbf_cbat9001_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -1387,7 +1380,6 @@ int mbr_cbat9001_wr_parameter(int verbose, FILE *mbfp, int swap, void *data_ptr,
 	/* get pointer to raw data structure */
 	struct mbf_cbat9001_struct *data = (struct mbf_cbat9001_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->par_year);
@@ -1562,7 +1554,6 @@ int mbr_cbat9001_wr_nav(int verbose, FILE *mbfp, int swap, void *data_ptr, int *
 	/* get pointer to raw data structure */
 	struct mbf_cbat9001_struct *data = (struct mbf_cbat9001_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->pos_year);
@@ -1697,7 +1688,6 @@ int mbr_cbat9001_wr_svp(int verbose, FILE *mbfp, int swap, void *data_ptr, int *
 	/* get pointer to raw data structure */
 	struct mbf_cbat9001_struct *data = (struct mbf_cbat9001_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -1827,7 +1817,6 @@ int mbr_cbat9001_wr_bath(int verbose, FILE *mbfp, int swap, void *data_ptr, int 
 	/* get pointer to raw data structure */
 	struct mbf_cbat9001_struct *data = (struct mbf_cbat9001_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);

--- a/src/mbio/mbr_dsl120pf.c
+++ b/src/mbio/mbr_dsl120pf.c
@@ -388,7 +388,6 @@ int mbr_dsl120pf_rd_header(int verbose, void *mbio_ptr, FILE *mbfp, int *error) 
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       rec_type:         %d\n", data->rec_type);
@@ -537,7 +536,6 @@ int mbr_dsl120pf_rd_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       bat_type:         %d\n", data->bat_type);
@@ -620,7 +618,6 @@ int mbr_dsl120pf_rd_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       amp_type:         %d\n", data->amp_type);
@@ -684,7 +681,6 @@ int mbr_dsl120pf_rd_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 		data->comment[79] = '\0';
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -977,7 +973,6 @@ int mbr_dsl120pf_wr_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	struct mbf_dsl120pf_struct *data = (struct mbf_dsl120pf_struct *)mb_io_ptr->raw_data;
 	char *data_ptr = (char *)data;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       rec_type:         %d\n", data->rec_type);
@@ -1154,7 +1149,6 @@ int mbr_dsl120pf_wr_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 	struct mbf_dsl120pf_struct *data = (struct mbf_dsl120pf_struct *)mb_io_ptr->raw_data;
 	char *data_ptr = (char *)data;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       rec_type:         %d\n", data->rec_type);
@@ -1334,7 +1328,6 @@ int mbr_dsl120pf_wr_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 	struct mbf_dsl120pf_struct *data = (struct mbf_dsl120pf_struct *)mb_io_ptr->raw_data;
 	char *data_ptr = (char *)data;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);

--- a/src/mbio/mbr_dsl120sf.c
+++ b/src/mbio/mbr_dsl120sf.c
@@ -356,7 +356,6 @@ int mbr_dsl120sf_rd_header(int verbose, void *mbio_ptr, FILE *mbfp, int *error) 
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       rec_type:         %d\n", data->rec_type);
@@ -505,7 +504,6 @@ int mbr_dsl120sf_rd_bath(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       bat_type:         %d\n", data->bat_type);
@@ -588,7 +586,6 @@ int mbr_dsl120sf_rd_amp(int verbose, void *mbio_ptr, FILE *mbfp, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       amp_type:         %d\n", data->amp_type);
@@ -652,7 +649,6 @@ int mbr_dsl120sf_rd_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 		data->comment[79] = '\0';
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -881,7 +877,6 @@ int mbr_dsl120sf_wr_bathamp(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 	struct mbf_dsl120sf_struct *data = (struct mbf_dsl120sf_struct *)mb_io_ptr->raw_data;
 	char *data_ptr = (char *)data;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       rec_type:         %d\n", data->rec_type);
@@ -1102,7 +1097,6 @@ int mbr_dsl120sf_wr_comment(int verbose, void *mbio_ptr, FILE *mbfp, int *error)
 	struct mbf_dsl120sf_struct *data = (struct mbf_dsl120sf_struct *)mb_io_ptr->raw_data;
 	char *data_ptr = (char *)data;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);

--- a/src/mbio/mbr_edgjstar.c
+++ b/src/mbio/mbr_edgjstar.c
@@ -1783,7 +1783,6 @@ int mbr_rt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	fprintf(stderr, "kind:%d error:%d status:%d\n", store->kind, *error, status);
 #endif
 
-	/* print debug statements */
 	if (status == MB_SUCCESS && verbose >= 5 && store->kind == MB_DATA_COMMENT) {
 		fprintf(stderr, "\ndbg5  New comment read by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Subsystem ID:\n");
@@ -2320,7 +2319,6 @@ int mbr_wt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbsys_jstar_struct *store = (struct mbsys_jstar_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5 && store->kind == MB_DATA_COMMENT) {
 		fprintf(stderr, "\ndbg5  New comment to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Subsystem ID:\n");

--- a/src/mbio/mbr_elmk2unb.c
+++ b/src/mbio/mbr_elmk2unb.c
@@ -331,7 +331,6 @@ int mbr_elmk2unb_rd_comment(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct 
 		strncpy(data->comment, line, MBF_ELMK2UNB_COMMENT_LENGTH - 1);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -477,7 +476,6 @@ int mbr_elmk2unb_rd_parameter(int verbose, FILE *mbfp, struct mbf_elmk2unb_struc
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->par_year);
@@ -602,7 +600,6 @@ int mbr_elmk2unb_rd_pos(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct *dat
 	if (data->pos_year == 96 && data->pos_month >= 6 && data->pos_month <= 8)
 		data->pos_longitude = -data->pos_longitude;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->pos_year);
@@ -698,7 +695,6 @@ int mbr_elmk2unb_rd_svp(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct *dat
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -797,7 +793,6 @@ int mbr_elmk2unb_rd_bathgen(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct 
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -881,7 +876,6 @@ int mbr_elmk2unb_rd_bathgen(int verbose, FILE *mbfp, struct mbf_elmk2unb_struct 
 #endif
 			}
 
-			/* print debug statements */
 			if (status == MB_SUCCESS && verbose >= 5) {
 				fprintf(stderr, "\ndbg5       beam:             %d\n", i);
 				fprintf(stderr, "dbg5       bath:             %d\n", data->beams[i].bath);
@@ -1233,7 +1227,6 @@ int mbr_elmk2unb_wr_comment(int verbose, FILE *mbfp, void *data_ptr, int *error)
 	/* get pointer to raw data structure */
 	struct mbf_elmk2unb_struct *data = (struct mbf_elmk2unb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -1305,7 +1298,6 @@ int mbr_elmk2unb_wr_parameter(int verbose, FILE *mbfp, void *data_ptr, int *erro
 	/* get pointer to raw data structure */
 	struct mbf_elmk2unb_struct *data = (struct mbf_elmk2unb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->par_year);
@@ -1504,7 +1496,6 @@ int mbr_elmk2unb_wr_pos(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbf_elmk2unb_struct *data = (struct mbf_elmk2unb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->pos_year);
@@ -1636,7 +1627,6 @@ int mbr_elmk2unb_wr_svp(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbf_elmk2unb_struct *data = (struct mbf_elmk2unb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->svp_year);
@@ -1750,7 +1740,6 @@ int mbr_elmk2unb_wr_bathgen(int verbose, FILE *mbfp, void *data_ptr, int *error)
 	/* get pointer to raw data structure */
 	struct mbf_elmk2unb_struct *data = (struct mbf_elmk2unb_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);

--- a/src/mbio/mbr_em12darw.c
+++ b/src/mbio/mbr_em12darw.c
@@ -358,7 +358,6 @@ int mbr_rt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			index += 2;
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Data read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Read values:\n");
@@ -544,7 +543,6 @@ int mbr_wt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *datacomment = (char *)&line[80];
 	struct mbsys_simrad_struct *store = (struct mbsys_simrad_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Status at beginning of MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       store->kind:    %d\n", store->kind);
@@ -625,14 +623,12 @@ int mbr_wt_em12darw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		strncpy(datacomment, store->comment, MBSYS_SIMRAD_COMMENT_LENGTH);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       store->kind:       %d\n", store->kind);
 		fprintf(stderr, "dbg5       error:             %d\n", *error);
 	}
 
-	/* print debug statements */
 	if (verbose >= 4) {
 		fprintf(stderr, "\ndbg4  Data to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg4  Status values:\n");

--- a/src/mbio/mbr_em12ifrm.c
+++ b/src/mbio/mbr_em12ifrm.c
@@ -867,7 +867,6 @@ int mbr_em12ifrm_rd_data(int verbose, void *mbio_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && data->kind == MB_DATA_DATA) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -918,7 +917,6 @@ int mbr_em12ifrm_rd_data(int verbose, void *mbio_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && data->kind == MB_DATA_COMMENT) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -1006,7 +1004,6 @@ int mbr_rt_em12ifrm(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		mb_navint_interp(verbose, mbio_ptr, ptime_d, (double)data->line_heading, 0.0, &plon, &plat, &pspeed, error);
 		data->speed = pspeed / 3.6;
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "dbg4     Interpolated Navigation:\n");
 			fprintf(stderr, "dbg4       longitude:  %f\n", plon);
@@ -1358,14 +1355,12 @@ int mbr_em12ifrm_wr_data(int verbose, void *mbio_ptr, char *data_ptr, int *error
 	/* get pointer to raw data structure */
 	struct mbf_em12ifrm_struct *data = (struct mbf_em12ifrm_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", mb_io_ptr->new_kind);
 		fprintf(stderr, "dbg5       error:      %d\n", *error);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && data->kind == MB_DATA_DATA) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);

--- a/src/mbio/mbr_em300mba.c
+++ b/src/mbio/mbr_em300mba.c
@@ -620,7 +620,6 @@ file will return error */
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -786,7 +785,6 @@ int mbr_em300mba_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -880,7 +878,6 @@ int mbr_em300mba_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -958,7 +955,6 @@ int mbr_em300mba_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1034,7 +1030,6 @@ int mbr_em300mba_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1147,7 +1142,6 @@ int mbr_em300mba_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1263,7 +1257,6 @@ int mbr_em300mba_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1378,7 +1371,6 @@ int mbr_em300mba_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1508,7 +1500,6 @@ int mbr_em300mba_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1640,7 +1631,6 @@ int mbr_em300mba_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1802,7 +1792,6 @@ int mbr_em300mba_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1921,7 +1910,6 @@ int mbr_em300mba_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2037,7 +2025,6 @@ int mbr_em300mba_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2240,7 +2227,6 @@ int mbr_em300mba_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 			*match = MB_NO;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
 		fprintf(stderr, "dbg5       sonar:           %d\n", store->sonar);
@@ -2392,7 +2378,6 @@ int mbr_em300mba_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2592,7 +2577,6 @@ int mbr_em300mba_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2819,7 +2803,6 @@ int mbr_em300mba_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -3138,7 +3121,6 @@ int mbr_em300mba_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 			*match = MB_NO;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -3354,7 +3336,6 @@ int mbr_em300mba_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -4282,7 +4263,6 @@ int mbr_em300mba_wr_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -4601,7 +4581,6 @@ int mbr_em300mba_wr_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -4758,7 +4737,6 @@ int mbr_em300mba_wr_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -4881,7 +4859,6 @@ int mbr_em300mba_wr_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5005,7 +4982,6 @@ int mbr_em300mba_wr_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5130,7 +5106,6 @@ int mbr_em300mba_wr_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 	/* get storage structure */
 	heading = (struct mbsys_simrad2_heading_struct *)store->heading;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5302,7 +5277,6 @@ int mbr_em300mba_wr_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 	/* get storage structure */
 	ssv = (struct mbsys_simrad2_ssv_struct *)store->ssv;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5472,7 +5446,6 @@ int mbr_em300mba_wr_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	/* get storage structure */
 	tilt = (struct mbsys_simrad2_tilt_struct *)store->tilt;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5642,7 +5615,6 @@ int mbr_em300mba_wr_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 	/* get storage structure */
 	extraparameters = (struct mbsys_simrad2_extraparameters_struct *)store->extraparameters;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5816,7 +5788,6 @@ int mbr_em300mba_wr_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	/* get storage structure */
 	attitude = (struct mbsys_simrad2_attitude_struct *)store->attitude;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5989,7 +5960,6 @@ int mbr_em300mba_wr_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6160,7 +6130,6 @@ int mbr_em300mba_wr_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6340,7 +6309,6 @@ int mbr_em300mba_wr_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	else
 		ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6549,7 +6517,6 @@ int mbr_em300mba_wr_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 	/* get storage structure */
 	ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6728,7 +6695,6 @@ int mbr_em300mba_wr_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	/* get storage structure */
 	ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6987,7 +6953,6 @@ int mbr_em300mba_wr_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	else
 		ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
@@ -7226,7 +7191,6 @@ int mbr_em300mba_wr_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 	else
 		ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -7501,7 +7465,6 @@ int mbr_em300mba_wr_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 	/* get storage structure */
 	wc = (struct mbsys_simrad2_watercolumn_struct *)store->wc;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);

--- a/src/mbio/mbr_em300raw.c
+++ b/src/mbio/mbr_em300raw.c
@@ -606,7 +606,6 @@ file will return error */
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -776,7 +775,6 @@ int mbr_em300raw_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -875,7 +873,6 @@ int mbr_em300raw_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -958,7 +955,6 @@ int mbr_em300raw_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1039,7 +1035,6 @@ int mbr_em300raw_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1157,7 +1152,6 @@ int mbr_em300raw_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1278,7 +1272,6 @@ int mbr_em300raw_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1398,7 +1391,6 @@ int mbr_em300raw_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1535,7 +1527,6 @@ int mbr_em300raw_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1673,7 +1664,6 @@ int mbr_em300raw_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1842,7 +1832,6 @@ int mbr_em300raw_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1968,7 +1957,6 @@ int mbr_em300raw_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2091,7 +2079,6 @@ int mbr_em300raw_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2297,7 +2284,6 @@ int mbr_em300raw_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 			*match = MB_NO;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2452,7 +2438,6 @@ int mbr_em300raw_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2657,7 +2642,6 @@ int mbr_em300raw_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2887,7 +2871,6 @@ int mbr_em300raw_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -3153,7 +3136,6 @@ int mbr_em300raw_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 			*match = MB_NO;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -3366,7 +3348,6 @@ int mbr_em300raw_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -4380,7 +4361,6 @@ int mbr_em300raw_wr_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -4700,7 +4680,6 @@ int mbr_em300raw_wr_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -4857,7 +4836,6 @@ int mbr_em300raw_wr_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -4980,7 +4958,6 @@ int mbr_em300raw_wr_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5104,7 +5081,6 @@ int mbr_em300raw_wr_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5228,7 +5204,6 @@ int mbr_em300raw_wr_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 	/* get storage structure */
 	struct mbsys_simrad2_heading_struct *heading = (struct mbsys_simrad2_heading_struct *)store->heading;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5399,7 +5374,6 @@ int mbr_em300raw_wr_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 	/* get storage structure */
 	struct mbsys_simrad2_ssv_struct *ssv = (struct mbsys_simrad2_ssv_struct *)store->ssv;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5568,7 +5542,6 @@ int mbr_em300raw_wr_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	/* get storage structure */
 	struct mbsys_simrad2_tilt_struct *tilt = (struct mbsys_simrad2_tilt_struct *)store->tilt;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5737,7 +5710,6 @@ int mbr_em300raw_wr_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 	/* get storage structure */
 	struct mbsys_simrad2_extraparameters_struct *extraparameters = (struct mbsys_simrad2_extraparameters_struct *)store->extraparameters;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5910,7 +5882,6 @@ int mbr_em300raw_wr_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	/* get storage structure */
 	struct mbsys_simrad2_attitude_struct *attitude = (struct mbsys_simrad2_attitude_struct *)store->attitude;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6083,7 +6054,6 @@ int mbr_em300raw_wr_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6253,7 +6223,6 @@ int mbr_em300raw_wr_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6424,7 +6393,6 @@ int mbr_em300raw_wr_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6603,7 +6571,6 @@ int mbr_em300raw_wr_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 	else
 		ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6801,7 +6768,6 @@ int mbr_em300raw_wr_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 	/* get storage structure */
 	struct mbsys_simrad2_ping_struct *ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6978,7 +6944,6 @@ int mbr_em300raw_wr_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	/* get storage structure */
 	struct mbsys_simrad2_ping_struct *ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -7236,7 +7201,6 @@ int mbr_em300raw_wr_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 	else
 		ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
@@ -7473,7 +7437,6 @@ int mbr_em300raw_wr_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 	else
 		ping = (struct mbsys_simrad2_ping_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -7688,7 +7651,6 @@ int mbr_em300raw_wr_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 	/* get storage structure */
 	struct mbsys_simrad2_watercolumn_struct *wc = (struct mbsys_simrad2_watercolumn_struct *)store->wc;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);

--- a/src/mbio/mbr_em710mba.c
+++ b/src/mbio/mbr_em710mba.c
@@ -438,7 +438,6 @@ int mbr_em710mba_rd_status(int verbose, void *mbio_ptr, int swap, struct mbsys_s
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                %d\n", store->type);
@@ -934,7 +933,6 @@ file will return error */
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1171,7 +1169,6 @@ int mbr_em710mba_rd_run_parameter(int verbose, void *mbio_ptr, int swap, struct 
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1263,7 +1260,6 @@ int mbr_em710mba_rd_clock(int verbose, void *mbio_ptr, int swap, struct mbsys_si
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1339,7 +1335,6 @@ int mbr_em710mba_rd_tide(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1413,7 +1408,6 @@ int mbr_em710mba_rd_height(int verbose, void *mbio_ptr, int swap, struct mbsys_s
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1523,7 +1517,6 @@ int mbr_em710mba_rd_heading(int verbose, void *mbio_ptr, int swap, struct mbsys_
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1634,7 +1627,6 @@ int mbr_em710mba_rd_ssv(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1744,7 +1736,6 @@ int mbr_em710mba_rd_tilt(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1889,7 +1880,6 @@ int mbr_em710mba_rd_extraparameters(int verbose, void *mbio_ptr, int swap, struc
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2027,7 +2017,6 @@ int mbr_em710mba_rd_attitude(int verbose, void *mbio_ptr, int swap, struct mbsys
 			store->kind = MB_DATA_ATTITUDE1;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:            %d\n", store->kind);
@@ -2177,7 +2166,6 @@ int mbr_em710mba_rd_netattitude(int verbose, void *mbio_ptr, int swap, struct mb
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:                 %d\n", store->kind);
@@ -2342,7 +2330,6 @@ int mbr_em710mba_rd_pos(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2457,7 +2444,6 @@ int mbr_em710mba_rd_svp(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2569,7 +2555,6 @@ int mbr_em710mba_rd_svp2(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2760,7 +2745,6 @@ int mbr_em710mba_rd_bath2(int verbose, void *mbio_ptr, int swap, struct mbsys_si
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -2977,7 +2961,6 @@ int mbr_em710mba_rd_bath2_mba(int verbose, void *mbio_ptr, int swap, struct mbsy
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -3208,7 +3191,6 @@ int mbr_em710mba_rd_bath3_mba(int verbose, void *mbio_ptr, int swap, struct mbsy
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -3438,7 +3420,6 @@ int mbr_em710mba_rd_rawbeam4(int verbose, void *mbio_ptr, int swap, struct mbsys
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -3610,7 +3591,6 @@ int mbr_em710mba_rd_quality(int verbose, void *mbio_ptr, int swap, struct mbsys_
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -3889,7 +3869,6 @@ int mbr_em710mba_rd_ss2_mba(int verbose, void *mbio_ptr, int swap, struct mbsys_
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -4103,7 +4082,6 @@ int mbr_em710mba_rd_wc(int verbose, void *mbio_ptr, int swap, struct mbsys_simra
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -4945,7 +4923,6 @@ int mbr_em710mba_wr_start(int verbose, void *mbio_ptr, int swap, struct mbsys_si
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5527,7 +5504,6 @@ int mbr_em710mba_wr_status(int verbose, void *mbio_ptr, int swap, struct mbsys_s
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                %d\n", store->type);
@@ -5688,7 +5664,6 @@ int mbr_em710mba_wr_run_parameter(int verbose, void *mbio_ptr, int swap, struct 
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5832,7 +5807,6 @@ int mbr_em710mba_wr_clock(int verbose, void *mbio_ptr, int swap, struct mbsys_si
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5942,7 +5916,6 @@ int mbr_em710mba_wr_tide(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6045,7 +6018,6 @@ int mbr_em710mba_wr_height(int verbose, void *mbio_ptr, int swap, struct mbsys_s
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6156,7 +6128,6 @@ int mbr_em710mba_wr_heading(int verbose, void *mbio_ptr, int swap, struct mbsys_
 	/* get storage structure */
 	struct mbsys_simrad3_heading_struct *heading = (struct mbsys_simrad3_heading_struct *)store->heading;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6299,7 +6270,6 @@ int mbr_em710mba_wr_ssv(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 	/* get storage structure */
 	struct mbsys_simrad3_ssv_struct *ssv = (struct mbsys_simrad3_ssv_struct *)store->ssv;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6440,7 +6410,6 @@ int mbr_em710mba_wr_tilt(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 	/* get storage structure */
 	struct mbsys_simrad3_tilt_struct *tilt = (struct mbsys_simrad3_tilt_struct *)store->tilt;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6581,7 +6550,6 @@ int mbr_em710mba_wr_extraparameters(int verbose, void *mbio_ptr, int swap, struc
 	/* get storage structure */
 	struct mbsys_simrad3_extraparameters_struct *extraparameters = (struct mbsys_simrad3_extraparameters_struct *)store->extraparameters;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6726,7 +6694,6 @@ int mbr_em710mba_wr_attitude(int verbose, void *mbio_ptr, int swap, struct mbsys
 	/* get storage structure */
 	struct mbsys_simrad3_attitude_struct *attitude = (struct mbsys_simrad3_attitude_struct *)store->attitude;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6875,7 +6842,6 @@ int mbr_em710mba_wr_netattitude(int verbose, void *mbio_ptr, int swap, struct mb
 	/* get storage structure */
 	struct mbsys_simrad3_netattitude_struct *netattitude = (struct mbsys_simrad3_netattitude_struct *)store->netattitude;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                 %d\n", store->type);
@@ -7033,7 +6999,6 @@ int mbr_em710mba_wr_pos(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -7176,7 +7141,6 @@ int mbr_em710mba_wr_svp(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -7320,7 +7284,6 @@ int mbr_em710mba_wr_svp2(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -7467,7 +7430,6 @@ int mbr_em710mba_wr_bath2(int verbose, void *mbio_ptr, int swap, struct mbsys_si
 	/* set which storage structure to use */
 	struct mbsys_simrad3_ping_struct *ping = (struct mbsys_simrad3_ping_struct *)&(store->pings[store->ping_index]);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -7630,7 +7592,6 @@ int mbr_em710mba_wr_bath3_mba(int verbose, void *mbio_ptr, int swap, struct mbsy
 	/* set which storage structure to use */
 	ping = (struct mbsys_simrad3_ping_struct *)&(store->pings[store->ping_index]);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -7810,7 +7771,6 @@ int mbr_em710mba_wr_rawbeam4(int verbose, void *mbio_ptr, int swap, struct mbsys
 	/* set which storage structure to use */
 	ping = (struct mbsys_simrad3_ping_struct *)&(store->pings[store->ping_index]);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -8011,7 +7971,6 @@ int mbr_em710mba_wr_quality(int verbose, void *mbio_ptr, int swap, struct mbsys_
 	/* set which storage structure to use */
 	struct mbsys_simrad3_ping_struct *ping = (struct mbsys_simrad3_ping_struct *)&(store->pings[store->ping_index]);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -8154,7 +8113,6 @@ int mbr_em710mba_wr_ss2_mba(int verbose, void *mbio_ptr, int swap, struct mbsys_
 	/* set which storage structure to use */
 	ping = (struct mbsys_simrad3_ping_struct *)&(store->pings[store->ping_index]);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:               %d\n", store->type);
@@ -8378,7 +8336,6 @@ int mbr_em710mba_wr_wc(int verbose, void *mbio_ptr, int swap, struct mbsys_simra
 	/* get storage structure */
 	struct mbsys_simrad3_watercolumn_struct *wc = (struct mbsys_simrad3_watercolumn_struct *)store->wc;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);

--- a/src/mbio/mbr_em710raw.c
+++ b/src/mbio/mbr_em710raw.c
@@ -449,7 +449,6 @@ int mbr_em710raw_rd_status(int verbose, void *mbio_ptr, int swap, struct mbsys_s
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                %d\n", store->type);
@@ -947,7 +946,6 @@ file will return error */
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1186,7 +1184,6 @@ int mbr_em710raw_rd_run_parameter(int verbose, void *mbio_ptr, int swap, struct 
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1280,7 +1277,6 @@ int mbr_em710raw_rd_clock(int verbose, void *mbio_ptr, int swap, struct mbsys_si
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1358,7 +1354,6 @@ int mbr_em710raw_rd_tide(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1434,7 +1429,6 @@ int mbr_em710raw_rd_height(int verbose, void *mbio_ptr, int swap, struct mbsys_s
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1545,7 +1539,6 @@ int mbr_em710raw_rd_heading(int verbose, void *mbio_ptr, int swap, struct mbsys_
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1657,7 +1650,6 @@ int mbr_em710raw_rd_ssv(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1768,7 +1760,6 @@ int mbr_em710raw_rd_tilt(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -1913,7 +1904,6 @@ int mbr_em710raw_rd_extraparameters(int verbose, void *mbio_ptr, int swap, struc
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2052,7 +2042,6 @@ int mbr_em710raw_rd_attitude(int verbose, void *mbio_ptr, int swap, struct mbsys
 			store->kind = MB_DATA_ATTITUDE1;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:            %d\n", store->kind);
@@ -2202,7 +2191,6 @@ int mbr_em710raw_rd_netattitude(int verbose, void *mbio_ptr, int swap, struct mb
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:                 %d\n", store->kind);
@@ -2367,7 +2355,6 @@ int mbr_em710raw_rd_pos(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2482,7 +2469,6 @@ int mbr_em710raw_rd_svp(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2594,7 +2580,6 @@ int mbr_em710raw_rd_svp2(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -2786,7 +2771,6 @@ int mbr_em710raw_rd_bath2(int verbose, void *mbio_ptr, int swap, struct mbsys_si
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -3009,7 +2993,6 @@ int mbr_em710raw_rd_rawbeam4(int verbose, void *mbio_ptr, int swap, struct mbsys
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -3182,7 +3165,6 @@ int mbr_em710raw_rd_quality(int verbose, void *mbio_ptr, int swap, struct mbsys_
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -3419,7 +3401,6 @@ int mbr_em710raw_rd_ss2(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:               %d\n", store->type);
@@ -3623,7 +3604,6 @@ int mbr_em710raw_rd_wc(int verbose, void *mbio_ptr, int swap, struct mbsys_simra
 #endif
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -4933,7 +4913,6 @@ int mbr_em710raw_wr_start(int verbose, void *mbio_ptr, int swap, struct mbsys_si
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5515,7 +5494,6 @@ int mbr_em710raw_wr_status(int verbose, void *mbio_ptr, int swap, struct mbsys_s
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                %d\n", store->type);
@@ -5676,7 +5654,6 @@ int mbr_em710raw_wr_run_parameter(int verbose, void *mbio_ptr, int swap, struct 
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5819,7 +5796,6 @@ int mbr_em710raw_wr_clock(int verbose, void *mbio_ptr, int swap, struct mbsys_si
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -5928,7 +5904,6 @@ int mbr_em710raw_wr_tide(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6031,7 +6006,6 @@ int mbr_em710raw_wr_height(int verbose, void *mbio_ptr, int swap, struct mbsys_s
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6142,7 +6116,6 @@ int mbr_em710raw_wr_heading(int verbose, void *mbio_ptr, int swap, struct mbsys_
 	/* get storage structure */
 	heading = (struct mbsys_simrad3_heading_struct *)store->heading;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6286,7 +6259,6 @@ int mbr_em710raw_wr_ssv(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 	/* get storage structure */
 	ssv = (struct mbsys_simrad3_ssv_struct *)store->ssv;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6428,7 +6400,6 @@ int mbr_em710raw_wr_tilt(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 	/* get storage structure */
 	tilt = (struct mbsys_simrad3_tilt_struct *)store->tilt;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6570,7 +6541,6 @@ int mbr_em710raw_wr_extraparameters(int verbose, void *mbio_ptr, int swap, struc
 	/* get storage structure */
 	extraparameters = (struct mbsys_simrad3_extraparameters_struct *)store->extraparameters;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6716,7 +6686,6 @@ int mbr_em710raw_wr_attitude(int verbose, void *mbio_ptr, int swap, struct mbsys
 	/* get storage structure */
 	attitude = (struct mbsys_simrad3_attitude_struct *)store->attitude;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -6866,7 +6835,6 @@ int mbr_em710raw_wr_netattitude(int verbose, void *mbio_ptr, int swap, struct mb
 	/* get storage structure */
 	netattitude = (struct mbsys_simrad3_netattitude_struct *)store->netattitude;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                 %d\n", store->type);
@@ -7024,7 +6992,6 @@ int mbr_em710raw_wr_pos(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -7167,7 +7134,6 @@ int mbr_em710raw_wr_svp(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -7311,7 +7277,6 @@ int mbr_em710raw_wr_svp2(int verbose, void *mbio_ptr, int swap, struct mbsys_sim
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -7459,7 +7424,6 @@ int mbr_em710raw_wr_bath2(int verbose, void *mbio_ptr, int swap, struct mbsys_si
 	/* set which storage structure to use */
 	ping = (struct mbsys_simrad3_ping_struct *)&(store->pings[store->ping_index]);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -7622,7 +7586,6 @@ int mbr_em710raw_wr_rawbeam4(int verbose, void *mbio_ptr, int swap, struct mbsys
 	/* set which storage structure to use */
 	ping = (struct mbsys_simrad3_ping_struct *)&(store->pings[store->ping_index]);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);
@@ -7824,7 +7787,6 @@ int mbr_em710raw_wr_quality(int verbose, void *mbio_ptr, int swap, struct mbsys_
 	/* set which storage structure to use */
 	ping = (struct mbsys_simrad3_ping_struct *)&(store->pings[store->ping_index]);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:                  %d\n", store->type);
@@ -7966,7 +7928,6 @@ int mbr_em710raw_wr_ss2(int verbose, void *mbio_ptr, int swap, struct mbsys_simr
 	/* set which storage structure to use */
 	ping = (struct mbsys_simrad3_ping_struct *)&(store->pings[store->ping_index]);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:               %d\n", store->type);
@@ -8152,7 +8113,6 @@ int mbr_em710raw_wr_wc(int verbose, void *mbio_ptr, int swap, struct mbsys_simra
 	/* get storage structure */
 	wc = (struct mbsys_simrad3_watercolumn_struct *)store->wc;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:            %d\n", store->type);

--- a/src/mbio/mbr_emoldraw.c
+++ b/src/mbio/mbr_emoldraw.c
@@ -282,7 +282,6 @@ int mbr_emoldraw_rd_start(int verbose, FILE *mbfp, struct mbsys_simrad_struct *s
 			store->comment[i] = line[341 + i];
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->par_year);
@@ -372,7 +371,6 @@ int mbr_emoldraw_rd_stop(int verbose, FILE *mbfp, struct mbsys_simrad_struct *st
 			store->comment[i] = line[341 + i];
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->par_year);
@@ -468,7 +466,6 @@ int mbr_emoldraw_rd_parameter(int verbose, FILE *mbfp, struct mbsys_simrad_struc
 			store->sonar = MBSYS_SIMRAD_EM1000;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->par_year);
@@ -567,7 +564,6 @@ int mbr_emoldraw_rd_pos(int verbose, FILE *mbfp, struct mbsys_simrad_struct *sto
 		mb_get_double(&(store->line_heading), line + 85, 5);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->pos_year);
@@ -641,7 +637,6 @@ int mbr_emoldraw_rd_svp(int verbose, FILE *mbfp, struct mbsys_simrad_struct *sto
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->svp_year);
@@ -751,7 +746,6 @@ int mbr_emoldraw_rd_em1000bath(int verbose, FILE *mbfp, struct mbsys_simrad_stru
 			ping->beams_bath = 48;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -877,7 +871,6 @@ int mbr_emoldraw_rd_em12bath(int verbose, FILE *mbfp, struct mbsys_simrad_struct
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -1002,7 +995,6 @@ int mbr_emoldraw_rd_em121bath(int verbose, FILE *mbfp, struct mbsys_simrad_struc
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -1172,7 +1164,6 @@ int mbr_emoldraw_rd_ss(int verbose, FILE *mbfp, struct mbsys_simrad_struct *stor
 	else
 		*more = MB_NO;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -1339,7 +1330,6 @@ int mbr_emoldraw_rd_ssp(int verbose, FILE *mbfp, struct mbsys_simrad_struct *sto
 	else
 		*more = MB_NO;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -2205,7 +2195,6 @@ int mbr_rt_emoldraw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		pheading = store->line_heading;
 		mb_navint_interp(verbose, mbio_ptr, ptime_d, pheading, rawspeed, &plon, &plat, &pspeed, error);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "dbg4       Interpolated Navigation:\n");
 			fprintf(stderr, "dbg4       longitude:  %f\n", plon);
@@ -2252,7 +2241,6 @@ int mbr_emoldraw_wr_start(int verbose, FILE *mbfp, struct mbsys_simrad_struct *s
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->par_year);
@@ -2380,7 +2368,6 @@ int mbr_emoldraw_wr_stop(int verbose, FILE *mbfp, struct mbsys_simrad_struct *st
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->par_year);
@@ -2507,7 +2494,6 @@ int mbr_emoldraw_wr_parameter(int verbose, FILE *mbfp, struct mbsys_simrad_struc
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->par_year);
@@ -2638,7 +2624,6 @@ int mbr_emoldraw_wr_pos(int verbose, FILE *mbfp, struct mbsys_simrad_struct *sto
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->pos_year);
@@ -2782,7 +2767,6 @@ int mbr_emoldraw_wr_svp(int verbose, FILE *mbfp, struct mbsys_simrad_struct *sto
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->svp_year);
@@ -2890,7 +2874,6 @@ int mbr_emoldraw_wr_em1000bath(int verbose, FILE *mbfp, struct mbsys_simrad_stru
 	/* get ping structure */
 	ping = (struct mbsys_simrad_survey_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -3026,7 +3009,6 @@ int mbr_emoldraw_wr_em12bath(int verbose, FILE *mbfp, struct mbsys_simrad_struct
 	/* get ping structure */
 	ping = (struct mbsys_simrad_survey_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -3167,7 +3149,6 @@ int mbr_emoldraw_wr_em121bath(int verbose, FILE *mbfp, struct mbsys_simrad_struc
 	/* get ping structure */
 	ping = (struct mbsys_simrad_survey_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -3329,7 +3310,6 @@ int mbr_emoldraw_wr_ss(int verbose, FILE *mbfp, struct mbsys_simrad_struct *stor
 	/* get ping structure */
 	ping = (struct mbsys_simrad_survey_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -3393,7 +3373,6 @@ int mbr_emoldraw_wr_ss(int verbose, FILE *mbfp, struct mbsys_simrad_struct *stor
 			datagram_size[num_datagrams] = new_datagram_size;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       num_datagrams:    %d\n", num_datagrams);
@@ -3412,7 +3391,6 @@ int mbr_emoldraw_wr_ss(int verbose, FILE *mbfp, struct mbsys_simrad_struct *stor
 	for (datagram = 0; datagram < num_datagrams; datagram++) {
 		num_beams = datagram_end[datagram] - datagram_start[datagram] + 1;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -3566,7 +3544,6 @@ int mbr_emoldraw_wr_ssp(int verbose, FILE *mbfp, struct mbsys_simrad_struct *sto
 	/* get ping structure */
 	ping = (struct mbsys_simrad_survey_struct *)store->ping;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -3631,7 +3608,6 @@ int mbr_emoldraw_wr_ssp(int verbose, FILE *mbfp, struct mbsys_simrad_struct *sto
 			datagram_size[num_datagrams] = new_datagram_size;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       num_datagrams:    %d\n", num_datagrams);
@@ -3650,7 +3626,6 @@ int mbr_emoldraw_wr_ssp(int verbose, FILE *mbfp, struct mbsys_simrad_struct *sto
 	for (datagram = 0; datagram < num_datagrams; datagram++) {
 		num_beams = datagram_end[datagram] - datagram_start[datagram] + 1;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5       year:             %d\n", store->year);

--- a/src/mbio/mbr_hs10jams.c
+++ b/src/mbio/mbr_hs10jams.c
@@ -383,7 +383,6 @@ int mbr_rt_hs10jams(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	mb_io_ptr->new_error = *error;
 	mb_io_ptr->new_kind = store->kind;
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS && store->kind == MB_DATA_DATA) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);

--- a/src/mbio/mbr_hsatlraw.c
+++ b/src/mbio/mbr_hsatlraw.c
@@ -958,7 +958,6 @@ int mbr_hsatlraw_read_line(int verbose, FILE *mbfp, int minimum_size, char *line
 			status = MB_FAILURE;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  New line read in function <%s>\n", __func__);
 			fprintf(stderr, "dbg5       line:       %s\n", line);
@@ -1018,7 +1017,6 @@ int mbr_hsatlraw_rd_ergnhydi(int verbose, FILE *mbfp, struct mbf_hsatlraw_struct
 		mb_get_double(&(data->tide), line + 63 + shift, 6);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1090,7 +1088,6 @@ int mbr_hsatlraw_rd_ergnpara(int verbose, FILE *mbfp, struct mbf_hsatlraw_struct
 		mb_get_double(&(data->depth_center), line + 77 + shift, 7);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1161,7 +1158,6 @@ int mbr_hsatlraw_rd_ergnposi(int verbose, FILE *mbfp, struct mbf_hsatlraw_struct
 		strncpy(data->sensors, line + 59 + shift, 8);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1290,7 +1286,6 @@ int mbr_hsatlraw_rd_ergneich(int verbose, FILE *mbfp, struct mbf_hsatlraw_struct
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1430,7 +1425,6 @@ int mbr_hsatlraw_rd_ergnmess(int verbose, FILE *mbfp, struct mbf_hsatlraw_struct
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1541,7 +1535,6 @@ int mbr_hsatlraw_rd_ergnslzt(int verbose, FILE *mbfp, struct mbf_hsatlraw_struct
 			mb_get_double(&(data->gyro[i]), line + i * 5 + shift, 5);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1639,7 +1632,6 @@ int mbr_hsatlraw_rd_ergnctds(int verbose, FILE *mbfp, struct mbf_hsatlraw_struct
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1779,7 +1771,6 @@ int mbr_hsatlraw_rd_ergnampl(int verbose, FILE *mbfp, struct mbf_hsatlraw_struct
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1855,7 +1846,6 @@ int mbr_hsatlraw_rd_ldeocmnt(int verbose, FILE *mbfp, struct mbf_hsatlraw_struct
 			data->comment[0] = '\0';
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Value read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -2009,7 +1999,6 @@ int mbr_hsatlraw_wr_rawline(int verbose, FILE *mbfp, void *data_ptr, int *error)
 	/* get pointer to raw data structure */
 	struct mbf_hsatlraw_struct *data = (struct mbf_hsatlraw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       raw line:         %s\n", data->comment);
@@ -2051,7 +2040,6 @@ int mbr_hsatlraw_wr_ergnhydi(int verbose, FILE *mbfp, void *data_ptr, int *error
 	/* get pointer to raw data structure */
 	struct mbf_hsatlraw_struct *data = (struct mbf_hsatlraw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2125,7 +2113,6 @@ int mbr_hsatlraw_wr_ergnpara(int verbose, FILE *mbfp, void *data_ptr, int *error
 	/* get pointer to raw data structure */
 	struct mbf_hsatlraw_struct *data = (struct mbf_hsatlraw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2205,7 +2192,6 @@ int mbr_hsatlraw_wr_ergnposi(int verbose, FILE *mbfp, void *data_ptr, int *error
 	/* get pointer to raw data structure */
 	struct mbf_hsatlraw_struct *data = (struct mbf_hsatlraw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2277,7 +2263,6 @@ int mbr_hsatlraw_wr_ergneich(int verbose, FILE *mbfp, void *data_ptr, int *error
 	/* get pointer to raw data structure */
 	struct mbf_hsatlraw_struct *data = (struct mbf_hsatlraw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2388,7 +2373,6 @@ int mbr_hsatlraw_wr_ergnmess(int verbose, FILE *mbfp, void *data_ptr, int *error
 	/* get pointer to raw data structure */
 	struct mbf_hsatlraw_struct *data = (struct mbf_hsatlraw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2505,12 +2489,10 @@ int mbr_hsatlraw_wr_ergnslzt(int verbose, FILE *mbfp, void *data_ptr, int *error
 		if (data->time[i] > 0)
 			datacheck = MB_YES;
 
-	/* print debug statements */
 	if (verbose >= 5 && datacheck == MB_NO) {
 		fprintf(stderr, "\ndbg5  No values to be written in MBIO function <%s>\n", __func__);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && datacheck == MB_YES) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2616,7 +2598,6 @@ int mbr_hsatlraw_wr_ergnctds(int verbose, FILE *mbfp, void *data_ptr, int *error
 	/* get pointer to raw data structure */
 	struct mbf_hsatlraw_struct *data = (struct mbf_hsatlraw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2709,12 +2690,10 @@ int mbr_hsatlraw_wr_ergnampl(int verbose, FILE *mbfp, void *data_ptr, int *error
 		if (data->amplitude[i] > 0)
 			datacheck = MB_YES;
 
-	/* print debug statements */
 	if (verbose >= 5 && datacheck == MB_NO) {
 		fprintf(stderr, "\ndbg5  No values to be written in MBIO function <%s>\n", __func__);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && datacheck == MB_YES) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2858,7 +2837,6 @@ int mbr_hsatlraw_wr_ldeocmnt(int verbose, FILE *mbfp, void *data_ptr, int *error
 	/* get pointer to raw data structure */
 	struct mbf_hsatlraw_struct *data = (struct mbf_hsatlraw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);

--- a/src/mbio/mbr_hsds2lam.c
+++ b/src/mbio/mbr_hsds2lam.c
@@ -414,7 +414,6 @@ int mbr_hsds2lam_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 		}
 	}
 
-/* print debug statements */
 #ifndef MBR_HSDS2LAM_DEBUG
 	if (verbose >= 5)
 #endif
@@ -561,7 +560,6 @@ int mbr_hsds2lam_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 	/* get pointer to raw data structure */
 	struct mbsys_atlas_struct *store = (struct mbsys_atlas_struct *)store_ptr;
 
-/* print debug statements */
 #ifndef MBR_HSDS2LAM_DEBUG
 	if (verbose >= 5)
 #endif

--- a/src/mbio/mbr_hsds2raw.c
+++ b/src/mbio/mbr_hsds2raw.c
@@ -358,7 +358,6 @@ int mbr_hsds2raw_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 	if (xdr_status == MB_YES)
 		xdr_status = xdr_int((XDR *)mb_io_ptr->xdrs, &telegram_sensor_status);
 
-/* print debug statements */
 #ifndef MBR_HSDS2RAW_DEBUG
 	if (verbose >= 5)
 #endif
@@ -490,7 +489,6 @@ int mbr_hsds2raw_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 		if (xdr_status != MB_YES || telegram_act_no == telegram_max_no)
 			done = MB_YES;
 
-/* print debug statements */
 #ifndef MBR_HSDS2RAW_DEBUG
 		if (verbose >= 5)
 #endif
@@ -512,7 +510,6 @@ int mbr_hsds2raw_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 		}
 	}
 
-/* print debug statements */
 #ifndef MBR_HSDS2RAW_DEBUG
 	if (verbose >= 5)
 #endif
@@ -620,7 +617,6 @@ int mbr_hsds2raw_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 		if (xdr_status != MB_YES || telegram_act_no == telegram_max_no)
 			done = MB_YES;
 
-/* print debug statements */
 #ifndef MBR_HSDS2RAW_DEBUG
 		if (verbose >= 5)
 #endif
@@ -644,7 +640,6 @@ int mbr_hsds2raw_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 		}
 	}
 
-/* print debug statements */
 #ifndef MBR_HSDS2RAW_DEBUG
 	if (verbose >= 5)
 #endif
@@ -728,7 +723,6 @@ int mbr_hsds2raw_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 			xdr_status = xdr_float((XDR *)mb_io_ptr->xdrs, &store->tr_stop[i]);
 	}
 
-/* print debug statements */
 #ifndef MBR_HSDS2RAW_DEBUG
 	if (verbose >= 5)
 #endif
@@ -852,7 +846,6 @@ int mbr_hsds2raw_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 	if (xdr_status == MB_YES)
 		xdr_status = xdr_opaque((XDR *)mb_io_ptr->xdrs, (char *)store->bs_nis, MBSYS_ATLAS_HSDS2_PFB_NUM);
 
-/* print debug statements */
 #ifndef MBR_HSDS2RAW_DEBUG
 	if (verbose >= 5)
 #endif
@@ -1044,7 +1037,6 @@ int mbr_hsds2raw_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 			if (xdr_status == MB_YES)
 				xdr_status = xdr_int((XDR *)mb_io_ptr->xdrs2, &profile_version);
 
-/* print debug statements */
 #ifndef MBR_HSDS2RAW_DEBUG
 			if (verbose >= 5)
 #endif
@@ -1195,7 +1187,6 @@ int mbr_hsds2raw_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 			if (xdr_status == MB_YES)
 				xdr_status = xdr_int((XDR *)mb_io_ptr->xdrs2, &sys_wind_status);
 
-/* print debug statements */
 #ifndef MBR_HSDS2RAW_DEBUG
 			if (verbose >= 5)
 #endif

--- a/src/mbio/mbr_hsldedmb.c
+++ b/src/mbio/mbr_hsldedmb.c
@@ -376,7 +376,6 @@ int mbr_wt_hsldedmb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *datacomment = (char *)data;
 	struct mbsys_hsds_struct *store = (struct mbsys_hsds_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Status at beginning of MBIO function <%s>\n", __func__);
 		if (store != NULL)

--- a/src/mbio/mbr_hsldeoih.c
+++ b/src/mbio/mbr_hsldeoih.c
@@ -369,7 +369,6 @@ int mbr_hsldeoih_rd_nav_source(int verbose, FILE *mbfp, struct mbf_hsldeoih_stru
 		strncpy(data->sensors, read_data.sensors, 8);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -460,7 +459,6 @@ int mbr_hsldeoih_rd_mean_velocity(int verbose, FILE *mbfp, struct mbf_hsldeoih_s
 		data->tide = read_data.tide;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -556,7 +554,6 @@ int mbr_hsldeoih_rd_velocity_profile(int verbose, FILE *mbfp, struct mbf_hsldeoi
 		*error = MB_ERROR_UNINTELLIGIBLE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -650,7 +647,6 @@ int mbr_hsldeoih_rd_standby(int verbose, FILE *mbfp, struct mbf_hsldeoih_struct 
 		data->depth_center = read_data.depth_center;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -922,7 +918,6 @@ int mbr_hsldeoih_rd_survey(int verbose, FILE *mbfp, struct mbf_hsldeoih_struct *
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1236,7 +1231,6 @@ int mbr_hsldeoih_rd_calibrate(int verbose, FILE *mbfp, struct mbf_hsldeoih_struc
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1346,7 +1340,6 @@ int mbr_hsldeoih_rd_comment(int verbose, FILE *mbfp, struct mbf_hsldeoih_struct 
 		strncpy(data->comment, read_data.comment, MBF_HSLDEOIH_MAXLINE);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -1506,7 +1499,6 @@ int mbr_hsldeoih_rd_data(int verbose, void *mbio_ptr, int *error) {
 		data->kind = MB_DATA_NAV_SOURCE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 4) {
 		fprintf(stderr, "\ndbg4  Read record label in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg4       label:      %d\n", label);
@@ -1705,7 +1697,6 @@ int mbr_hsldeoih_wr_nav_source(int verbose, FILE *mbfp, struct mbf_hsldeoih_stru
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1802,7 +1793,6 @@ int mbr_hsldeoih_wr_mean_velocity(int verbose, FILE *mbfp, struct mbf_hsldeoih_s
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -1903,7 +1893,6 @@ int mbr_hsldeoih_wr_velocity_profile(int verbose, FILE *mbfp, struct mbf_hsldeoi
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2000,7 +1989,6 @@ int mbr_hsldeoih_wr_standby(int verbose, FILE *mbfp, struct mbf_hsldeoih_struct 
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2109,7 +2097,6 @@ int mbr_hsldeoih_wr_survey(int verbose, FILE *mbfp, struct mbf_hsldeoih_struct *
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2381,7 +2368,6 @@ int mbr_hsldeoih_wr_calibrate(int verbose, FILE *mbfp, struct mbf_hsldeoih_struc
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       longitude:        %f\n", data->lon);
@@ -2653,7 +2639,6 @@ int mbr_hsldeoih_wr_comment(int verbose, FILE *mbfp, struct mbf_hsldeoih_struct 
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to write in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);

--- a/src/mbio/mbr_hsmdaraw.c
+++ b/src/mbio/mbr_hsmdaraw.c
@@ -1075,7 +1075,6 @@ int mbr_rt_hsmdaraw(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	/* read next (record of) data from file */
 	const int status = mbr_hsmdaraw_rd_data(verbose, mbio_ptr, error);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "dbg5: In function name:\t%s\n", __func__);
 		fprintf(stderr, "dbg5:\t Returned from  mbr_hsmdaraw_rd_data()\n");

--- a/src/mbio/mbr_hsmdldih.c
+++ b/src/mbio/mbr_hsmdldih.c
@@ -1071,7 +1071,6 @@ int mbr_rt_hsmdldih(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	/* read next (record of) data from file */
 	const int status = mbr_hsmdldih_rd_data(verbose, mbio_ptr, error);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "dbg5: In function name:\t%s\n", __func__);
 		fprintf(stderr, "dbg5:\t Returned from  mbr_hsmdldih_rd_data()\n");

--- a/src/mbio/mbr_hsunknwn.c
+++ b/src/mbio/mbr_hsunknwn.c
@@ -357,7 +357,6 @@ int mbr_rt_hsunknwn(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	mb_io_ptr->new_kind = store->kind;
 	mb_io_ptr->new_error = *error;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:             %d\n", store->kind);
@@ -409,7 +408,6 @@ int mbr_wt_hsunknwn(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbsys_hsds_struct *store = (struct mbsys_hsds_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Status at beginning of MBIO function <%s>\n", __func__);
 		if (store != NULL)
@@ -419,7 +417,6 @@ int mbr_wt_hsunknwn(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "dbg5       error:          %d\n", *error);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:             %d\n", store->kind);

--- a/src/mbio/mbr_hsuricen.c
+++ b/src/mbio/mbr_hsuricen.c
@@ -384,7 +384,6 @@ int mbr_wt_hsuricen(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *datacomment = (char *)data;
 	struct mbsys_hsds_struct *store = (struct mbsys_hsds_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Status at beginning of MBIO function <%s>\n", __func__);
 		if (store != NULL)
@@ -456,7 +455,6 @@ int mbr_wt_hsuricen(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", dataplus->kind);

--- a/src/mbio/mbr_hsurivax.c
+++ b/src/mbio/mbr_hsurivax.c
@@ -388,7 +388,6 @@ int mbr_wt_hsurivax(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char *datacomment = (char *)data;
 	struct mbsys_hsds_struct *store = (struct mbsys_hsds_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Status at beginning of MBIO function <%s>\n", __func__);
 		if (store != NULL)
@@ -460,7 +459,6 @@ int mbr_wt_hsurivax(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", dataplus->kind);

--- a/src/mbio/mbr_hypc8101.c
+++ b/src/mbio/mbr_hypc8101.c
@@ -401,7 +401,6 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 					done = MB_YES;
 					data->kind = MB_DATA_ATTITUDE;
 
-					/* print debug statements */
 					if (verbose >= 4) {
 						fprintf(stderr, "\ndbg4  New data read by MBIO function <%s>\n", __func__);
 						fprintf(stderr, "dbg4  New attitude values:\n");
@@ -451,7 +450,6 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 					done = MB_YES;
 					data->kind = MB_DATA_HEADING;
 
-					/* print debug statements */
 					if (verbose >= 4) {
 						fprintf(stderr, "\ndbg4  New data read by MBIO function <%s>\n", __func__);
 						fprintf(stderr, "dbg4  New heading values:\n");
@@ -497,7 +495,6 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 					done = MB_NO;
 					data->kind = MB_DATA_NAV;
 
-					/* print debug statements */
 					if (verbose >= 4) {
 						fprintf(stderr, "\ndbg4  New data read by MBIO function <%s>\n", __func__);
 						fprintf(stderr, "dbg4  New position values:\n");
@@ -561,7 +558,6 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 					done = MB_YES;
 					data->kind = MB_DATA_NAV;
 
-					/* print debug statements */
 					if (verbose >= 4) {
 						fprintf(stderr, "\ndbg4  New data read by MBIO function <%s>\n", __func__);
 						fprintf(stderr, "dbg4  New navigation values:\n");
@@ -718,7 +714,6 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 					done = MB_YES;
 					data->kind = MB_DATA_DATA;
 
-					/* print debug statements */
 					if (verbose >= 4) {
 						fprintf(stderr, "\ndbg4  New data read by MBIO function <%s>\n", __func__);
 						fprintf(stderr, "dbg4  New ping values:\n");
@@ -837,7 +832,6 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 				done = MB_YES;
 				data->kind = MB_DATA_PARAMETER;
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  New data read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4  New parameter values:\n");

--- a/src/mbio/mbr_hysweep1.c
+++ b/src/mbio/mbr_hysweep1.c
@@ -715,7 +715,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					}
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  RMB data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       RMB_device_number:                 %d\n", store->RMB_device_number);
@@ -902,7 +901,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					}
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  RMB data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       RSS_device_number:                 %d\n", store->RSS_device_number);
@@ -1021,7 +1019,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					}
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  MSS data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       MSS_device_number:                 %d\n", store->MSS_device_number);
@@ -1055,7 +1052,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  SNR data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       SNR_device_number:                 %d\n", store->SNR_device_number);
@@ -1119,7 +1115,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  TID data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       TID_device_number:                 %d\n", store->TID_device_number);
@@ -1148,7 +1143,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  HCP data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       HCP_device_number:                 %d\n", store->HCP_device_number);
@@ -1178,7 +1172,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  EC1 data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       EC1_device_number:                 %d\n", store->EC1_device_number);
@@ -1207,7 +1200,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  GPS data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       GPS_device_number:                 %d\n", store->GPS_device_number);
@@ -1231,7 +1223,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  GYR data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       GYR_device_number:                 %d\n", store->GYR_device_number);
@@ -1260,7 +1251,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  POS data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       POS_device_number:                 %d\n", store->POS_device_number);
@@ -1310,7 +1300,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  DEV data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       DEV_device_number:                 %d\n", device->DEV_device_number);
@@ -1337,7 +1326,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  DV2 data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       DV2_device_number:                 %d\n", DV2_device_number);
@@ -1351,7 +1339,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 			else if (strncmp(line, "EOH", 3) == 0) {
 				store->type = MBSYS_HYSWEEP_RECORDTYPE_EOH;
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  EOH data record read by MBIO function <%s>\n", __func__);
 				}
@@ -1378,7 +1365,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					mb_io_ptr->projection_initialized = MB_YES;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  Hysweep file header read by MBIO function <%s>\n", __func__);
 				}
@@ -1394,7 +1380,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 			else if (strncmp(line, "EOL", 3) == 0) {
 				store->type = MBSYS_HYSWEEP_RECORDTYPE_EOL;
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  EOL data record read by MBIO function <%s>\n", __func__);
 				}
@@ -1418,7 +1403,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					}
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  FTP data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       FTP_record:                        %s\n", store->FTP_record);
@@ -1436,7 +1420,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  VER data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       VER_version:                       %s\n", store->VER_version);
@@ -1458,7 +1441,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  HSP data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       HSP_minimum_depth:                 %f\n", store->HSP_minimum_depth);
@@ -1487,7 +1469,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  HSX data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       HSX_record:                        %d\n", store->HSX_record);
@@ -1508,7 +1489,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  HVF data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       HVF_device_number:                 %d\n", HVF_device_number);
@@ -1593,7 +1573,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  INF data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       INF_surveyor:                      %s\n", store->INF_surveyor);
@@ -1610,7 +1589,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 			else if (strncmp(line, "LBP", 3) == 0) {
 				store->type = MBSYS_HYSWEEP_RECORDTYPE_LBP;
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  LBP data record read by MBIO function <%s>\n", __func__);
 				}
@@ -1620,7 +1598,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 			else if (strncmp(line, "LIN", 3) == 0) {
 				store->type = MBSYS_HYSWEEP_RECORDTYPE_LIN;
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  LIN data record read by MBIO function <%s>\n", __func__);
 				}
@@ -1630,7 +1607,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 			else if (strncmp(line, "LNN", 3) == 0) {
 				store->type = MBSYS_HYSWEEP_RECORDTYPE_LNN;
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  LNN data record read by MBIO function <%s>\n", __func__);
 				}
@@ -1659,7 +1635,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  MBI data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       MBI_device_number:                 %d\n", MBI_device_number);
@@ -1702,7 +1677,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  OF2 data record read by OF2O function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       OF2_device_number:                 %d\n", OF2_device_number);
@@ -1733,7 +1707,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  PRI data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       primary_nav_device:                %d\n", store->primary_nav_device);
@@ -1744,7 +1717,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 			else if (strncmp(line, "PTS", 3) == 0) {
 				store->type = MBSYS_HYSWEEP_RECORDTYPE_PTS;
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  PTS data record read by MBIO function <%s>\n", __func__);
 				}
@@ -1768,7 +1740,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  SSI data record read by SSIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       SSI_device_number:                 %d\n", SSI_device_number);
@@ -1782,7 +1753,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 			else if (strncmp(line, "SVC", 3) == 0) {
 				store->type = MBSYS_HYSWEEP_RECORDTYPE_SVC;
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  SVC data record read by MBIO function <%s>\n", __func__);
 				}
@@ -1812,7 +1782,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  TND data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       TND_survey_time_i[0]:              %d\n", store->TND_survey_time_i[0]);
@@ -1837,7 +1806,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  DFT data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       DFT_device_number:                 %d\n", store->DFT_device_number);
@@ -1866,7 +1834,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  FIX data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       FIX_device_number:                 %d\n", store->FIX_device_number);
@@ -1887,7 +1854,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  PSA data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       PSA_device_number:                 %d\n", store->PSA_device_number);
@@ -1909,7 +1875,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					*error = MB_ERROR_UNINTELLIGIBLE;
 				}
 
-				/* print debug statements */
 				if (verbose >= 4) {
 					fprintf(stderr, "\ndbg4  COM data record read by MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg4       COM_comment:                       %s\n", store->COM_comment);
@@ -1929,7 +1894,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 						*error = MB_ERROR_UNINTELLIGIBLE;
 					}
 
-					/* print debug statements */
 					if (verbose >= 4) {
 						fprintf(stderr, "\ndbg4  PRJ data record read by MBIO function <%s>\n", __func__);
 						fprintf(stderr, "dbg4       PRJ_proj4_command:                 %s\n", store->PRJ_proj4_command);
@@ -1938,7 +1902,6 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 
 				/* do not overwrite previously set projection */
 				else {
-					/* print debug statements */
 					if (verbose >= 4) {
 						fprintf(stderr, "\ndbg4  PRJ data record ignored by MBIO function <%s>\n", __func__);
 						fprintf(stderr, "dbg4       Previously set PRJ_proj4_command:  %s\n", store->PRJ_proj4_command);
@@ -2269,7 +2232,6 @@ int mbr_rt_hysweep1(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			status = mbsys_hysweep_makess(verbose, mbio_ptr, store_ptr, MB_NO, pixel_size, MB_NO, swath_width, 5, error);
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Multibeam bathymetry calculated by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4       RMB_device_number:                 %d\n", store->RMB_device_number);
@@ -2535,7 +2497,6 @@ int mbr_hysweep1_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 			hysweeptmp.num_devices++;
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  FTP data record to be written by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4       FTP_record:                        %s\n", hysweeptmp.FTP_record);
@@ -2646,7 +2607,6 @@ int mbr_hysweep1_wr_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 
 	/* call appropriate writing routines for ping data */
 	if (status == MB_SUCCESS && store->kind == MB_DATA_DATA) {
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  RMB data record read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4       RMB_device_number:                 %d\n", store->RMB_device_number);

--- a/src/mbio/mbr_image83p.c
+++ b/src/mbio/mbr_image83p.c
@@ -574,7 +574,6 @@ int mbr_wt_image83p(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbsys_image83p_struct *store = (struct mbsys_image83p_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Status at beginning of MBIO function <%s>\n", __func__);
 		if (store != NULL)

--- a/src/mbio/mbr_imagemba.c
+++ b/src/mbio/mbr_imagemba.c
@@ -541,7 +541,6 @@ int mbr_wt_imagemba(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbsys_image83p_struct *store = (struct mbsys_image83p_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Status at beginning of MBIO function <%s>\n", __func__);
 		if (store != NULL)

--- a/src/mbio/mbr_kemkmall.c
+++ b/src/mbio/mbr_kemkmall.c
@@ -529,7 +529,6 @@ int mbr_kemkmall_rd_hdr(int verbose, char *buffer, void *header_ptr, void *emdgm
     *emdgm_type = UNKNOWN;
   }
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:    %u\n", header->numBytesDgm);
@@ -614,7 +613,6 @@ int mbr_kemkmall_rd_spo(int verbose, char *buffer, void *store_ptr, void *header
   index += 4;
   memcpy(&(spo->sensorData.posDataFromSensor), &buffer[index], numBytesRawSensorData);
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:                 %u\n", spo->header.numBytesDgm);
@@ -782,7 +780,6 @@ int mbr_kemkmall_rd_skm(int verbose, char *buffer, void *store_ptr, void *header
     index += 4;
   }
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:                %u\n", skm->header.numBytesDgm);
@@ -924,7 +921,6 @@ int mbr_kemkmall_rd_svp(int verbose, char *buffer, void *store_ptr, void *header
     index += 4;
   }
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, " dbg5       numBytesDgm:     %u\n", svp->header.numBytesDgm);
@@ -1038,7 +1034,6 @@ int mbr_kemkmall_rd_svt(int verbose, char *buffer, void *store_ptr, void *header
     index += 4;
   }
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:             %u\n", svt->header.numBytesDgm);
@@ -1140,7 +1135,6 @@ int mbr_kemkmall_rd_scl(int verbose, char *buffer, void *store_ptr, void *header
   index += 4;
   memcpy(&(scl->sensorData.dataFromSensor), &buffer[index], numBytesRawSensorData);
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:         %u\n", scl->header.numBytesDgm);
@@ -1237,7 +1231,6 @@ int mbr_kemkmall_rd_sde(int verbose, char *buffer, void *store_ptr, void *header
   index += 4;
   memcpy(&(sde->sensorData.dataFromSensor), &buffer[index], numBytesRawSensorData);
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:      %u\n", sde->header.numBytesDgm);
@@ -1332,7 +1325,6 @@ int mbr_kemkmall_rd_shi(int verbose, char *buffer, void *store_ptr, void *header
   index += 4;
   memcpy(&(shi->sensorData.dataFromSensor), &buffer[index], numBytesRawSensorData);
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:      %u\n", shi->header.numBytesDgm);
@@ -1435,7 +1427,6 @@ int mbr_kemkmall_rd_sha(int verbose, char *buffer, void *store_ptr, void *header
     index += sha->dataInfo.numBytesRawSensorData;
   }
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:            %u\n", sha->header.numBytesDgm);
@@ -1521,7 +1512,6 @@ int mbr_kemkmall_rd_mrz(int verbose, char *buffer, void *store_ptr, void *header
   mb_get_binary_short(MB_YES, &buffer[index], &(partition.dgmNum));
   index += 2;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr,"dbg5       numOfDgms = %d\n", partition.numOfDgms);
@@ -1688,7 +1678,6 @@ int mbr_kemkmall_rd_mrz(int verbose, char *buffer, void *store_ptr, void *header
   mb_get_binary_float(MB_YES, &buffer[index], &(mrz->pingInfo.ellipsoidHeightReRefPoint_m));
   index += 4;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr,"dbg5       numBytesInfoData:             %d\n", mrz->pingInfo.numBytesInfoData);
@@ -1779,7 +1768,6 @@ int mbr_kemkmall_rd_mrz(int verbose, char *buffer, void *store_ptr, void *header
     mb_get_binary_short(MB_YES, &buffer[index], &(mrz->sectorInfo[i].padding1));
     index += 2;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       #MWC transmit sector %d/%d:\n", i + 1, mrz->pingInfo.numTxSectors);
@@ -1833,7 +1821,6 @@ int mbr_kemkmall_rd_mrz(int verbose, char *buffer, void *store_ptr, void *header
   mb_get_binary_short(MB_YES, &buffer[index], &(mrz->rxInfo.numBytesPerClass));
   index += 2;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesInfoData:           %d\n", mrz->rxInfo.numBytesRxInfo);
@@ -1868,7 +1855,6 @@ int mbr_kemkmall_rd_mrz(int verbose, char *buffer, void *store_ptr, void *header
     mrz->extraDetClassInfo[i].alarmFlag = buffer[index];
     index++;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       numExtraDetInClass:  %d\n", mrz->extraDetClassInfo[i].numExtraDetInClass);
@@ -2009,7 +1995,6 @@ int mbr_kemkmall_rd_mrz(int verbose, char *buffer, void *store_ptr, void *header
       mrz->sounding[i].beamflag_enabled = 1;
     }
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       soundingIndex:                   %d\n", mrz->sounding[i].soundingIndex);
@@ -2057,7 +2042,6 @@ int mbr_kemkmall_rd_mrz(int verbose, char *buffer, void *store_ptr, void *header
     }
   }
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numSidescanSamples:  %d\n", numSidescanSamples);
@@ -2133,7 +2117,6 @@ int mbr_kemkmall_rd_mwc(int verbose, char *buffer, void *store_ptr, void *header
   mb_get_binary_short(MB_YES, &buffer[index], &(partition.dgmNum));
   index += 2;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numOfDgms:  %d\n", partition.numOfDgms);
@@ -2162,7 +2145,6 @@ int mbr_kemkmall_rd_mwc(int verbose, char *buffer, void *store_ptr, void *header
   cmnPart.algorithmType = buffer[index];
   index++;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesCmnPart:     %d\n", cmnPart.numBytesCmnPart);
@@ -2196,7 +2178,6 @@ int mbr_kemkmall_rd_mwc(int verbose, char *buffer, void *store_ptr, void *header
   mb_get_binary_float(MB_YES, &buffer[index], &(mwc->txInfo.heave_m));
   index += 4;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesTxInfo:       %d\n", mwc->txInfo.numBytesTxInfo);
@@ -2219,7 +2200,6 @@ int mbr_kemkmall_rd_mwc(int verbose, char *buffer, void *store_ptr, void *header
     mb_get_binary_short(MB_YES, &buffer[index], &(mwc->sectorData[i].padding));
     index += 2;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       #MWC transmit sector %d/%d:\n", i + 1, mwc->txInfo.numTxSectors);
@@ -2249,7 +2229,6 @@ int mbr_kemkmall_rd_mwc(int verbose, char *buffer, void *store_ptr, void *header
   mb_get_binary_float(MB_YES, &buffer[index], &(mwc->rxInfo.soundVelocity_mPerSec));
   index += 4;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesRxInfo:         %d\n", mwc->rxInfo.numBytesRxInfo);
@@ -2354,7 +2333,6 @@ int mbr_kemkmall_rd_mwc(int verbose, char *buffer, void *store_ptr, void *header
             break;
         }
 
-        /* print debug statements */
         if (status == MB_SUCCESS && verbose >= 5) {
           fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
           fprintf(stderr, "dbg5       #MWC receiver beam data %d/%d:\n", i, mwc->rxInfo.numBeams);
@@ -2463,7 +2441,6 @@ int mbr_kemkmall_rd_cpo(int verbose, char *buffer, void *store_ptr, void *header
   memcpy(&cpo->sensorData.posDataFromSensor, &buffer[index], numBytesRawSensorData);
   index += numBytesRawSensorData;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:                  %u\n", cpo->header.numBytesDgm);
@@ -2540,7 +2517,6 @@ int mbr_kemkmall_rd_che(int verbose, char *buffer, void *store_ptr, void *header
   /* extract the data */
   int index = MBSYS_KMBES_HEADER_SIZE;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:    %u\n", che->header.numBytesDgm);
@@ -2574,7 +2550,6 @@ int mbr_kemkmall_rd_che(int verbose, char *buffer, void *store_ptr, void *header
   che->cmnPart.algorithmType = buffer[index];
   index++;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesCmnPart:      %d\n", che->cmnPart.numBytesCmnPart);
@@ -2592,7 +2567,6 @@ int mbr_kemkmall_rd_che(int verbose, char *buffer, void *store_ptr, void *header
   mb_get_binary_float(MB_YES, &buffer[index], &che->data.heave_m);
   index += 4;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       heave_m                         = %f\n", che->data.heave_m);
@@ -2658,7 +2632,6 @@ int mbr_kemkmall_rd_iip(int verbose, char *buffer, void *store_ptr, void *header
   memcpy(&iip->install_txt, &buffer[index], numBytesRawSensorData);
 //fprintf(stderr, "\niip->install_txt:\n%s\n", iip->install_txt);
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:      %u\n", iip->header.numBytesDgm);
@@ -2735,7 +2708,6 @@ int mbr_kemkmall_rd_iop(int verbose, char *buffer, void *store_ptr, void *header
   index += 2;
   memcpy(&iop->runtime_txt, &buffer[index], numBytesRawSensorData);
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:                %u\n", iop->header.numBytesDgm);
@@ -2815,7 +2787,6 @@ int mbr_kemkmall_rd_xmb(int verbose, char *buffer, void *store_ptr, void *header
   index += numBytesVersion;
   memset(&xmb->version[numBytesVersion], 0, MB_COMMENT_MAXLINE - numBytesVersion);
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:    %u\n", xmb->header.numBytesDgm);
@@ -2891,7 +2862,6 @@ int mbr_kemkmall_rd_xmc(int verbose, char *buffer, void *store_ptr, void *header
   index += numBytesComment;
   memset(&xmc->comment[numBytesComment], 0, MB_COMMENT_MAXLINE - numBytesComment);
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:    %u\n", xmc->header.numBytesDgm);
@@ -2981,7 +2951,6 @@ int mbr_kemkmall_rd_xms(int verbose, char *buffer, void *store_ptr, void *header
     index += 4;
   }
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:    %u\n", xms->header.numBytesDgm);
@@ -3809,7 +3778,6 @@ int mbr_kemkmall_wr_header(int verbose, char **bufferptr, void *header_ptr, int 
   /* get pointer to raw data structure */
   header = (struct mbsys_kmbes_header *)header_ptr;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:    %u\n", header->numBytesDgm);
@@ -3879,7 +3847,6 @@ int mbr_kemkmall_wr_spo(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_spo *spo = &(store->spo);
   struct mbsys_kmbes_header *header = &store->spo.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:                 %u\n", spo->header.numBytesDgm);
@@ -4008,7 +3975,6 @@ int mbr_kemkmall_wr_skm(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_skm *skm = &(store->skm);
   struct mbsys_kmbes_header *header = &store->skm.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:                %u\n", skm->header.numBytesDgm);
@@ -4226,7 +4192,6 @@ int mbr_kemkmall_wr_svp(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_svp *svp = &(store->svp);
   struct mbsys_kmbes_header *header = &store->svp.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, " dbg5       numBytesDgm:     %u\n", svp->header.numBytesDgm);
@@ -4348,7 +4313,6 @@ int mbr_kemkmall_wr_svt(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_svt *svt = &(store->svt);
   struct mbsys_kmbes_header *header = &store->svt.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:              %u\n", svt->header.numBytesDgm);
@@ -4478,7 +4442,6 @@ int mbr_kemkmall_wr_scl(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_scl *scl = &(store->scl);
   struct mbsys_kmbes_header *header = &store->scl.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:         %u\n", scl->header.numBytesDgm);
@@ -4587,7 +4550,6 @@ int mbr_kemkmall_wr_sde(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_sde *sde = &(store->sde);
   struct mbsys_kmbes_header *header = &store->sde.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:      %u\n", sde->header.numBytesDgm);
@@ -4705,7 +4667,6 @@ int mbr_kemkmall_wr_shi(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_shi *shi = &(store->shi);
   struct mbsys_kmbes_header *header = &store->shi.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:      %u\n", shi->header.numBytesDgm);
@@ -4814,7 +4775,6 @@ int mbr_kemkmall_wr_sha(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_sha *sha = &(store->sha);
   struct mbsys_kmbes_header *header = &store->sha.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:            %u\n", sha->header.numBytesDgm);
@@ -4999,7 +4959,6 @@ int mbr_kemkmall_wr_mrz(int verbose, int *bufferalloc, char **bufferptr, void *s
     mb_put_binary_short(MB_YES, mrz->partition.dgmNum, &buffer[index]);
     index += 2;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       numOfDgms:  %d\n", mrz->partition.numOfDgms);
@@ -5152,7 +5111,6 @@ int mbr_kemkmall_wr_mrz(int verbose, int *bufferalloc, char **bufferptr, void *s
     mb_put_binary_float(MB_YES, mrz->pingInfo.ellipsoidHeightReRefPoint_m, &buffer[index]);
     index += 4;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       numBytesInfoData:            %d\n", mrz->pingInfo.numBytesInfoData);
@@ -5234,7 +5192,6 @@ int mbr_kemkmall_wr_mrz(int verbose, int *bufferalloc, char **bufferptr, void *s
       mb_put_binary_short(MB_YES, mrz->sectorInfo[i].padding1, &buffer[index]);
       index += 2;
 
-      /* print debug statements */
       if (verbose >= 5) {
         fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
         fprintf(stderr, "dbg5       #MWC transmit sector %d/%d:\n", i + 1, mrz->pingInfo.numTxSectors);
@@ -5283,7 +5240,6 @@ int mbr_kemkmall_wr_mrz(int verbose, int *bufferalloc, char **bufferptr, void *s
     mb_put_binary_short(MB_YES, mrz->rxInfo.numBytesPerClass, &buffer[index]);
     index += 2;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       numBytesInfoData:          %d\n", mrz->rxInfo.numBytesRxInfo);
@@ -5309,7 +5265,6 @@ int mbr_kemkmall_wr_mrz(int verbose, int *bufferalloc, char **bufferptr, void *s
       buffer[index] = mrz->extraDetClassInfo[i].alarmFlag;
       index++;
 
-      /* print debug statements */
       if (verbose >= 5) {
         fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
         fprintf(stderr, "dbg5       numExtraDetInClass:  %d\n", mrz->extraDetClassInfo[i].numExtraDetInClass);
@@ -5424,7 +5379,6 @@ int mbr_kemkmall_wr_mrz(int verbose, int *bufferalloc, char **bufferptr, void *s
 
       //numSidescanSamples += mrz->sounding[i].SInumSamples;
 
-      /* print debug statements */
       if (verbose >= 5) {
         fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
         fprintf(stderr, "dbg5       soundingIndex:                  %d\n", mrz->sounding[i].soundingIndex);
@@ -5552,7 +5506,6 @@ int mbr_kemkmall_wr_mwc(int verbose, int *bufferalloc, char **bufferptr, void *s
     mb_put_binary_short(MB_YES, mwc->partition.dgmNum, &buffer[index]);
     index += 2;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       numOfDgms:  %d\n", mwc->partition.numOfDgms);
@@ -5581,7 +5534,6 @@ int mbr_kemkmall_wr_mwc(int verbose, int *bufferalloc, char **bufferptr, void *s
     buffer[index] = mwc->cmnPart.algorithmType;
     index++;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       numBytesCmnPart:     %d\n", mwc->cmnPart.numBytesCmnPart);
@@ -5608,7 +5560,6 @@ int mbr_kemkmall_wr_mwc(int verbose, int *bufferalloc, char **bufferptr, void *s
     mb_put_binary_float(MB_YES, mwc->txInfo.heave_m, &buffer[index]);
     index += 4;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       numBytesTxInfo:       %d\n", mwc->txInfo.numBytesTxInfo);
@@ -5631,7 +5582,6 @@ int mbr_kemkmall_wr_mwc(int verbose, int *bufferalloc, char **bufferptr, void *s
       mb_put_binary_short(MB_YES, mwc->sectorData[i].padding, &buffer[index]);
       index += 2;
 
-      /* print debug statements */
       if (verbose >= 5) {
         fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
         fprintf(stderr, "dbg5       #MWC transmit sector %d/%d:\n", i + 1, mwc->txInfo.numTxSectors);
@@ -5661,7 +5611,6 @@ int mbr_kemkmall_wr_mwc(int verbose, int *bufferalloc, char **bufferptr, void *s
     mb_put_binary_float(MB_YES, mwc->rxInfo.soundVelocity_mPerSec, &buffer[index]);
     index += 4;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       numBytesRxInfo:         %d\n", mwc->rxInfo.numBytesRxInfo);
@@ -5711,7 +5660,6 @@ int mbr_kemkmall_wr_mwc(int verbose, int *bufferalloc, char **bufferptr, void *s
           }
       }
 
-      /* print debug statements */
       if (status == MB_SUCCESS && verbose >= 5) {
         fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
         fprintf(stderr, "dbg5       #MWC receiver beam data %d/%d:\n", i, mwc->rxInfo.numBeams);
@@ -5779,7 +5727,6 @@ int mbr_kemkmall_wr_cpo(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_cpo *cpo = &(store->cpo);
   struct mbsys_kmbes_header *header = &store->cpo.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:                  %u\n", cpo->header.numBytesDgm);
@@ -5933,7 +5880,6 @@ int mbr_kemkmall_wr_che(int verbose, int *bufferalloc, char **bufferptr, void *s
     /* insert the data */
     index = MBSYS_KMBES_HEADER_SIZE;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg5       numBytesDgm:    %u\n", che->header.numBytesDgm);
@@ -6032,7 +5978,6 @@ int mbr_kemkmall_wr_iip(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_iip *iip = &(store->iip);
   struct mbsys_kmbes_header *header = &store->iip.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:      %u\n", iip->header.numBytesDgm);
@@ -6129,7 +6074,6 @@ int mbr_kemkmall_wr_iop(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_iop *iop = &(store->iop);
   struct mbsys_kmbes_header *header = &store->iop.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:      %u\n", iop->header.numBytesDgm);
@@ -6238,7 +6182,6 @@ int mbr_kemkmall_wr_xmb(int verbose, int *bufferalloc, char **bufferptr, void *s
   xmb->header.time_sec = iip->header.time_sec;
   xmb->header.time_nanosec = iip->header.time_nanosec;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:             %u\n", xmb->header.numBytesDgm);
@@ -6339,7 +6282,6 @@ int mbr_kemkmall_wr_xmc(int verbose, int *bufferalloc, char **bufferptr, void *s
   store->xmc.header.numBytesDgm = MBSYS_KMBES_HEADER_SIZE + numBytesComment + 36;
   *size = (size_t) xmc->header.numBytesDgm;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:    %u\n", xmc->header.numBytesDgm);
@@ -6429,7 +6371,6 @@ int mbr_kemkmall_wr_xms(int verbose, int *bufferalloc, char **bufferptr, void *s
   struct mbsys_kmbes_xms *xms = &(store->xms);
   struct mbsys_kmbes_header *header = &store->xms.header;
 
-  /* print debug statements */
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
     fprintf(stderr, "dbg5       numBytesDgm:    %u\n", xms->header.numBytesDgm);

--- a/src/mbio/mbr_l3xseraw.c
+++ b/src/mbio/mbr_l3xseraw.c
@@ -240,7 +240,6 @@ int mbr_l3xseraw_rd_svp(int verbose, int buffer_size, char *buffer, void *store_
 			mb_get_binary_int(SWAPFLAG, &buffer[index], (int *)&group_id);
 			index += 4;
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Group %d of %d bytes to be parsed in MBIO function <%s>\n", group_id, byte_count,
 				        __func__);
@@ -377,7 +376,6 @@ int mbr_l3xseraw_rd_svp(int verbose, int buffer_size, char *buffer, void *store_
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       svp_source:          %d\n", store->svp_source);
@@ -501,7 +499,6 @@ int mbr_l3xseraw_rd_ship(int verbose, int buffer_size, char *buffer, void *store
 			mb_get_binary_int(SWAPFLAG, &buffer[index], (int *)&group_id);
 			index += 4;
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Group %d of %d bytes to be parsed in MBIO function <%s>\n", group_id, byte_count,
 				        __func__);
@@ -698,7 +695,6 @@ int mbr_l3xseraw_rd_ship(int verbose, int buffer_size, char *buffer, void *store
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       par_source:          %d\n", store->par_source);
@@ -846,7 +842,6 @@ int mbr_l3xseraw_rd_sidescan(int verbose, int buffer_size, char *buffer, void *s
 			mb_get_binary_int(SWAPFLAG, &buffer[index], (int *)&group_id);
 			index += 4;
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Group %d of %d bytes to be parsed in MBIO function <%s>\n", group_id, byte_count,
 				        __func__);
@@ -1136,7 +1131,6 @@ int mbr_l3xseraw_rd_sidescan(int verbose, int buffer_size, char *buffer, void *s
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sid_frame:            %d\n", store->sid_frame);
@@ -1311,7 +1305,6 @@ int mbr_l3xseraw_rd_multibeam(int verbose, int buffer_size, char *buffer, void *
 			mb_get_binary_int(SWAPFLAG, &buffer[index], (int *)&group_id);
 			index += 4;
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Group %d of %d bytes to be parsed in MBIO function <%s>\n", group_id, byte_count,
 				        __func__);
@@ -1888,7 +1881,6 @@ int mbr_l3xseraw_rd_multibeam(int verbose, int buffer_size, char *buffer, void *
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       mul_group_beam:      %d\n", store->mul_group_beam);
@@ -2084,7 +2076,6 @@ int byte_count;
 			mb_get_binary_int(SWAPFLAG, &buffer[index], (int *)&group_id);
 			index += 4;
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Group %d of %d bytes to be parsed in MBIO function <%s>\n", group_id, byte_count,
 				        __func__);
@@ -2226,7 +2217,6 @@ int byte_count;
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sbm_source:          %d\n", store->sbm_source);
@@ -2503,7 +2493,6 @@ int mbr_l3xseraw_rd_comment(int verbose, int buffer_size, char *buffer, void *st
 			mb_get_binary_int(SWAPFLAG, &buffer[index], (int *)&group_id);
 			index += 4;
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Group %d of %d bytes to be parsed in MBIO function <%s>\n", group_id, byte_count,
 				        __func__);
@@ -2524,7 +2513,6 @@ int mbr_l3xseraw_rd_comment(int verbose, int buffer_size, char *buffer, void *st
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:             %s\n", store->comment);
@@ -2624,7 +2612,6 @@ int mbr_l3xseraw_rd_nav(int verbose, int buffer_size, char *buffer, void *store_
 			mb_get_binary_int(SWAPFLAG, &buffer[index], (int *)&group_id);
 			index += 4;
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Group %d of %d bytes to be parsed in MBIO function <%s>\n", group_id, byte_count,
 				        __func__);
@@ -2822,7 +2809,6 @@ int mbr_l3xseraw_rd_nav(int verbose, int buffer_size, char *buffer, void *store_
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       nav_source:          %d\n", store->nav_source);
@@ -3394,7 +3380,6 @@ int mbr_l3xseraw_wr_nav(int verbose, int *buffer_size, char *buffer, void *store
 	/* get pointer to store data structure */
 	struct mbsys_xse_struct *store = (struct mbsys_xse_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       nav_source:          %d\n", store->nav_source);
@@ -4069,7 +4054,6 @@ int mbr_l3xseraw_wr_svp(int verbose, int *buffer_size, char *buffer, void *store
 	/* get pointer to store data structure */
 	struct mbsys_xse_struct *store = (struct mbsys_xse_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       svp_source:          %d\n", store->svp_source);
@@ -4477,7 +4461,6 @@ int mbr_l3xseraw_wr_ship(int verbose, int *buffer_size, char *buffer, void *stor
 	/* get pointer to store data structure */
 	struct mbsys_xse_struct *store = (struct mbsys_xse_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       par_source:          %d\n", store->par_source);
@@ -4984,8 +4967,6 @@ int mbr_l3xseraw_wr_multibeam(int verbose, int *buffer_size, char *buffer, void 
 	/* get pointer to store data structure */
 	struct mbsys_xse_struct *store = (struct mbsys_xse_struct *)store_ptr;
 
-	/* print debug statements */
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       mul_group_beam:      %d\n", store->mul_group_beam);
@@ -6102,7 +6083,6 @@ int mbr_l3xseraw_wr_sidescan(int verbose, int *buffer_size, char *buffer, void *
 	/* get pointer to store data structure */
 	struct mbsys_xse_struct *store = (struct mbsys_xse_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sid_frame:            %d\n", store->sid_frame);
@@ -6705,7 +6685,6 @@ int mbr_l3xseraw_wr_seabeam(int verbose, int *buffer_size, char *buffer, void *s
 	/* get pointer to store data structure */
 	struct mbsys_xse_struct *store = (struct mbsys_xse_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sbm_source:          %d\n", store->sbm_source);
@@ -7136,7 +7115,6 @@ int mbr_l3xseraw_wr_comment(int verbose, int *buffer_size, char *buffer, void *s
 	/* get pointer to store data structure */
 	struct mbsys_xse_struct *store = (struct mbsys_xse_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:             %s\n", store->comment);

--- a/src/mbio/mbr_mbldeoih.c
+++ b/src/mbio/mbr_mbldeoih.c
@@ -564,7 +564,6 @@ int mbr_rt_mbldeoih(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	mb_io_ptr->new_kind = store->kind;
 	mb_io_ptr->new_error = *error;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  New header read in function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       flag:       %d\n", *flag);
@@ -950,7 +949,6 @@ int mbr_wt_mbldeoih(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	*flag = mb_swap_short(*flag);
 #endif
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  New header set in function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       flag:       %d\n", *flag);
@@ -1190,7 +1188,6 @@ int mbr_wt_mbldeoih(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		*error = MB_ERROR_EOF;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Going to write data in function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", store->kind);

--- a/src/mbio/mbr_mr1aldeo.c
+++ b/src/mbio/mbr_mr1aldeo.c
@@ -309,7 +309,6 @@ int mbr_mr1aldeo_rd_hdr(int verbose, XDR *xdrs, struct mbf_mr1aldeo_struct *data
 		*error = MB_ERROR_EOF;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       mf_magic:         %d\n", data->mf_magic);
@@ -464,7 +463,6 @@ int mbr_mr1aldeo_rd_ping(int verbose, XDR *xdrs, struct mbf_mr1aldeo_struct *dat
 	if (status == MB_FAILURE)
 		*error = MB_ERROR_EOF;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sec:              %d\n", data->sec);
@@ -497,7 +495,6 @@ int mbr_mr1aldeo_rd_ping(int verbose, XDR *xdrs, struct mbf_mr1aldeo_struct *dat
 		fprintf(stderr, "\n");
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "dbg5       port_beam  depth   xtrack    tt   angle\n");
 		for (int i = 0; i < data->port_btycount; i++) {
@@ -724,7 +721,6 @@ int mbr_mr1aldeo_wr_hdr(int verbose, XDR *xdrs, struct mbf_mr1aldeo_struct *data
 		fprintf(stderr, "dbg2       hdr_comment:%p\n", (void *)*hdr_comment);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       mf_magic:         %d\n", data->mf_magic);
@@ -780,7 +776,6 @@ int mbr_mr1aldeo_wr_ping(int verbose, XDR *xdrs, struct mbf_mr1aldeo_struct *dat
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sec:              %d\n", data->sec);

--- a/src/mbio/mbr_mr1bldeo.c
+++ b/src/mbio/mbr_mr1bldeo.c
@@ -306,7 +306,6 @@ int mbr_mr1bldeo_rd_hdr(int verbose, XDR *xdrs, struct mbf_mr1bldeo_struct *data
 		*error = MB_ERROR_EOF;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       mf_magic:         %d\n", data->mf_magic);
@@ -461,7 +460,6 @@ int mbr_mr1bldeo_rd_ping(int verbose, XDR *xdrs, struct mbf_mr1bldeo_struct *dat
 	if (status == MB_FAILURE)
 		*error = MB_ERROR_EOF;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sec:              %d\n", data->sec);
@@ -494,7 +492,6 @@ int mbr_mr1bldeo_rd_ping(int verbose, XDR *xdrs, struct mbf_mr1bldeo_struct *dat
 		fprintf(stderr, "\n");
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "dbg5       port_beam  depth   xtrack    tt   angle\n");
 		for (int i = 0; i < data->port_btycount; i++) {
@@ -721,7 +718,6 @@ int mbr_mr1bldeo_wr_hdr(int verbose, XDR *xdrs, struct mbf_mr1bldeo_struct *data
 		fprintf(stderr, "dbg2       hdr_comment:%p\n", (void *)*hdr_comment);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       mf_magic:         %d\n", data->mf_magic);
@@ -777,7 +773,6 @@ int mbr_mr1bldeo_wr_ping(int verbose, XDR *xdrs, struct mbf_mr1bldeo_struct *dat
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sec:              %d\n", data->sec);

--- a/src/mbio/mbr_mr1prhig.c
+++ b/src/mbio/mbr_mr1prhig.c
@@ -302,7 +302,6 @@ int mbr_mr1prhig_rd_hdr(int verbose, XDR *xdrs, struct mbf_mr1prhig_struct *data
 		*error = MB_ERROR_EOF;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       mf_magic:         %d\n", data->mf_magic);
@@ -450,7 +449,6 @@ int mbr_mr1prhig_rd_ping(int verbose, XDR *xdrs, struct mbf_mr1prhig_struct *dat
 	if (status == MB_FAILURE)
 		*error = MB_ERROR_EOF;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sec:              %d\n", data->sec);
@@ -482,7 +480,6 @@ int mbr_mr1prhig_rd_ping(int verbose, XDR *xdrs, struct mbf_mr1prhig_struct *dat
 		fprintf(stderr, "\n");
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "dbg5       port_beam  depth   xtrack\n");
 		for (int i = 0; i < data->port_btycount; i++) {
@@ -733,7 +730,6 @@ int mbr_mr1prhig_wr_hdr(int verbose, XDR *xdrs, struct mbf_mr1prhig_struct *data
 		fprintf(stderr, "dbg2       hdr_comment:%p\n", (void *)*hdr_comment);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       mf_magic:         %d\n", data->mf_magic);
@@ -789,7 +785,6 @@ int mbr_mr1prhig_wr_ping(int verbose, XDR *xdrs, struct mbf_mr1prhig_struct *dat
 		fprintf(stderr, "dbg2       data:       %p\n", (void *)data);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sec:              %d\n", data->sec);

--- a/src/mbio/mbr_mr1prvr2.c
+++ b/src/mbio/mbr_mr1prvr2.c
@@ -224,7 +224,6 @@ int mbr_mr1prvr2_rd_data(int verbose, void *mbio_ptr, int *error) {
 			mb_io_ptr->hdr_comment_loc = 0;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5       mf_version:       %d\n", store->header.bsf_version);
@@ -311,7 +310,6 @@ int mbr_mr1prvr2_rd_data(int verbose, void *mbio_ptr, int *error) {
 			store->ping.png_flags = store->ping.png_flags ^ PNG_BTYSSFLAGSABSENT;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5       png_flags:        %u\n", store->ping.png_flags);
@@ -505,7 +503,6 @@ int mbr_mr1prvr2_wr_data(int verbose, void *mbio_ptr, char *store_ptr, int *erro
 	struct mbsys_mr1v2001_struct *store = (struct mbsys_mr1v2001_struct *)store_ptr;
 	char *xdrs = mb_io_ptr->xdrs;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       png_flags:        %u\n", store->ping.png_flags);

--- a/src/mbio/mbr_mstiffss.c
+++ b/src/mbio/mbr_mstiffss.c
@@ -940,7 +940,6 @@ int mbr_rt_mstiffss(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (status == MB_SUCCESS && verbose >= 5) {
 		fprintf(stderr, "\ndbg5  New data record read by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Raw values:\n");

--- a/src/mbio/mbr_oicgeoda.c
+++ b/src/mbio/mbr_oicgeoda.c
@@ -560,7 +560,6 @@ int mbr_rt_oicgeoda(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  New header read in function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:             %d\n", header->type);
@@ -945,7 +944,6 @@ int mbr_rt_oicgeoda(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS) {
 		fprintf(stderr, "\ndbg5  New processed data generated in function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       beams_bath:       %d\n", header->beams_bath);
@@ -1315,7 +1313,6 @@ int mbr_wt_oicgeoda(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			dataplus->client[i] = store->client[i];
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  New header set in function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:             %d\n", header->type);

--- a/src/mbio/mbr_oicmbari.c
+++ b/src/mbio/mbr_oicmbari.c
@@ -478,7 +478,6 @@ int mbr_rt_oicmbari(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  New header read in function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:             %d\n", header->type);
@@ -741,7 +740,6 @@ int mbr_rt_oicmbari(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	}
 #endif
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS) {
 		fprintf(stderr, "\ndbg5  New processed data read in function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       beams_bath:       %d\n", header->beams_bath);
@@ -1113,7 +1111,6 @@ int mbr_wt_oicmbari(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			dataplus->client[i] = store->client[i];
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  New header set in function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       type:             %d\n", header->type);
@@ -1231,7 +1228,6 @@ int mbr_wt_oicmbari(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS) {
 		fprintf(stderr, "\ndbg5  New processed data set in function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       beams_bath:       %d\n", header->beams_bath);

--- a/src/mbio/mbr_sb2000sb.c
+++ b/src/mbio/mbr_sb2000sb.c
@@ -326,7 +326,6 @@ int mbr_rt_sb2000sb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (status == MB_SUCCESS && verbose >= 5) {
 		fprintf(stderr, "\ndbg5  New header record in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  New header values:\n");
@@ -388,7 +387,6 @@ int mbr_rt_sb2000sb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			store->ssv_source[1] = buffer[23];
 		}
 
-		/* print debug statements */
 		if (status == MB_SUCCESS && verbose >= 5) {
 			fprintf(stderr, "\ndbg5  New sensor record read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5  New sensor values:\n");
@@ -438,7 +436,6 @@ int mbr_rt_sb2000sb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			mb_get_binary_short(MB_NO, &buffer[6 + i * 4], &store->bath_acrosstrack[i]);
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  New data record read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5  New data values:\n");
@@ -469,7 +466,6 @@ int mbr_rt_sb2000sb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		mb_get_binary_short(MB_NO, &buffer[140], &store->vru2_forward);
 		mb_get_binary_short(MB_NO, &buffer[142], &store->vru2_vert);
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  New svp record read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5  New svp values:\n");
@@ -498,7 +494,6 @@ int mbr_rt_sb2000sb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		strncpy(store->comment, buffer, MIN(store->data_size, MBSYS_SB2000_COMMENT_LENGTH - 1));
 		store->comment[MIN(store->data_size, MBSYS_SB2000_COMMENT_LENGTH - 1)] = '\0';
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  New comment record read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5  New comment:\n");
@@ -538,14 +533,12 @@ int mbr_wt_sb2000sb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbsys_sb2000_struct *store = (struct mbsys_sb2000_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", store->kind);
 		fprintf(stderr, "dbg5       error:      %d\n", *error);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Header record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Header values:\n");
@@ -567,7 +560,6 @@ int mbr_wt_sb2000sb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "dbg5       data_type:  %c%c\n", store->data_type[0], store->data_type[1]);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && store->kind == MB_DATA_DATA) {
 		fprintf(stderr, "\ndbg5  Sensor record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Sensor values:\n");
@@ -585,7 +577,6 @@ int mbr_wt_sb2000sb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "dbg5       ssv_source:      %c%c\n", store->ssv_source[0], store->ssv_source[1]);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && store->kind == MB_DATA_VELOCITY_PROFILE) {
 		fprintf(stderr, "\ndbg5  SVP record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  SVP values:\n");
@@ -608,7 +599,6 @@ int mbr_wt_sb2000sb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		        store->vru[4], store->vru[5], store->vru[6], store->vru[7]);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && store->kind == MB_DATA_DATA) {
 		fprintf(stderr, "\ndbg5  Data record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Data values:\n");
@@ -618,7 +608,6 @@ int mbr_wt_sb2000sb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			fprintf(stderr, "dbg5       beam: %d  bath: %d  across_track: %d\n", i, store->bath[i], store->bath_acrosstrack[i]);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && store->kind == MB_DATA_COMMENT) {
 		fprintf(stderr, "\ndbg5  Comment record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Comment:\n");

--- a/src/mbio/mbr_sb2000ss.c
+++ b/src/mbio/mbr_sb2000ss.c
@@ -333,7 +333,6 @@ int mbr_rt_sb2000ss(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		store->data_size = 1001;
 	}
 
-	/* print debug statements */
 	if (status == MB_SUCCESS && verbose >= 5) {
 		fprintf(stderr, "\ndbg5  New header record in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  New header values:\n");
@@ -436,7 +435,6 @@ int mbr_rt_sb2000ss(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  New data record read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5  New data values:\n");
@@ -485,7 +483,6 @@ int mbr_rt_sb2000ss(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		mb_get_binary_short(MB_NO, &buffer[140], &store->vru2_forward);
 		mb_get_binary_short(MB_NO, &buffer[142], &store->vru2_vert);
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  New svp record read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5  New svp values:\n");
@@ -514,7 +511,6 @@ int mbr_rt_sb2000ss(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		strncpy(store->comment, buffer, MIN(store->data_size, MBSYS_SB2000_COMMENT_LENGTH - 1));
 		store->comment[MIN(store->data_size, MBSYS_SB2000_COMMENT_LENGTH - 1)] = '\0';
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  New comment record read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5  New comment:\n");
@@ -555,14 +551,12 @@ int mbr_wt_sb2000ss(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbsys_sb2000_struct *store = (struct mbsys_sb2000_struct *)store_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", store->kind);
 		fprintf(stderr, "dbg5       error:      %d\n", *error);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Header record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Header values:\n");
@@ -584,7 +578,6 @@ int mbr_wt_sb2000ss(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "dbg5       data_type:  %c%c\n", store->data_type[0], store->data_type[1]);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && store->kind == MB_DATA_DATA) {
 		fprintf(stderr, "\ndbg5  Sensor record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Sensor values:\n");
@@ -603,7 +596,6 @@ int mbr_wt_sb2000ss(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "\n");
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && store->kind == MB_DATA_VELOCITY_PROFILE) {
 		fprintf(stderr, "\ndbg5  SVP record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  SVP values:\n");
@@ -626,7 +618,6 @@ int mbr_wt_sb2000ss(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		        store->vru[4], store->vru[5], store->vru[6], store->vru[7]);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && store->kind == MB_DATA_DATA) {
 		fprintf(stderr, "\ndbg5  Data record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Data values:\n");
@@ -643,7 +634,6 @@ int mbr_wt_sb2000ss(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && store->kind == MB_DATA_COMMENT) {
 		fprintf(stderr, "\ndbg5  Comment record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Comment:\n");

--- a/src/mbio/mbr_sb2100bi.c
+++ b/src/mbio/mbr_sb2100bi.c
@@ -822,7 +822,6 @@ int mbr_sb2100bi_rd_pr(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *stor
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -912,7 +911,6 @@ int mbr_sb2100bi_rd_tr(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *stor
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Value read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", store->comment);
@@ -1050,7 +1048,6 @@ int mbr_sb2100bi_rd_dh(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *stor
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -1182,7 +1179,6 @@ int mbr_sb2100bi_rd_br(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *stor
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       beam depth xtrack ltrack tt angle angfor amp sig2noise echo src quality\n");
@@ -1276,7 +1272,6 @@ int mbr_sb2100bi_rd_sr(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *stor
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       pixel amplitude alongtrack\n");
@@ -1538,7 +1533,6 @@ int mbr_sb2100bi_wr_fh(int verbose, FILE *mbfp, int *error) {
 		fprintf(stderr, "dbg2       mbfp:       %p\n", (void *)mbfp);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       file_header_text: \n%s%s\n", mbf_sb2100bi_file_header_text_1,
@@ -1616,7 +1610,6 @@ int mbr_sb2100bi_wr_pr(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *stor
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -1750,7 +1743,6 @@ int mbr_sb2100bi_wr_tr(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *stor
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", store->comment);
@@ -1839,7 +1831,6 @@ int mbr_sb2100bi_wr_dh(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *stor
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", store->year);
@@ -2015,7 +2006,6 @@ int mbr_sb2100bi_wr_br(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *stor
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       beam depth xtrack ltrack tt angle angfor amp sig2noise echo src quality\n");
@@ -2131,7 +2121,6 @@ int mbr_sb2100bi_wr_sr(int verbose, FILE *mbfp, struct mbsys_sb2100_struct *stor
 		fprintf(stderr, "dbg2       store:      %p\n", (void *)store);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       pixel amplitude alongtrack\n");

--- a/src/mbio/mbr_sb2100rw.c
+++ b/src/mbio/mbr_sb2100rw.c
@@ -334,7 +334,6 @@ int mbr_sb2100rw_read_line(int verbose, FILE *mbfp, int minimum_size, char *line
 			status = MB_FAILURE;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg5  New line read in function <%s>\n", __func__);
 			fprintf(stderr, "dbg5       line:       %s\n", line);
@@ -450,7 +449,6 @@ int mbr_sb2100rw_rd_pr(int verbose, FILE *mbfp, struct mbf_sb2100rw_struct *data
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -501,7 +499,6 @@ int mbr_sb2100rw_rd_tr(int verbose, FILE *mbfp, struct mbf_sb2100rw_struct *data
 		strncpy(data->comment, line, nchars - 1);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Value read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -601,7 +598,6 @@ int mbr_sb2100rw_rd_dr(int verbose, FILE *mbfp, struct mbf_sb2100rw_struct *data
 			data->algorithm_order[i] = line[1 + shift + i];
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -683,7 +679,6 @@ int mbr_sb2100rw_rd_dr(int verbose, FILE *mbfp, struct mbf_sb2100rw_struct *data
 	  }
 	**/
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "dbg5       beam src tt angle angfor depth xtrack ltrack amp sig2noise echo quality\n");
 		for (int i = 0; i < data->num_beams; i++) {
@@ -794,7 +789,6 @@ int mbr_sb2100rw_rd_ss(int verbose, FILE *mbfp, struct mbf_sb2100rw_struct *data
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -870,7 +864,6 @@ int mbr_sb2100rw_rd_ss(int verbose, FILE *mbfp, struct mbf_sb2100rw_struct *data
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "dbg5       beam amp_ss ltrack\n");
 		for (int i = 0; i < data->num_pixels; i++) {
@@ -1179,7 +1172,6 @@ int mbr_sb2100rw_wr_rawline(int verbose, FILE *mbfp, void *data_ptr, int *error)
 	/* get pointer to raw data structure */
 	struct mbf_sb2100rw_struct *data = (struct mbf_sb2100rw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       raw line:         %s\n", data->comment);
@@ -1283,7 +1275,6 @@ int mbr_sb2100rw_wr_pr(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbf_sb2100rw_struct *data = (struct mbf_sb2100rw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -1359,7 +1350,6 @@ int mbr_sb2100rw_wr_tr(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbf_sb2100rw_struct *data = (struct mbf_sb2100rw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       comment:          %s\n", data->comment);
@@ -1410,7 +1400,6 @@ int mbr_sb2100rw_wr_dr(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbf_sb2100rw_struct *data = (struct mbf_sb2100rw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);
@@ -1591,7 +1580,6 @@ int mbr_sb2100rw_wr_ss(int verbose, FILE *mbfp, void *data_ptr, int *error) {
 	/* get pointer to raw data structure */
 	struct mbf_sb2100rw_struct *data = (struct mbf_sb2100rw_struct *)data_ptr;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       year:             %d\n", data->year);

--- a/src/mbio/mbr_sbifremr.c
+++ b/src/mbio/mbr_sbifremr.c
@@ -676,7 +676,6 @@ int mbr_wt_sbifremr(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", data->kind);

--- a/src/mbio/mbr_sbsiocen.c
+++ b/src/mbio/mbr_sbsiocen.c
@@ -349,7 +349,6 @@ int mbr_wt_sbsiocen(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 
 	int status = MB_SUCCESS;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", dataplus->kind);

--- a/src/mbio/mbr_sbsiolsi.c
+++ b/src/mbio/mbr_sbsiolsi.c
@@ -348,7 +348,6 @@ int mbr_wt_sbsiolsi(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 
 	int status = MB_SUCCESS;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", dataplus->kind);

--- a/src/mbio/mbr_sbsiomrg.c
+++ b/src/mbio/mbr_sbsiomrg.c
@@ -238,7 +238,6 @@ int mbr_rt_sbsiomrg(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	mb_io_ptr->new_kind = dataplus->kind;
 	mb_io_ptr->new_error = *error;
 
-	/* print debug statements */
 	if (verbose >= 5 && status == MB_SUCCESS && dataplus->kind == MB_DATA_DATA) {
 		fprintf(stderr, "\ndbg5  New ping read by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Raw ping values:\n");
@@ -469,7 +468,6 @@ int mbr_wt_sbsiomrg(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		strncat(datacomment, store->comment, mb_io_ptr->data_structure_size - 3);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", dataplus->kind);

--- a/src/mbio/mbr_sbsioswb.c
+++ b/src/mbio/mbr_sbsioswb.c
@@ -230,7 +230,6 @@ int mbr_rt_sbsioswb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	}
 #endif
 
-	/* print debug statements */
 	if (status == MB_SUCCESS && verbose >= 5) {
 		fprintf(stderr, "\ndbg5  New header record read by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  New header values:\n");
@@ -309,7 +308,6 @@ int mbr_rt_sbsioswb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		data->data_size = mb_swap_short(data->data_size);
 #endif
 
-		/* print debug statements */
 		if (status == MB_SUCCESS && verbose >= 5) {
 			fprintf(stderr, "\ndbg5  Header record after byte shift in MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5  New header values:\n");
@@ -394,7 +392,6 @@ int mbr_rt_sbsioswb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 #endif
 
-		/* print debug statements */
 		if (status == MB_SUCCESS && verbose >= 5) {
 			fprintf(stderr, "\ndbg5  New sensor record read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5  New sensor values:\n");
@@ -463,7 +460,6 @@ int mbr_rt_sbsioswb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			}
 		}
 
-		/* print debug statements */
 		if (status == MB_SUCCESS && verbose >= 5 && data->kind == MB_DATA_DATA) {
 			fprintf(stderr, "\ndbg5  New data record read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5  New data values:\n");
@@ -490,7 +486,6 @@ int mbr_rt_sbsioswb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			*error = MB_ERROR_EOF;
 		}
 
-		/* print debug statements */
 		if (status == MB_SUCCESS && verbose >= 5) {
 			fprintf(stderr, "\ndbg5  New comment record read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg5  New comment:\n");
@@ -711,14 +706,12 @@ int mbr_wt_sbsioswb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	sensor_size = data->sensor_size;
 	data_size = data->data_size;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", data->kind);
 		fprintf(stderr, "dbg5       error:      %d\n", *error);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Header record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Header values:\n");
@@ -740,7 +733,6 @@ int mbr_wt_sbsioswb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "dbg5       data_type:  %c%c\n", data->data_type[0], data->data_type[1]);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && data->kind == MB_DATA_DATA) {
 		fprintf(stderr, "\ndbg5  Sensor record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Sensor values:\n");
@@ -748,7 +740,6 @@ int mbr_wt_sbsioswb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		fprintf(stderr, "dbg5       eclipse_heading: %d\n", data->eclipse_heading);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && data->kind == MB_DATA_DATA) {
 		fprintf(stderr, "\ndbg5  Data record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Data values:\n");
@@ -759,7 +750,6 @@ int mbr_wt_sbsioswb(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			        data->bath_struct[i].bath_acrosstrack);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5 && data->kind == MB_DATA_COMMENT) {
 		fprintf(stderr, "\ndbg5  Comment record to be written by MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5  Comment:\n");

--- a/src/mbio/mbr_sburicen.c
+++ b/src/mbio/mbr_sburicen.c
@@ -353,7 +353,6 @@ int mbr_wt_sburicen(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		strncat(datacomment, store->comment, MBSYS_SB_MAXLINE - 1);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", dataplus->kind);

--- a/src/mbio/mbr_sburivax.c
+++ b/src/mbio/mbr_sburivax.c
@@ -377,7 +377,6 @@ int mbr_wt_sburivax(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 
 	int status = MB_SUCCESS;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Ready to write data in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       kind:       %d\n", dataplus->kind);

--- a/src/mbio/mbr_wasspenl.c
+++ b/src/mbio/mbr_wasspenl.c
@@ -285,7 +285,6 @@ int mbr_wasspenl_rd_genbathy(int verbose, char *buffer, void *store_ptr, int *er
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       genbathy->version:                    %u\n", genbathy->version);
@@ -405,7 +404,6 @@ int mbr_wasspenl_rd_corbathy(int verbose, char *buffer, void *store_ptr, int *er
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       corbathy->version:                    %u\n", corbathy->version);
@@ -521,7 +519,6 @@ int mbr_wasspenl_rd_rawsonar(int verbose, char *buffer, void *store_ptr, int *er
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       rawsonar->version:                    %u\n", rawsonar->version);
@@ -598,7 +595,6 @@ int mbr_wasspenl_rd_gen_sens(int verbose, char *buffer, void *store_ptr, int *er
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       gen_sens->version:                    %u\n", gen_sens->version);
@@ -670,7 +666,6 @@ int mbr_wasspenl_rd_nvupdate(int verbose, char *buffer, void *store_ptr, int *er
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       nvupdate->version:                    %u\n", nvupdate->version);
@@ -762,7 +757,6 @@ int mbr_wasspenl_rd_wcd_navi(int verbose, char *buffer, void *store_ptr, int *er
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       wcd_navi->version:                    %u\n", wcd_navi->version);
@@ -873,7 +867,6 @@ int mbr_wasspenl_rd_sensprop(int verbose, char *buffer, void *store_ptr, int *er
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sensprop->version:                    %u\n", sensprop->version);
@@ -964,7 +957,6 @@ int mbr_wasspenl_rd_sys_prop(int verbose, char *buffer, void *store_ptr, int *er
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sys_prop->version:                    %u\n", sys_prop->version);
@@ -1033,7 +1025,6 @@ int mbr_wasspenl_rd_sys_cfg1(int verbose, char *buffer, void *store_ptr, int *er
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < sys_cfg1->sys_cfg1_len; i++) {
@@ -1083,7 +1074,6 @@ int mbr_wasspenl_rd_mcomment(int verbose, char *buffer, void *store_ptr, int *er
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       mcomment->comment_length:             %u\n", mcomment->comment_length);
@@ -1143,7 +1133,6 @@ int mbr_wasspenl_rd_unknown1(int verbose, char *buffer, void *store_ptr, int *er
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < unknown1->unknown1_len; i++) {
@@ -1448,7 +1437,6 @@ int mbr_wasspenl_wr_genbathy(int verbose, int *bufferalloc, char **bufferptr, vo
 	genbathy->version = 3;
 	genbathy->checksum = 0x8806CBA5;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       genbathy->version:                    %u\n", genbathy->version);
@@ -1586,7 +1574,6 @@ int mbr_wasspenl_wr_corbathy(int verbose, int *bufferalloc, char **bufferptr, vo
 	corbathy->version = 4;
 	corbathy->checksum = 0x8806CBA5;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       corbathy->version:                    %u\n", corbathy->version);
@@ -1732,7 +1719,6 @@ int mbr_wasspenl_wr_rawsonar(int verbose, int *bufferalloc, char **bufferptr, vo
 	rawsonar->version = 2;
 	rawsonar->checksum = 0x8806CBA5;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       rawsonar->version:                    %u\n", rawsonar->version);
@@ -1858,7 +1844,6 @@ int mbr_wasspenl_wr_gen_sens(int verbose, int *bufferalloc, char **bufferptr, vo
 	gen_sens->version = 2;
 	gen_sens->checksum = 0x8806CBA5;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       gen_sens->version:                    %u\n", gen_sens->version);
@@ -1942,7 +1927,6 @@ int mbr_wasspenl_wr_nvupdate(int verbose, int *bufferalloc, char **bufferptr, vo
 	nvupdate->version = 4;
 	nvupdate->checksum = 0x8806CBA5;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       nvupdate->version:                    %u\n", nvupdate->version);
@@ -2041,7 +2025,6 @@ int mbr_wasspenl_wr_wcd_navi(int verbose, int *bufferalloc, char **bufferptr, vo
 	wcd_navi->version = 4;
 	wcd_navi->checksum = 0x8806CBA5;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       wcd_navi->version:                    %u\n", wcd_navi->version);
@@ -2147,7 +2130,6 @@ int mbr_wasspenl_wr_sensprop(int verbose, int *bufferalloc, char **bufferptr, vo
 	sensprop->version = 1;
 	sensprop->checksum = 0x8806CBA5;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sensprop->version:                    %u\n", sensprop->version);
@@ -2280,7 +2262,6 @@ int mbr_wasspenl_wr_sys_prop(int verbose, int *bufferalloc, char **bufferptr, vo
 	sys_prop->version = 1;
 	sys_prop->checksum = 0x8806CBA5;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       sys_prop->version:                    %u\n", sys_prop->version);
@@ -2379,7 +2360,6 @@ int mbr_wasspenl_wr_sys_cfg1(int verbose, int *bufferalloc, char **bufferptr, vo
 	struct mbsys_wassp_struct *store = (struct mbsys_wassp_struct *)store_ptr;
 	struct mbsys_wassp_sys_cfg1_struct *sys_cfg1 = &(store->sys_cfg1);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < sys_cfg1->sys_cfg1_len; i++) {
@@ -2439,7 +2419,6 @@ int mbr_wasspenl_wr_mcomment(int verbose, int *bufferalloc, char **bufferptr, vo
 	struct mbsys_wassp_mcomment_struct *mcomment = &(store->mcomment);
 	mcomment->checksum = 0x8806CBA5;
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5       mcomment->comment_length:             %u\n", mcomment->comment_length);
@@ -2511,7 +2490,6 @@ int mbr_wasspenl_wr_unknown1(int verbose, int *bufferalloc, char **bufferptr, vo
 	struct mbsys_wassp_struct *store = (struct mbsys_wassp_struct *)store_ptr;
 	struct mbsys_wassp_unknown1_struct *unknown1 = &(store->unknown1);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		for (int i = 0; i < unknown1->unknown1_len; i++) {

--- a/src/mbio/mbr_xtfb1624.c
+++ b/src/mbio/mbr_xtfb1624.c
@@ -701,7 +701,6 @@ int mbr_xtfb1624_rd_data(int verbose, void *mbio_ptr, int *error) {
 				mb_io_ptr->projection_initialized = MB_YES;
 			}
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 				fprintf(stderr, "dbg5       FileFormat:                 %d\n", fileheader->FileFormat);
@@ -822,7 +821,6 @@ int mbr_xtfb1624_rd_data(int verbose, void *mbio_ptr, int *error) {
 				packetheader.HeaderType = 99;
 			}
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 				fprintf(stderr, "dbg5       Bytes Skipped:              %d\n", skip);
@@ -885,7 +883,6 @@ int mbr_xtfb1624_rd_data(int verbose, void *mbio_ptr, int *error) {
 				mb_attint_add(verbose, mbio_ptr, timetag, heave, roll, pitch, error);
 				mb_hedint_add(verbose, mbio_ptr, timetag, heading, error);
 
-				/* print debug statements */
 				if (verbose >= 5) {
 					fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg5       MagicNumber:                %d %d %x%x\n",
@@ -1280,7 +1277,6 @@ int mbr_xtfb1624_rd_data(int verbose, void *mbio_ptr, int *error) {
 				done = MB_YES;
 			}
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 				fprintf(stderr, "dbg5       MagicNumber:                %d %d %x%x\n", pingheader->packetheader.MagicNumber[0],

--- a/src/mbio/mbr_xtfr8101.c
+++ b/src/mbio/mbr_xtfr8101.c
@@ -386,7 +386,6 @@ int mbr_xtfr8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 				mb_io_ptr->projection_initialized = MB_YES;
 			}
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 				fprintf(stderr, "dbg5       FileFormat:                 %d\n", fileheader->FileFormat);
@@ -505,7 +504,6 @@ int mbr_xtfr8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 				packetheader.HeaderType = 99;
 			}
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 				fprintf(stderr, "dbg5       Bytes Skipped:              %d\n", skip);
@@ -568,7 +566,6 @@ int mbr_xtfr8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 				mb_attint_add(verbose, mbio_ptr, timetag, heave, roll, pitch, error);
 				mb_hedint_add(verbose, mbio_ptr, timetag, heading, error);
 
-				/* print debug statements */
 				if (verbose >= 5) {
 					fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg5       MagicNumber:                %d %d %x%x\n",
@@ -954,7 +951,6 @@ int mbr_xtfr8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 				done = MB_YES;
 			}
 
-			/* print debug statements */
 			if (verbose >= 5) {
 				fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 				fprintf(stderr, "dbg5       MagicNumber:                %d %d %x%x\n",
@@ -1433,7 +1429,6 @@ int mbr_xtfr8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 					done = MB_YES;
 				}
 
-				/* print debug statements */
 				if (verbose >= 5) {
 					fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
 					fprintf(stderr, "dbg5       MagicNumber:                %d %d %x%x\n",

--- a/src/mbio/mbsys_atlas.c
+++ b/src/mbio/mbsys_atlas.c
@@ -441,7 +441,6 @@ int mbsys_atlas_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -481,7 +480,6 @@ int mbsys_atlas_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 		/* copy comment */
 		strncpy(comment, store->comment, MBSYS_ATLAS_COMMENT_LENGTH);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -978,7 +976,6 @@ int mbsys_atlas_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		*pitch = RTD * store->start_pitch;
 		*heave = store->start_heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_benthos.c
+++ b/src/mbio/mbsys_benthos.c
@@ -282,7 +282,6 @@ int mbsys_benthos_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 			ssalongtrack[i] = 0;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -334,7 +333,6 @@ int mbsys_benthos_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		*namp = 0;
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -362,7 +360,6 @@ int mbsys_benthos_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -670,7 +667,6 @@ int mbsys_benthos_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 		*pitch = store->png_pitch;
 		*heave = store->png_heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -722,7 +718,6 @@ int mbsys_benthos_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 		*pitch = store->png_pitch;
 		*heave = store->png_heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -1062,7 +1057,6 @@ int mbsys_benthos_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel
 			store->ss_acrosstrack[i] = ssacrosstrack[i];
 		}
 
-		/* print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "\ndbg2  Sidescan regenerated in <%s>\n", __func__);
 			fprintf(stderr, "dbg2       beams_bath:    %d\n", store->beams_bath);

--- a/src/mbio/mbsys_dsl.c
+++ b/src/mbio/mbsys_dsl.c
@@ -295,7 +295,6 @@ int mbsys_dsl_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 			ssacrosstrack[j] = dx * (i + 0.5);
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -334,7 +333,6 @@ int mbsys_dsl_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -791,7 +789,6 @@ int mbsys_dsl_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		*pitch = store->pitch;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_elac.c
+++ b/src/mbio/mbsys_elac.c
@@ -326,7 +326,6 @@ int mbsys_elac_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 				amp[ibeam] = reflscale * store->profile[i].amp[j];
 			}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -362,7 +361,6 @@ int mbsys_elac_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -864,7 +862,6 @@ int mbsys_elac_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 		*pitch = 0.005 * store->profile[0].pitch;
 		*heave = 0.001 * store->profile[0].heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_elacmk2.c
+++ b/src/mbio/mbsys_elacmk2.c
@@ -329,7 +329,6 @@ int mbsys_elacmk2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 			amp[i] = reflscale * store->beams[j].amplitude;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -382,7 +381,6 @@ int mbsys_elacmk2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		/* get speed  */
 		*speed = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -412,7 +410,6 @@ int mbsys_elacmk2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -933,7 +930,6 @@ int mbsys_elacmk2_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 			*heave = 0.0;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -997,7 +993,6 @@ int mbsys_elacmk2_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 			*heave = 0.0;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_gsf.c
+++ b/src/mbio/mbsys_gsf.c
@@ -528,7 +528,6 @@ int mbsys_gsf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -567,7 +566,6 @@ int mbsys_gsf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 		else
 			comment[0] = '\0';
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -1389,7 +1387,6 @@ int mbsys_gsf_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		else
 			*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_hdcs.c
+++ b/src/mbio/mbsys_hdcs.c
@@ -401,7 +401,6 @@ int mbsys_hdcs_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 		/* get speed */
 		*speed = 3.6e-3 * store->vesselVelocity;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Extracting data by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Data type:\n");
@@ -570,7 +569,6 @@ int mbsys_hdcs_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 			ssalongtrack[i] = 0.001 * store->ssalongtrack[i];
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -610,7 +608,6 @@ int mbsys_hdcs_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 		/* copy comment */
 		strncpy(comment, store->comment, MBSYS_HDCS_MAX_COMMENT);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -1121,7 +1118,6 @@ int mbsys_hdcs_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 		*pitch = RTD * 1E-7 * store->vesselPitch;
 		*heave = 0.001 * store->vesselHeave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_hs10.c
+++ b/src/mbio/mbsys_hs10.c
@@ -213,7 +213,6 @@ int mbsys_hs10_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 			bathalongtrack[i] = 0.0;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -249,7 +248,6 @@ int mbsys_hs10_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 		/* copy comment */
 		strncpy(comment, store->comment, MBSYS_HS10_COMMENT);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -713,7 +711,6 @@ int mbsys_hs10_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 		*pitch = 0.0;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_hsds.c
+++ b/src/mbio/mbsys_hsds.c
@@ -219,7 +219,6 @@ int mbsys_hsds_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 			amp[i] = store->back_scale * store->back[i];
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -255,7 +254,6 @@ int mbsys_hsds_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -740,7 +738,6 @@ int mbsys_hsds_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 		*pitch = store->pitch;
 		*heave = store->heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_hsmd.c
+++ b/src/mbio/mbsys_hsmd.c
@@ -267,7 +267,6 @@ int mbsys_hsmd_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -302,7 +301,6 @@ int mbsys_hsmd_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -840,7 +838,6 @@ int mbsys_hsmd_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 		*pitch = store->pitch_tx;
 		*heave = store->heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_hysweep.c
+++ b/src/mbio/mbsys_hysweep.c
@@ -1355,7 +1355,6 @@ int mbsys_hysweep_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		else
 			*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -1417,7 +1416,6 @@ int mbsys_hysweep_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		*namp = 0;
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -1453,7 +1451,6 @@ int mbsys_hysweep_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		else
 			comment[0] = '\0';
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -1478,7 +1475,6 @@ int mbsys_hysweep_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 			time_i[i] = store->time_i[i];
 		*time_d = store->time_d;
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -2664,7 +2660,6 @@ int mbsys_hysweep_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "\ndbg2  Sidescan regenerated in <%s>\n", __func__);
 			fprintf(stderr, "dbg2       pixels_ss:  %d\n", store->MSS_num_pixels);

--- a/src/mbio/mbsys_image83p.c
+++ b/src/mbio/mbsys_image83p.c
@@ -192,7 +192,6 @@ int mbsys_image83p_extract(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 			bathalongtrack[i] = store->bathalongtrack[i];
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -224,7 +223,6 @@ int mbsys_image83p_extract(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 		/* copy comment */
 		strncpy(comment, store->comment, MBSYS_IMAGE83P_COMMENTLEN);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -658,7 +656,6 @@ int mbsys_image83p_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int
 		*pitch = 0.1 * (store->pitch - 900.0) + ((double)store->profile_tilt_angle - 180.0);
 		*heave = store->heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_jstar.c
+++ b/src/mbio/mbsys_jstar.c
@@ -614,7 +614,6 @@ int mbsys_jstar_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 			beamflag[0] = MB_FLAG_NULL;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -762,7 +761,6 @@ int mbsys_jstar_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 			ss[i] = MB_SIDESCAN_NULL;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -798,7 +796,6 @@ int mbsys_jstar_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 		/* copy comment */
 		strcpy(comment, store->comment.comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -1501,7 +1498,6 @@ int mbsys_jstar_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		*pitch = 180.0 / 32768.0 * (double)sbp->pitch;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -1568,7 +1564,6 @@ int mbsys_jstar_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		*pitch = 180.0 / 32768.0 * (double)ssport->pitch;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_kmbes.c
+++ b/src/mbio/mbsys_kmbes.c
@@ -410,7 +410,6 @@ int mbsys_kmbes_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
       }
     }
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -467,7 +466,6 @@ int mbsys_kmbes_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
     *namp = 0;
     *nss = 0;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -515,7 +513,6 @@ int mbsys_kmbes_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
     *namp = 0;
     *nss = 0;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -560,7 +557,6 @@ int mbsys_kmbes_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
     *namp = 0;
     *nss = 0;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -596,7 +592,6 @@ int mbsys_kmbes_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
     else
       comment[0] = '\0';
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  New ping values:\n");
@@ -621,7 +616,6 @@ int mbsys_kmbes_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
       time_i[i] = store->time_i[i];
     *time_d = store->time_d;
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_ldeoih.c
+++ b/src/mbio/mbsys_ldeoih.c
@@ -375,7 +375,6 @@ int mbsys_ldeoih_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 			ssalongtrack[i] = store->distance_scale * store->ss_alongtrack[i];
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -415,7 +414,6 @@ int mbsys_ldeoih_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -1071,7 +1069,6 @@ int mbsys_ldeoih_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
 		*pitch = store->pitch;
 		*heave = store->heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_mr1.c
+++ b/src/mbio/mbsys_mr1.c
@@ -279,7 +279,6 @@ int mbsys_mr1_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 			ssalongtrack[j] = 0.0;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -319,7 +318,6 @@ int mbsys_mr1_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -842,7 +840,6 @@ int mbsys_mr1_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		*pitch = store->png_pitch;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_mr1b.c
+++ b/src/mbio/mbsys_mr1b.c
@@ -281,7 +281,6 @@ int mbsys_mr1b_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 			ssalongtrack[j] = 0.0;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -321,7 +320,6 @@ int mbsys_mr1b_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -842,7 +840,6 @@ int mbsys_mr1b_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 		*pitch = store->png_pitch;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_mr1v2001.c
+++ b/src/mbio/mbsys_mr1v2001.c
@@ -333,7 +333,6 @@ int mbsys_mr1v2001_extract(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 			ssalongtrack[j] = ssyoffset;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -373,7 +372,6 @@ int mbsys_mr1v2001_extract(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -1104,7 +1102,6 @@ int mbsys_mr1v2001_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int
 		*pitch = ping->png_pitch.sns_repval;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_mstiff.c
+++ b/src/mbio/mbsys_mstiff.c
@@ -183,7 +183,6 @@ int mbsys_mstiff_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 			ssalongtrack[i] = 0.0;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -563,7 +562,6 @@ int mbsys_mstiff_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
 		*pitch = 0.0;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_navnetcdf.c
+++ b/src/mbio/mbsys_navnetcdf.c
@@ -500,7 +500,6 @@ int mbsys_navnetcdf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		*namp = 0;
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -540,7 +539,6 @@ int mbsys_navnetcdf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -962,7 +960,6 @@ int mbsys_navnetcdf_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, in
 		*pitch = 0.0;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_netcdf.c
+++ b/src/mbio/mbsys_netcdf.c
@@ -1313,7 +1313,6 @@ int mbsys_netcdf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -1353,7 +1352,6 @@ int mbsys_netcdf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -2167,7 +2165,6 @@ int mbsys_netcdf_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
 		*pitch = store->mbPitch[0] * store->mbPitch_scale_factor;
 		*heave = store->mbTransmissionHeave[0] * store->mbTransmissionHeave_scale_factor;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_oic.c
+++ b/src/mbio/mbsys_oic.c
@@ -302,7 +302,6 @@ int mbsys_oic_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 			ssalongtrack[i] = store->ssalongtrack[i];
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -342,7 +341,6 @@ int mbsys_oic_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 		/* copy comment */
 		strncpy(comment, store->client, MBSYS_OIC_MAX_COMMENT);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -889,7 +887,6 @@ int mbsys_oic_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		*pitch = store->fish_pitch;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_reson.c
+++ b/src/mbio/mbsys_reson.c
@@ -313,7 +313,6 @@ int mbsys_reson_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 			amp[i] = reflscale * store->amp[i];
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -371,7 +370,6 @@ int mbsys_reson_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 		*namp = 0;
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -399,7 +397,6 @@ int mbsys_reson_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -887,7 +884,6 @@ int mbsys_reson_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		*pitch = 0.005 * store->pitch;
 		*heave = 0.001 * store->heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -944,7 +940,6 @@ int mbsys_reson_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		*pitch = 0.005 * store->pitch;
 		*heave = 0.001 * store->heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_reson7k.c
+++ b/src/mbio/mbsys_reson7k.c
@@ -5209,7 +5209,6 @@ int mbsys_reson7k_preprocess(int verbose,     /* in: verbosity level set on comm
       /*--------------------------------------------------------------*/
       if (status == MB_SUCCESS && (bathymetry->optionaldata == MB_NO || pars->recalculate_bathymetry == MB_YES)) {
 
-        /* print debug statements */
         if (verbose >= 2) {
           fprintf(stderr, "\ndbg2 Recalculating bathymetry in %s: 7k ping records read:\n", __func__);
           fprintf(stderr, "dbg2      current_ping_number:           %d\n", store->current_ping_number);
@@ -6212,7 +6211,6 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
       }
     }
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -6272,7 +6270,6 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
     *namp = 0;
     *nss = 0;
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -6319,7 +6316,6 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
     *namp = 0;
     *nss = 0;
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -6374,7 +6370,6 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
     *namp = 0;
     *nss = 0;
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -6431,7 +6426,6 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
     *namp = 0;
     *nss = 0;
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -6467,7 +6461,6 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
     else
       comment[0] = '\0';
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  New ping values:\n");
@@ -6492,7 +6485,6 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
       time_i[i] = store->time_i[i];
     *time_d = store->time_d;
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -7560,7 +7552,6 @@ int mbsys_reson7k_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
       *navlat = ((double)fsdwssheader->latitude) / 360000.0;
     }
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -9992,7 +9983,6 @@ int mbsys_reson7k_makess(int verbose, void *mbio_ptr, void *store_ptr, int sourc
       processedsidescan->alongtrack[i] = ssalongtrack[i];
     }
 
-    /* print debug statements */
     if (verbose >= 2) {
       fprintf(stderr, "\ndbg2  Sidescan regenerated in <%s>\n", __func__);
       fprintf(stderr, "dbg2       pixels_ss:  %d\n", nss);

--- a/src/mbio/mbsys_reson7k3.c
+++ b/src/mbio/mbsys_reson7k3.c
@@ -4570,7 +4570,6 @@ int mbsys_reson7k3_preprocess(int verbose,     /* in: verbosity level set on com
         || (store->read_SegmentedRawDetection == MB_YES && SegmentedRawDetection->optionaldata == MB_NO)
         || pars->recalculate_bathymetry == MB_YES) {
 
-      /* print debug statements */
       if (verbose >= 2) {
         fprintf(stderr, "\ndbg2 Recalculating Bathymetry in %s: 7k ping records read:\n", __func__);
         fprintf(stderr, "dbg2      read_ProcessedSideScan:              %d\n",
@@ -5455,7 +5454,6 @@ if (store->kind == MB_DATA_DATA) {
 			}
     } // end extract processed multibeam sidescan
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -5512,7 +5510,6 @@ if (store->kind == MB_DATA_DATA) {
     *namp = 0;
     *nss = 0;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -5560,7 +5557,6 @@ if (store->kind == MB_DATA_DATA) {
     *namp = 0;
     *nss = 0;
 
-    /* print debug statements */
     if (verbose >= 5) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -5596,7 +5592,6 @@ if (store->kind == MB_DATA_DATA) {
     else
       comment[0] = '\0';
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  New ping values:\n");
@@ -5621,7 +5616,6 @@ if (store->kind == MB_DATA_DATA) {
       time_i[i] = store->time_i[i];
     *time_d = store->time_d;
 
-    /* print debug statements */
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
       fprintf(stderr, "dbg4  Extracted values:\n");
@@ -8798,7 +8792,6 @@ int mbsys_reson7k3_makess(int verbose, void *mbio_ptr, void *store_ptr, int sour
       ProcessedSideScan->alongtrack[i] = ssalongtrack[i];
     }
 
-    /* print debug statements */
     if (verbose >= 2) {
       fprintf(stderr, "\ndbg2  SideScan regenerated in <%s>\n", __func__);
       fprintf(stderr, "dbg2       pixels_ss:  %d\n", nss);

--- a/src/mbio/mbsys_reson8k.c
+++ b/src/mbio/mbsys_reson8k.c
@@ -340,7 +340,6 @@ int mbsys_reson8k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 			ssalongtrack[i] = store->ss_alongtrack[i];
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -392,7 +391,6 @@ int mbsys_reson8k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		*namp = 0;
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -420,7 +418,6 @@ int mbsys_reson8k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -882,7 +879,6 @@ int mbsys_reson8k_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 		*pitch = store->png_pitch;
 		*heave = store->png_heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -934,7 +930,6 @@ int mbsys_reson8k_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 		*pitch = store->png_pitch;
 		*heave = store->png_heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -1399,7 +1394,6 @@ int mbsys_reson8k_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel
 			store->ss_alongtrack[i] = ssalongtrack[i];
 		}
 
-		/* print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "\ndbg2  Sidescan regenerated in <%s>\n", __func__);
 			fprintf(stderr, "dbg2       beams_bath:    %d\n", store->beams_bath);

--- a/src/mbio/mbsys_sb.c
+++ b/src/mbio/mbsys_sb.c
@@ -212,7 +212,6 @@ int mbsys_sb_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
 			bathalongtrack[id - i] = 0.0;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -244,7 +243,6 @@ int mbsys_sb_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -724,7 +722,6 @@ int mbsys_sb_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 		*pitch = 0.0;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_sb2000.c
+++ b/src/mbio/mbsys_sb2000.c
@@ -227,7 +227,6 @@ int mbsys_sb2000_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -263,7 +262,6 @@ int mbsys_sb2000_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -760,7 +758,6 @@ int mbsys_sb2000_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
 		*pitch = 0.01 * store->pitch;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_sb2100.c
+++ b/src/mbio/mbsys_sb2100.c
@@ -229,7 +229,6 @@ int mbsys_sb2100_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 			ssalongtrack[i] = store->pixels[i].alongtrack;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -269,7 +268,6 @@ int mbsys_sb2100_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -852,7 +850,6 @@ int mbsys_sb2100_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
 		*pitch = store->pitch;
 		*heave = -store->heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_simrad.c
+++ b/src/mbio/mbsys_simrad.c
@@ -501,7 +501,6 @@ int mbsys_simrad_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 			*nss = 0;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -562,7 +561,6 @@ int mbsys_simrad_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 		*namp = 0;
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -590,7 +588,6 @@ int mbsys_simrad_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -1555,7 +1552,6 @@ int mbsys_simrad_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
 		*pitch = 0.01 * ping->pitch;
 		*heave = 0.01 * ping->ping_heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -1617,7 +1613,6 @@ int mbsys_simrad_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *
 		*pitch = 0.0;
 		*heave = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -2264,7 +2259,6 @@ int mbsys_simrad_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_
 		/* get pixel interpolation */
 		pixel_int_use = pixel_int + 1;
 
-		/* print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "\ndbg2  Sidescan regenerated in <%s>\n", __func__);
 			fprintf(stderr, "dbg2       depthscale:    %f\n", depthscale);
@@ -2382,7 +2376,6 @@ int mbsys_simrad_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "\ndbg2  Sidescan regenerated in <%s>\n", __func__);
 			fprintf(stderr, "dbg2       beams_bath:    %d\n", ping->beams_bath);

--- a/src/mbio/mbsys_simrad2.c
+++ b/src/mbio/mbsys_simrad2.c
@@ -2585,7 +2585,6 @@ int mbsys_simrad2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 			*nss += MBSYS_SIMRAD2_MAXPIXELS;
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -2655,7 +2654,6 @@ int mbsys_simrad2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		*namp = 0;
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -2683,7 +2681,6 @@ int mbsys_simrad2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		/* copy comment */
 		strncpy(comment, store->par_com, MBSYS_SIMRAD2_COMMENT_LENGTH);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -3971,7 +3968,6 @@ int mbsys_simrad2_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 		*pitch = 0.01 * ping->png_pitch;
 		*heave = 0.01 * ping->png_heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -4047,7 +4043,6 @@ int mbsys_simrad2_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int 
 		*pitch = 0.01 * store->pos_pitch;
 		*heave = 0.01 * store->pos_heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -4799,7 +4794,6 @@ int mbsys_simrad2_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "\ndbg2  Sidescan regenerated in <%s>\n", __func__);
 			fprintf(stderr, "dbg2       png_nbeams_ss: %d\n", ping->png_nbeams_ss);
@@ -5057,7 +5051,6 @@ int mbsys_simrad2_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "\ndbg2  Sidescan regenerated in <%s>\n", __func__);
 			fprintf(stderr, "dbg2       png_nbeams_ss: %d\n", ping->png_nbeams_ss);

--- a/src/mbio/mbsys_simrad3.c
+++ b/src/mbio/mbsys_simrad3.c
@@ -2115,7 +2115,6 @@ int mbsys_simrad3_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -2185,7 +2184,6 @@ int mbsys_simrad3_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		*namp = 0;
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -2213,7 +2211,6 @@ int mbsys_simrad3_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		/* copy comment */
 		strncpy(comment, store->par_com, MBSYS_SIMRAD3_COMMENT_LENGTH);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -3986,7 +3983,6 @@ int mbsys_simrad3_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel
 			}
 		}
 
-		/* print debug statements */
 		if (verbose >= 2) {
 			fprintf(stderr, "\ndbg2  Sidescan regenerated in <%s>\n", __func__);
 			fprintf(stderr, "dbg2       png_nbeams_ss: %d\n", ping->png_nbeams_ss);

--- a/src/mbio/mbsys_singlebeam.c
+++ b/src/mbio/mbsys_singlebeam.c
@@ -314,7 +314,6 @@ int mbsys_singlebeam_extract(int verbose, void *mbio_ptr, void *store_ptr, int *
 		bathacrosstrack[0] = 0.0;
 		bathalongtrack[0] = 0.0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -346,7 +345,6 @@ int mbsys_singlebeam_extract(int verbose, void *mbio_ptr, void *store_ptr, int *
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -776,7 +774,6 @@ int mbsys_singlebeam_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, i
 		*pitch = store->pitch;
 		*heave = store->heave;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_stereopair.c
+++ b/src/mbio/mbsys_stereopair.c
@@ -304,7 +304,6 @@ int mbsys_stereopair_extract(int verbose, void *mbio_ptr, void *store_ptr, int *
 		//	{
 		//	}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -360,7 +359,6 @@ int mbsys_stereopair_extract(int verbose, void *mbio_ptr, void *store_ptr, int *
 		*namp = 0;
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -392,7 +390,6 @@ int mbsys_stereopair_extract(int verbose, void *mbio_ptr, void *store_ptr, int *
 		/* copy comment */
 		strncpy(comment, store->comment, MIN(store->comment_len, MB_COMMENT_MAXLINE));
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");

--- a/src/mbio/mbsys_surf.c
+++ b/src/mbio/mbsys_surf.c
@@ -309,7 +309,6 @@ int mbsys_surf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 				}
 			}
 		}
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -350,7 +349,6 @@ int mbsys_surf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 		/*		strncpy(comment,store->comment,
 		            MBSYS_SURF_COMMENT_LENGTH);*/
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -901,7 +899,6 @@ int mbsys_surf_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 		*pitch = -RTD * store->SoundingData.pitchWhileTransmitting;
 		*heave = -store->SoundingData.heaveWhileTransmitting;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_swathplus.c
+++ b/src/mbio/mbsys_swathplus.c
@@ -434,7 +434,6 @@ int mbsys_swathplus_extract(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		/* extract sidescan */
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -487,7 +486,6 @@ int mbsys_swathplus_extract(int verbose, void *mbio_ptr, void *store_ptr, int *k
 			comment[0] = '\0';
 		}
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -512,7 +510,6 @@ int mbsys_swathplus_extract(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		}
 		*time_d = store->time_d;
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -1907,7 +1904,6 @@ int swpls_rd_projection(int verbose, char *buffer, void *store_ptr, int *error) 
 		}
 	}
 
-	/* print debug statements */
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -1977,7 +1973,6 @@ int swpls_rd_comment(int verbose, char *buffer, void *store_ptr, int *error) {
 		store->kind = MB_DATA_NONE;
 	}
 
-	/* print debug statements */
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);
 		fprintf(stderr, "dbg2  Return values:\n");
@@ -2905,7 +2900,6 @@ int swpls_wr_sxpheader(int verbose, int *bufferalloc, char **bufferptr, void *st
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_header *header = &(store->sxp_header);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_sxpheader(verbose, stderr, header, error);
@@ -2971,7 +2965,6 @@ int swpls_wr_sxpping(int verbose, int *bufferalloc, char **bufferptr, void *stor
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_sxpping *ping = &(store->sxp_ping);
 
-	/* print debug statements */
 	if (verbose >= 4) {
 		fprintf(stderr, "\ndbg4  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_sxpping(verbose, stderr, ping, error);
@@ -3136,7 +3129,6 @@ int swpls_wr_projection(int verbose, int *bufferalloc, char **bufferptr, void *s
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_projection *projection = &(store->projection);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_projection(verbose, stderr, projection, error);
@@ -3210,7 +3202,6 @@ int swpls_wr_comment(int verbose, int *bufferalloc, char **bufferptr, void *stor
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_comment *comment = &(store->comment);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_comment(verbose, stderr, comment, error);
@@ -3284,7 +3275,6 @@ int swpls_wr_sxiheader(int verbose, int *bufferalloc, char **bufferptr, void *st
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_header *header = &(store->sxi_header);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_sxiheader(verbose, stderr, header, error);
@@ -3350,7 +3340,6 @@ int swpls_wr_sxiping(int verbose, int *bufferalloc, char **bufferptr, void *stor
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_sxiping *ping = &(store->sxi_ping);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_sxiping(verbose, stderr, ping, error);
@@ -3448,7 +3437,6 @@ int swpls_wr_attitude(int verbose, int *bufferalloc, char **bufferptr, void *sto
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_attitude *attitude = &(store->attitude);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_attitude(verbose, stderr, attitude, error);
@@ -3524,7 +3512,6 @@ int swpls_wr_posll(int verbose, int *bufferalloc, char **bufferptr, void *store_
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_posll *posll = &(store->posll);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_posll(verbose, stderr, posll, error);
@@ -3596,7 +3583,6 @@ int swpls_wr_posen(int verbose, int *bufferalloc, char **bufferptr, void *store_
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_posen *posen = &(store->posen);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_posen(verbose, stderr, posen, error);
@@ -3668,7 +3654,6 @@ int swpls_wr_ssv(int verbose, int *bufferalloc, char **bufferptr, void *store_pt
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_ssv *ssv = &(store->ssv);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_ssv(verbose, stderr, ssv, error);
@@ -3738,7 +3723,6 @@ int swpls_wr_tide(int verbose, int *bufferalloc, char **bufferptr, void *store_p
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_tide *tide = &(store->tide);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_tide(verbose, stderr, tide, error);
@@ -3803,7 +3787,6 @@ int swpls_wr_echosounder(int verbose, int *bufferalloc, char **bufferptr, void *
 		swpls_pr_echosounder(verbose, stderr, echosounder, error);
 	}
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		fprintf(stderr, "dbg5        echosounder->time_d:      %d\n", echosounder->time_d);
@@ -3876,7 +3859,6 @@ int swpls_wr_agds(int verbose, int *bufferalloc, char **bufferptr, void *store_p
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_agds *agds = &(store->agds);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_agds(verbose, stderr, agds, error);
@@ -3948,7 +3930,6 @@ int swpls_wr_pos_offset(int verbose, int *bufferalloc, char **bufferptr, void *s
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_pos_offset *pos_offset = &(store->pos_offset);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_pos_offset(verbose, stderr, pos_offset, error);
@@ -4024,7 +4005,6 @@ int swpls_wr_imu_offset(int verbose, int *bufferalloc, char **bufferptr, void *s
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_imu_offset *imu_offset = &(store->imu_offset);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_imu_offset(verbose, stderr, imu_offset, error);
@@ -4100,7 +4080,6 @@ int swpls_wr_txer_offset(int verbose, int *bufferalloc, char **bufferptr, void *
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_txer_offset *txer_offset = &(store->txer_offset);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_txer_offset(verbose, stderr, txer_offset, error);
@@ -4184,7 +4163,6 @@ int swpls_wr_wl_offset(int verbose, int *bufferalloc, char **bufferptr, void *st
 	struct mbsys_swathplus_struct *store = (struct mbsys_swathplus_struct *)store_ptr;
 	swpls_wl_offset *wl_offset = &(store->wl_offset);
 
-	/* print debug statements */
 	if (verbose >= 5) {
 		fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
 		swpls_pr_wl_offset(verbose, stderr, wl_offset, error);

--- a/src/mbio/mbsys_templatesystem.c
+++ b/src/mbio/mbsys_templatesystem.c
@@ -311,7 +311,6 @@ int mbsys_templatesystem_extract(int verbose, void *mbio_ptr, void *store_ptr, i
 			ssalongtrack[i] = store->ssalongtrack[i];
 		}
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -368,7 +367,6 @@ int mbsys_templatesystem_extract(int verbose, void *mbio_ptr, void *store_ptr, i
 		*namp = 0;
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -404,7 +402,6 @@ int mbsys_templatesystem_extract(int verbose, void *mbio_ptr, void *store_ptr, i
 		else
 			comment[0] = '\0';
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -429,7 +426,6 @@ int mbsys_templatesystem_extract(int verbose, void *mbio_ptr, void *store_ptr, i
 			time_i[i] = store->time_i[i];
 		*time_d = store->time_d;
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_wassp.c
+++ b/src/mbio/mbsys_wassp.c
@@ -358,7 +358,6 @@ int mbsys_wassp_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 		/* extract sidescan */
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -415,7 +414,6 @@ int mbsys_wassp_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 		*namp = 0;
 		*nss = 0;
 
-		/* print debug statements */
 		if (verbose >= 5) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");
@@ -451,7 +449,6 @@ int mbsys_wassp_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 		else
 			comment[0] = '\0';
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");
@@ -476,7 +473,6 @@ int mbsys_wassp_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 			time_i[i] = store->time_i[i];
 		*time_d = store->time_d;
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Data extracted by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  Extracted values:\n");

--- a/src/mbio/mbsys_xse.c
+++ b/src/mbio/mbsys_xse.c
@@ -697,7 +697,6 @@ int mbsys_xse_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 		/* copy comment */
 		strcpy(comment, store->comment);
 
-		/* print debug statements */
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
 			fprintf(stderr, "dbg4  New ping values:\n");


### PR DESCRIPTION
Done by doing:

```shell
perl -i -ne '/print debug statements/ or print' *.c
```