### PR TITLE
Stop including local ctime() getenv() prototypes.

### DIFF
--- a/src/mbnavadjust/mbnavadjust_callbacks.c
+++ b/src/mbnavadjust/mbnavadjust_callbacks.c
@@ -24,13 +24,12 @@
  */
 /*--------------------------------------------------------------------*/
 
-/* include files */
+#include <assert.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
-#include <math.h>
-#include <assert.h>
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
@@ -41,7 +40,6 @@
 #include <windows.h>
 #endif
 
-/* X11 includes */
 #include <X11/cursorfont.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
@@ -5262,8 +5260,6 @@ int do_info_add(char *info, int timetag) {
 	char tag[STRING_MAX];
 	time_t right_now;
 	char date[32], user[128], *user_ptr, host[128];
-	char *ctime();
-	char *getenv();
 
 	/* reposition to end of text */
 	pos = XmTextGetLastPosition(text_messages);

--- a/src/mbvelocitytool/mbvelocity_prog.c
+++ b/src/mbvelocitytool/mbvelocity_prog.c
@@ -22,20 +22,18 @@
  *
  * Author:      D. W. Caress
  * Date:        June 6, 1993
- *
- *
  */
 
 /*--------------------------------------------------------------------*/
 
 /* standard include files */
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <math.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
+#include <unistd.h>
 
 /* Need to include windows.h BEFORE the the Xm stuff otherwise VC14+ barf with conflicts */
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
@@ -192,12 +190,6 @@ int beam_last = 100;
 #define XG_DASHLINE 1
 int ncolors;
 int pixel_values[256];
-
-/* system function declarations */
-char *ctime();
-#ifndef WIN32
-char *getenv();
-#endif
 
 /*--------------------------------------------------------------------*/
 /* Initialize the 'mbio' struct                                       */

--- a/src/otps/mbotps.c
+++ b/src/otps/mbotps.c
@@ -81,14 +81,6 @@
 #define MBOTPS_MODE_NAV_WRT_STATION     0x03
 #define MBOTPS_DEFAULT_MODEL "atlas_v1"
 
-/* system function declarations */
-char *ctime();
-
-#ifndef WIN32
-char *getenv();
-
-#endif
-
 /*--------------------------------------------------------------------*/
 
 int main

--- a/src/utilities/mbbackangle.c
+++ b/src/utilities/mbbackangle.c
@@ -419,9 +419,6 @@ int main(int argc, char **argv) {
 	int ix, jy, kgrid, k, n;
 	int kgrid00, kgrid10, kgrid01, kgrid11;
 
-	char *ctime();
-	char *getenv();
-
 	/* get current default values */
 	status = mb_defaults(verbose, &format, &pings, &lonflip, bounds, btime_i, etime_i, &speedmin, &timegap);
 

--- a/src/utilities/mbcopy.c
+++ b/src/utilities/mbcopy.c
@@ -1863,9 +1863,6 @@ int main(int argc, char **argv) {
   int format;
   double seconds;
 
-  char *ctime();
-  char *getenv();
-
   /* get current default values */
   int status = mb_defaults(verbose, &format, &pings, &lonflip, bounds, btime_i, etime_i, &speedmin, &timegap);
   status &= mb_fbtversion(verbose, &fbtversion);

--- a/src/utilities/mbdefaults.c
+++ b/src/utilities/mbdefaults.c
@@ -90,7 +90,6 @@ int main(int argc, char **argv) {
 	double illuminate_elevation;
 	double illuminate_azimuth;
 	double slope_magnitude;
-	char *getenv();
 
 	/* MBIO control parameters */
 	int format;

--- a/src/utilities/mbfilter.c
+++ b/src/utilities/mbfilter.c
@@ -722,9 +722,6 @@ int main(int argc, char **argv) {
 	int ja, jb, jbeg, jend;
 	int ii, jj, n;
 
-	char *ctime();
-	char *getenv();
-
 	/* get current default values */
 	int status = mb_defaults(verbose, &format, &pings, &lonflip, bounds, btime_i, etime_i, &speedmin, &timegap);
 

--- a/src/utilities/mbgpstide.c
+++ b/src/utilities/mbgpstide.c
@@ -67,13 +67,6 @@
 #include "mbsys_simrad2.h"
 #include "mbsys_simrad3.h"
 
-
-/* system function declarations */
-char *ctime();
-#ifndef WIN32
-char *getenv();
-#endif
-
 /*--------------------------------------------------------------------*/
 
 int main(int argc, char **argv) {

--- a/src/utilities/mblevitus.c
+++ b/src/utilities/mblevitus.c
@@ -113,9 +113,6 @@ int main(int argc, char **argv) {
 	char *lonptr, *latptr;
 	int last_good;
 
-	char *ctime();
-	char *getenv();
-
 	/* set default output */
 	strcpy(ofile, "velocity");
 

--- a/src/utilities/mbmosaic.c
+++ b/src/utilities/mbmosaic.c
@@ -140,8 +140,6 @@ int write_ascii(int verbose, char *outfile, float *grid, int nx, int ny, double 
 	FILE *fp = NULL;
 	time_t right_now;
 	char date[32], user[MB_PATH_MAXLINE], *user_ptr, host[MB_PATH_MAXLINE];
-	char *ctime();
-	char *getenv();
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  Function <%s> called\n", __func__);

--- a/src/utilities/mbprocess.c
+++ b/src/utilities/mbprocess.c
@@ -728,9 +728,6 @@ int main(int argc, char **argv) {
 	int ix, jy, kgrid;
 	int kgrid00, kgrid10, kgrid01, kgrid11;
 
-	char *ctime();
-	char *getenv();
-
 	/* get current default values */
 	int status = mb_defaults(verbose, &mbp_format, &pings, &lonflip, bounds, btime_i, etime_i, &speedmin, &timegap);
 	status &= mb_uselockfiles(verbose, &uselockfiles);

--- a/src/utilities/mbsslayout.c
+++ b/src/utilities/mbsslayout.c
@@ -549,8 +549,6 @@ int main(int argc, char **argv) {
 
 	time_t right_now;
 	char date[32], user[MB_PATH_MAXLINE], *user_ptr, host[MB_PATH_MAXLINE];
-	char *ctime();
-	char *getenv();
 
 	mb_path command;
 	int interp_status = MB_SUCCESS;


### PR DESCRIPTION
- getenv should always come from stdlib.h
- ctime should always come from time.h

Using local prototypes of standard functions is risky.

See also:
  man 3 getenv
  man 3 ctime
  http://www.cplusplus.com/reference/cstdlib/getenv/
  http://www.cplusplus.com/reference/ctime/