### PR TITLE
travis/script.sh: Turn off -Wall for now.

### DIFF
--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-CFLAGS='-O2 -Wall' ./configure --enable-mbtrn --enable-test
+CFLAGS="-O2"
+# TODO(schwehr): Enable more checks.
+# CFLAGS="$CFLAGS -Wall"
+# CFLAGS="$CFLAGS -Wextra"
+CFLAGS="$CFLAGS" ./configure --enable-mbtrn --enable-test
 make -j 3
 make check


### PR DESCRIPTION
I suspect this is adding ~30% to total time for a CI run.  As the code
improves, the amount of additional time for checking should decrease
some.  I suspect that logging all the warnings is current a
substantial load on travis runs.