### PR TITLE
mbdumpesf.c: Cleanup

### DIFF
--- a/src/utilities/mbdumpesf.c
+++ b/src/utilities/mbdumpesf.c
@@ -21,6 +21,7 @@
  */
 
 #include <math.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>
@@ -51,25 +52,7 @@ static const char usage_message[] =
 /*--------------------------------------------------------------------*/
 
 int main(int argc, char **argv) {
-	int option_index;
-	int errflg = 0;
-	int c;
-	int help = 0;
-	int flag = 0;
-
-	/* MBIO status variables */
 	int verbose = 0;
-	int error = MB_ERROR_NO_ERROR;
-
-	/* command line option definitions */
-	/* mbdumpesf --input=esffile
-	 *		[--output=esffile --ignore-unflag --ignore-flag
-	 *		--ignore-filter --ignore-zero
-	 *		--verbose --help] */
-	static struct option options[] = {
-	    {"verbose", no_argument, NULL, 0},       {"help", no_argument, NULL, 0},          {"input", required_argument, NULL, 0},
-	    {"output", required_argument, NULL, 0},  {"ignore-unflag", no_argument, NULL, 0}, {"ignore-flag", no_argument, NULL, 0},
-	    {"ignore-filter", no_argument, NULL, 0}, {"ignore-zero", no_argument, NULL, 0},   {NULL, 0, NULL, 0}};
 
 	/* MBIO read and write control parameters */
 	char iesffile[MB_PATH_MAXLINE];
@@ -77,26 +60,114 @@ int main(int argc, char **argv) {
 	int omode = OUTPUT_TEXT;
 	FILE *iesffp = NULL;
 	FILE *oesffp = NULL;
-	struct stat file_status;
-	int fstat;
-	int byteswapped;
-	int nedit;
+
+	bool ignore_unflag = false;
+	bool ignore_flag = false;
+	bool ignore_filter = false;
+	bool ignore_zero = false;
+
+	/* process argument list */
+	{
+		const struct option options[] = {
+			{"verbose", no_argument, NULL, 0},
+			{"help", no_argument, NULL, 0},
+			{"input", required_argument, NULL, 0},
+			{"output", required_argument, NULL, 0},
+			{"ignore-unflag", no_argument, NULL, 0},
+			{"ignore-flag", no_argument, NULL, 0},
+			{"ignore-filter", no_argument, NULL, 0},
+			{"ignore-zero", no_argument, NULL, 0},
+			{NULL, 0, NULL, 0}};
+		int option_index;
+		bool errflg = false;
+		int c;
+		bool help = false;
+		while ((c = getopt_long(argc, argv, "VvHhI:i:", options, &option_index)) != -1)
+		{
+			switch (c) {
+			/* long options all return c=0 */
+			case 0:
+				if (strcmp("verbose", options[option_index].name) == 0) {
+					verbose++;
+				}
+				else if (strcmp("help", options[option_index].name) == 0) {
+					help = true;
+				}
+				else if (strcmp("input", options[option_index].name) == 0) {
+					strcpy(iesffile, optarg);
+				}
+				else if (strcmp("output", options[option_index].name) == 0) {
+					strcpy(oesffile, optarg);
+					omode = OUTPUT_ESF;
+				}
+				else if (strcmp("ignore-unflag", options[option_index].name) == 0) {
+					ignore_unflag = true;
+				}
+				else if (strcmp("ignore-flag", options[option_index].name) == 0) {
+					ignore_flag = true;
+				}
+				else if (strcmp("ignore-filter", options[option_index].name) == 0) {
+					ignore_filter = true;
+				}
+				else if (strcmp("ignore-zero", options[option_index].name) == 0) {
+					ignore_zero = true;
+				}
+
+				break;
+			case 'H':
+			case 'h':
+				help = true;
+				break;
+			case 'V':
+			case 'v':
+				verbose++;
+				break;
+			case 'I':
+			case 'i':
+				sscanf(optarg, "%s", iesffile);
+				break;
+			case '?':
+				errflg = true;
+			}
+		}
+
+		if (errflg) {
+			fprintf(stderr, "usage: %s\n", usage_message);
+			fprintf(stderr, "\nProgram <%s> Terminated\n", program_name);
+			exit(MB_ERROR_BAD_USAGE);
+		}
+
+		if (help) {
+			fprintf(stderr, "\n%s\n", help_message);
+			fprintf(stderr, "\nusage: %s\n", usage_message);
+			exit(MB_ERROR_NO_ERROR);
+		}
+
+		if (verbose == 1 || help) {
+			fprintf(stderr, "\nProgram %s\n", program_name);
+			fprintf(stderr, "MB-system Version %s\n", MB_VERSION);
+		}
+
+		if (verbose >= 2) {
+			fprintf(stderr, "\ndbg2  Program <%s>\n", program_name);
+			fprintf(stderr, "dbg2  MB-system Version %s\n", MB_VERSION);
+			fprintf(stderr, "dbg2  Control Parameters:\n");
+			fprintf(stderr, "dbg2       verbose:          %d\n", verbose);
+			fprintf(stderr, "dbg2       help:             %d\n", help);
+			fprintf(stderr, "dbg2       input esf file:   %s\n", iesffile);
+			fprintf(stderr, "dbg2       omode:            %d\n", omode);
+			if (omode == OUTPUT_ESF)
+				fprintf(stderr, "dbg2       output esf file:  %s\n", oesffile);
+			fprintf(stderr, "dbg2       ignore_unflag:    %d\n", ignore_unflag);
+			fprintf(stderr, "dbg2       ignore_flag:      %d\n", ignore_flag);
+			fprintf(stderr, "dbg2       ignore_filter:    %d\n", ignore_filter);
+			fprintf(stderr, "dbg2       ignore_zero:      %d\n", ignore_zero);
+		}
+	}
+
 	double time_d;
-	int time_i[7];
 	int beam;
 	int action;
-	int esf_mode;
-
-	/* time, user, host variables */
-	time_t right_now;
-	char date[32], user[MBP_FILENAMESIZE], *user_ptr, host[MBP_FILENAMESIZE];
-	mb_path esf_header;
-
-	int ignore;
-	int ignore_unflag = MB_NO;
-	int ignore_flag = MB_NO;
-	int ignore_filter = MB_NO;
-	int ignore_zero = MB_NO;
 
 	int beam_flag = 0;
 	int beam_unflag = 0;
@@ -107,157 +178,55 @@ int main(int argc, char **argv) {
 	int beam_zero_ignore = 0;
 	int beam_filter_ignore = 0;
 
-	/* get current default values */
-	byteswapped = mb_swap_check();
+	const int byteswapped = mb_swap_check();
 
-	int status = MB_SUCCESS;
-
-	/* process argument list */
-	while ((c = getopt_long(argc, argv, "VvHhI:i:", options, &option_index)) != -1)
-		switch (c) {
-		/* long options all return c=0 */
-		case 0:
-			/* verbose */
-			if (strcmp("verbose", options[option_index].name) == 0) {
-				verbose++;
-			}
-
-			/* help */
-			else if (strcmp("help", options[option_index].name) == 0) {
-				help++;
-			}
-
-			/*-------------------------------------------------------
-			 * Define input and optional output esf file */
-
-			/* input */
-			else if (strcmp("input", options[option_index].name) == 0) {
-				strcpy(iesffile, optarg);
-			}
-
-			/* output */
-			else if (strcmp("output", options[option_index].name) == 0) {
-				strcpy(oesffile, optarg);
-				omode = OUTPUT_ESF;
-			}
-
-			/*-------------------------------------------------------
-			 * Set special modes to ignore types of edit events,
-			 * thereby removing them from the output stream */
-
-			/* ignore-unflag */
-			else if (strcmp("ignore-unflag", options[option_index].name) == 0) {
-				ignore_unflag = MB_YES;
-			}
-
-			/* ignore-flag */
-			else if (strcmp("ignore-flag", options[option_index].name) == 0) {
-				ignore_flag = MB_YES;
-			}
-
-			/* ignore-unflag */
-			else if (strcmp("ignore-filter", options[option_index].name) == 0) {
-				ignore_filter = MB_YES;
-			}
-
-			/* ignore-unflag */
-			else if (strcmp("ignore-zero", options[option_index].name) == 0) {
-				ignore_zero = MB_YES;
-			}
-
-			break;
-		case 'H':
-		case 'h':
-			help++;
-			break;
-		case 'V':
-		case 'v':
-			verbose++;
-			break;
-		case 'I':
-		case 'i':
-			sscanf(optarg, "%s", iesffile);
-			flag++;
-			break;
-		case '?':
-			errflg++;
-		}
-
-	/* if error flagged then print it and exit */
-	if (errflg) {
-		fprintf(stderr, "usage: %s\n", usage_message);
-		fprintf(stderr, "\nProgram <%s> Terminated\n", program_name);
-		error = MB_ERROR_BAD_USAGE;
-		exit(error);
-	}
-
-	/* if help desired then print it and exit */
-	if (help) {
-		fprintf(stderr, "\n%s\n", help_message);
-		fprintf(stderr, "\nusage: %s\n", usage_message);
-		exit(error);
-	}
-
-	if (verbose == 1 || help) {
-		fprintf(stderr, "\nProgram %s\n", program_name);
-		fprintf(stderr, "MB-system Version %s\n", MB_VERSION);
-	}
-
-	if (verbose >= 2) {
-		fprintf(stderr, "\ndbg2  Program <%s>\n", program_name);
-		fprintf(stderr, "dbg2  MB-system Version %s\n", MB_VERSION);
-		fprintf(stderr, "dbg2  Control Parameters:\n");
-		fprintf(stderr, "dbg2       verbose:          %d\n", verbose);
-		fprintf(stderr, "dbg2       help:             %d\n", help);
-		fprintf(stderr, "dbg2       input esf file:   %s\n", iesffile);
-		fprintf(stderr, "dbg2       omode:            %d\n", omode);
-		if (omode == OUTPUT_ESF)
-			fprintf(stderr, "dbg2       output esf file:  %s\n", oesffile);
-		fprintf(stderr, "dbg2       ignore_unflag:    %d\n", ignore_unflag);
-		fprintf(stderr, "dbg2       ignore_flag:      %d\n", ignore_flag);
-		fprintf(stderr, "dbg2       ignore_filter:    %d\n", ignore_filter);
-		fprintf(stderr, "dbg2       ignore_zero:      %d\n", ignore_zero);
-	}
+	int error = MB_ERROR_NO_ERROR;
 
 	/* check that esf file exists */
-	fstat = stat(iesffile, &file_status);
+	struct stat file_status;
+	const int fstat = stat(iesffile, &file_status);
 	if (fstat == 0 && (file_status.st_mode & S_IFMT) != S_IFDIR) {
 		/* open the input esf file */
 		if ((iesffp = fopen(iesffile, "r")) == NULL) {
-			error = MB_ERROR_OPEN_FAIL;
 			fprintf(stderr, "\nUnable to edit save file <%s> for reading\n", iesffile);
 			fprintf(stderr, "\nProgram <%s> Terminated\n", program_name);
-			exit(error);
+			exit(MB_ERROR_OPEN_FAIL);
 		}
 
 		/* open the output esf file */
 		if (omode == OUTPUT_ESF && (oesffp = fopen(oesffile, "w")) == NULL) {
-			error = MB_ERROR_OPEN_FAIL;
 			fprintf(stderr, "\nUnable to edit save file <%s> for reading\n", iesffile);
 			fprintf(stderr, "\nProgram <%s> Terminated\n", program_name);
-			exit(error);
+			exit(MB_ERROR_OPEN_FAIL);
 		}
 
 		/* read file header to discern the format */
+		int status = MB_SUCCESS;
+		int nedit = 0;
+		char esf_header[MB_PATH_MAXLINE * 3];  /* Need more space than an mb_path */
 		if (fread(esf_header, MB_PATH_MAXLINE, 1, iesffp) == 1 && strncmp(esf_header, "ESFVERSION", 10) == 0) {
 			nedit = (file_status.st_size - MB_PATH_MAXLINE) / (sizeof(double) + 2 * sizeof(int));
 
 			if (omode == OUTPUT_ESF && oesffp != NULL) {
 				memset(esf_header, 0, MB_PATH_MAXLINE);
-				esf_mode = MB_ESF_MODE_EXPLICIT;
-				right_now = time((time_t *)0);
+				const int esf_mode = MB_ESF_MODE_EXPLICIT;
+				const time_t right_now = time((time_t *)0);
+				char date[32];
 				strcpy(date, ctime(&right_now));
 				date[strlen(date) - 1] = '\0';
-				if ((user_ptr = getenv("USER")) == NULL)
+				const char *user_ptr = getenv("USER");
+				if (user_ptr == NULL)
 					user_ptr = getenv("LOGNAME");
+				char user[MBP_FILENAMESIZE];
 				if (user_ptr != NULL)
 					strcpy(user, user_ptr);
 				else
 					strcpy(user, "unknown");
+				char host[MBP_FILENAMESIZE];
 				gethostname(host, MBP_FILENAMESIZE);
 				sprintf(esf_header,
-			        "ESFVERSION03\nESF Mode: %d\nMB-System Version %s\nProgram: %s\nUser: %s\nCPU: %s\nDate: %s\n",
-			        esf_mode, MB_VERSION, program_name, user, host, date);
+				        "ESFVERSION03\nESF Mode: %d\nMB-System Version %s\nProgram: %s\nUser: %s\nCPU: %s\nDate: %s\n",
+				        esf_mode, MB_VERSION, program_name, user, host, date);
 				if (fwrite(esf_header, MB_PATH_MAXLINE, 1, oesffp) != 1) {
 					status = MB_FAILURE;
 					error = MB_ERROR_WRITE_FAIL;
@@ -271,21 +240,21 @@ int main(int argc, char **argv) {
 
 		/* loop over reading edit events and printing them out */
 		for (int i = 0; i < nedit && error == MB_ERROR_NO_ERROR; i++) {
-			ignore = MB_NO;
+			bool ignore = false;
 			if (fread(&(time_d), sizeof(double), 1, iesffp) != 1 || fread(&(beam), sizeof(int), 1, iesffp) != 1 ||
 			    fread(&(action), sizeof(int), 1, iesffp) != 1) {
-				ignore = MB_YES;
+				ignore = true;
 				status = MB_FAILURE;
 				error = MB_ERROR_EOF;
 			}
 			else if (strncmp(((char *)&time_d), "ESFVERSI", 8) == 0) {
-				ignore = MB_YES;
+				ignore = true;
 				if (fread(esf_header, MB_PATH_MAXLINE-16, 1, iesffp) != 1) {
 					status = MB_FAILURE;
 					error = MB_ERROR_EOF;
 				}
 			}
-			else if (byteswapped == MB_YES) {
+			else if (byteswapped) {
 				mb_swap_double(&(time_d));
 				beam = mb_swap_int(beam);
 				action = mb_swap_int(action);
@@ -294,29 +263,29 @@ int main(int argc, char **argv) {
 			if (ignore == MB_NO) {
 				if (action == MBP_EDIT_FLAG) {
 					beam_flag++;
-					if (ignore_flag == MB_YES) {
-						ignore = MB_YES;
+					if (ignore_flag) {
+						ignore = true;
 						beam_flag_ignore++;
 					}
 				}
 				else if (action == MBP_EDIT_UNFLAG) {
 					beam_unflag++;
-					if (ignore_unflag == MB_YES) {
-						ignore = MB_YES;
+					if (ignore_unflag) {
+						ignore = true;
 						beam_unflag_ignore++;
 					}
 				}
 				else if (action == MBP_EDIT_ZERO) {
 					beam_zero++;
-					if (ignore_zero == MB_YES) {
-						ignore = MB_YES;
+					if (ignore_zero) {
+						ignore = true;
 						beam_zero_ignore++;
 					}
 				}
 				else if (action == MBP_EDIT_FILTER) {
 					beam_filter++;
-					if (ignore_filter == MB_YES) {
-						ignore = MB_YES;
+					if (ignore_filter) {
+						ignore = true;
 						beam_filter_ignore++;
 					}
 				}
@@ -325,12 +294,13 @@ int main(int argc, char **argv) {
 			/* write out the edit if not ignored */
 			if (ignore == MB_NO) {
 				if (omode == OUTPUT_TEXT) {
+					int time_i[7];
 					mb_get_date(verbose, time_d, time_i);
 					fprintf(stdout, "EDITS READ: i:%d time: %f %4.4d/%2.2d/%2.2d %2.2d:%2.2d:%2.2d.%6.6d beam:%d action:%d\n", i,
 					        time_d, time_i[0], time_i[1], time_i[2], time_i[3], time_i[4], time_i[5], time_i[6], beam, action);
 				}
 				else {
-					if (byteswapped == MB_YES) {
+					if (byteswapped) {
 						mb_swap_double(&time_d);
 						beam = mb_swap_int(beam);
 						action = mb_swap_int(action);
@@ -364,7 +334,7 @@ int main(int argc, char **argv) {
 		fprintf(stderr, "\t%d beams unflagged\n", beam_unflag);
 		fprintf(stderr, "\t%d beams zeroed\n", beam_zero);
 		fprintf(stderr, "\t%d beams flagged by filter\n", beam_filter);
-		if (ignore_flag == MB_YES || ignore_unflag == MB_YES || ignore_zero == MB_YES || ignore_filter == MB_YES) {
+		if (ignore_flag || ignore_unflag || ignore_zero || ignore_filter) {
 			fprintf(stderr, "\nBeam flag ignore totals:\n");
 			fprintf(stderr, "\t%d beams flagged manually (ignored in output)\n", beam_flag_ignore);
 			fprintf(stderr, "\t%d beams unflagged (ignored in output)\n", beam_unflag_ignore);


### PR DESCRIPTION
- Use stdbool
- Localize variables
- Add const
- Remove redundant comments
- Call exit with code directly
- Increase the size of `esf_header` to prevent a buffer overflow