### PR TITLE
mbsegyinfo.c: Cleanup

### DIFF
--- a/src/utilities/mbsegyinfo.c
+++ b/src/utilities/mbsegyinfo.c
@@ -16,10 +16,10 @@
  *
  * Author:	D. W. Caress
  * Date:	June 2, 2004
- *
  */
 
 #include <math.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -31,16 +31,6 @@
 #include "mb_segy.h"
 #include "mb_status.h"
 
-#define MAX_OPTIONS 25
-#define MBLIST_CHECK_ON 0
-#define MBLIST_CHECK_ON_NULL 1
-#define MBLIST_CHECK_OFF_RAW 2
-#define MBLIST_CHECK_OFF_NAN 3
-#define MBLIST_CHECK_OFF_FLAGNAN 4
-#define MBLIST_SET_OFF 0
-#define MBLIST_SET_ON 1
-#define MBLIST_SET_ALL 2
-
 static const char program_name[] = "MBsegyinfo";
 static const char help_message[] =
     "MBsegyinfo lists table data from a segy data file.";
@@ -50,18 +40,8 @@ static const char usage_message[] =
 /*--------------------------------------------------------------------*/
 
 int main(int argc, char **argv) {
-	int errflg = 0;
-	int c;
-	int help = 0;
-	int flag = 0;
-
-	/* MBIO status variables */
 	int verbose = 0;
-	int error = MB_ERROR_NO_ERROR;
-	char *message;
-
-	/* MBIO read control parameters */
-	char read_file[MB_PATH_MAXLINE];
+	int format;
 	int pings;
 	int lonflip;
 	double bounds[4];
@@ -70,179 +50,115 @@ int main(int argc, char **argv) {
 	double speedmin;
 	double timegap;
 
-	/* segy data */
-	void *mbsegyioptr;
-	struct mb_segyasciiheader_struct asciiheader;
-	struct mb_segyfileheader_struct fileheader;
-	struct mb_segytraceheader_struct traceheader;
-	float *trace;
-
-	/* output format list controls */
-	int nread = 0;
-	int first = MB_YES;
-
-	/* limit variables */
-	int shotmin = 0;
-	int shotmax = 0;
-	int shottracemin = 0;
-	int shottracemax = 0;
-	int rpmin = 0;
-	int rpmax = 0;
-	int rptracemin = 0;
-	int rptracemax = 0;
-	double rangemin = 0.0;
-	double rangemax = 0.0;
-	double receiverelevationmin = 0.0;
-	double receiverelevationmax = 0.0;
-	double sourceelevationmin = 0.0;
-	double sourceelevationmax = 0.0;
-	double sourcedepthmin = 0.0;
-	double sourcedepthmax = 0.0;
-	double sourcewaterdepthmin = 0.0;
-	double sourcewaterdepthmax = 0.0;
-	double receiverwaterdepthmin = 0.0;
-	double receiverwaterdepthmax = 0.0;
-	double delaymin = 0.0;
-	double delaymax = 0.0;
-	double lonmin = 0.0;
-	double lonmax = 0.0;
-	double latmin = 0.0;
-	double latmax = 0.0;
-	double lonbeg = 0.0;
-	double latbeg = 0.0;
-	double lonend = 0.0;
-	double latend = 0.0;
-	double timbeg = 0.0;
-	double timend = 0.0;
-	int timbeg_i[7];
-	int timend_i[7];
-	int timbeg_j[5];
-	int timend_j[5];
-
-	int time_i[7], time_j[5];
-	double time_d;
-	double navlon, navlat;
-	double factor, sonardepth, waterdepth;
-	double tracelength, delay;
-	double range;
-	double receiverelevation;
-	double sourceelevation;
-	double sourcedepth;
-	double sourcewaterdepth;
-	double receiverwaterdepth;
-
-	/* output stream for basic stuff (stdout if verbose <= 1,
-	    output if verbose > 1) */
-	FILE *stream = NULL;
-	FILE *output = NULL;
-	int output_usefile = MB_NO;
-	char output_file[MB_PATH_MAXLINE];
-
-	int format;
-
 	/* get current default values */
 	int status = mb_defaults(verbose, &format, &pings, &lonflip, bounds, btime_i, etime_i, &speedmin, &timegap);
 
-	/* set read_file to null */
-	read_file[0] = '\0';
+	char read_file[MB_PATH_MAXLINE] = "";
+	bool output_usefile = false;
 
 	/* process argument list */
-	while ((c = getopt(argc, argv, "I:i:L:l:OoVvWwHh")) != -1)
-		switch (c) {
-		case 'H':
-		case 'h':
-			help++;
-			break;
-		case 'V':
-		case 'v':
-			verbose++;
-			break;
-		case 'I':
-		case 'i':
-			sscanf(optarg, "%s", read_file);
-			flag++;
-			break;
-		case 'L':
-		case 'l':
-			sscanf(optarg, "%d", &lonflip);
-			flag++;
-			break;
-		case 'O':
-		case 'o':
-			output_usefile = MB_YES;
-			flag++;
-			break;
-		case '?':
-			errflg++;
+	{
+		bool errflg = false;
+		bool help = false;
+		int c;
+		while ((c = getopt(argc, argv, "I:i:L:l:OoVvWwHh")) != -1)
+		{
+			switch (c) {
+			case 'H':
+			case 'h':
+				help = true;
+				break;
+			case 'V':
+			case 'v':
+				verbose++;
+				break;
+			case 'I':
+			case 'i':
+				sscanf(optarg, "%s", read_file);
+				break;
+			case 'L':
+			case 'l':
+				sscanf(optarg, "%d", &lonflip);
+				break;
+			case 'O':
+			case 'o':
+				output_usefile = true;
+				break;
+			case '?':
+				errflg = true;
+			}
 		}
 
-	/* set output stream */
-	if (verbose <= 1)
-		stream = stdout;
-	else
-		stream = stderr;
+		if (errflg) {
+			fprintf(stderr, "usage: %s\n", usage_message);
+			fprintf(stderr, "\nProgram <%s> Terminated\n", program_name);
+			exit(MB_ERROR_BAD_USAGE);
+		}
 
-	/* if error flagged then print it and exit */
-	if (errflg) {
-		fprintf(stderr, "usage: %s\n", usage_message);
-		fprintf(stderr, "\nProgram <%s> Terminated\n", program_name);
-		error = MB_ERROR_BAD_USAGE;
-		exit(error);
+		if (verbose == 1 || help) {
+			fprintf(stderr, "\nProgram %s\n", program_name);
+			fprintf(stderr, "MB-system Version %s\n", MB_VERSION);
+		}
+
+		if (verbose >= 2) {
+			fprintf(stderr, "\ndbg2  Program <%s>\n", program_name);
+			fprintf(stderr, "dbg2  MB-system Version %s\n", MB_VERSION);
+			fprintf(stderr, "dbg2  Control Parameters:\n");
+			fprintf(stderr, "dbg2       verbose:        %d\n", verbose);
+			fprintf(stderr, "dbg2       help:           %d\n", help);
+			fprintf(stderr, "dbg2       lonflip:        %d\n", lonflip);
+			fprintf(stderr, "dbg2       bounds[0]:      %f\n", bounds[0]);
+			fprintf(stderr, "dbg2       bounds[1]:      %f\n", bounds[1]);
+			fprintf(stderr, "dbg2       bounds[2]:      %f\n", bounds[2]);
+			fprintf(stderr, "dbg2       bounds[3]:      %f\n", bounds[3]);
+			fprintf(stderr, "dbg2       btime_i[0]:     %d\n", btime_i[0]);
+			fprintf(stderr, "dbg2       btime_i[1]:     %d\n", btime_i[1]);
+			fprintf(stderr, "dbg2       btime_i[2]:     %d\n", btime_i[2]);
+			fprintf(stderr, "dbg2       btime_i[3]:     %d\n", btime_i[3]);
+			fprintf(stderr, "dbg2       btime_i[4]:     %d\n", btime_i[4]);
+			fprintf(stderr, "dbg2       btime_i[5]:     %d\n", btime_i[5]);
+			fprintf(stderr, "dbg2       btime_i[6]:     %d\n", btime_i[6]);
+			fprintf(stderr, "dbg2       etime_i[0]:     %d\n", etime_i[0]);
+			fprintf(stderr, "dbg2       etime_i[1]:     %d\n", etime_i[1]);
+			fprintf(stderr, "dbg2       etime_i[2]:     %d\n", etime_i[2]);
+			fprintf(stderr, "dbg2       etime_i[3]:     %d\n", etime_i[3]);
+			fprintf(stderr, "dbg2       etime_i[4]:     %d\n", etime_i[4]);
+			fprintf(stderr, "dbg2       etime_i[5]:     %d\n", etime_i[5]);
+			fprintf(stderr, "dbg2       etime_i[6]:     %d\n", etime_i[6]);
+			fprintf(stderr, "dbg2       speedmin:       %f\n", speedmin);
+			fprintf(stderr, "dbg2       timegap:        %f\n", timegap);
+			fprintf(stderr, "dbg2       read_file:      %s\n", read_file);
+		}
+
+		if (help) {
+			fprintf(stderr, "\n%s\n", help_message);
+			fprintf(stderr, "\nusage: %s\n", usage_message);
+			exit(MB_ERROR_NO_ERROR);
+		}
 	}
 
-	if (verbose == 1 || help) {
-		fprintf(stderr, "\nProgram %s\n", program_name);
-		fprintf(stderr, "MB-system Version %s\n", MB_VERSION);
-	}
-
-	if (verbose >= 2) {
-		fprintf(stderr, "\ndbg2  Program <%s>\n", program_name);
-		fprintf(stderr, "dbg2  MB-system Version %s\n", MB_VERSION);
-		fprintf(stderr, "dbg2  Control Parameters:\n");
-		fprintf(stderr, "dbg2       verbose:        %d\n", verbose);
-		fprintf(stderr, "dbg2       help:           %d\n", help);
-		fprintf(stderr, "dbg2       lonflip:        %d\n", lonflip);
-		fprintf(stderr, "dbg2       bounds[0]:      %f\n", bounds[0]);
-		fprintf(stderr, "dbg2       bounds[1]:      %f\n", bounds[1]);
-		fprintf(stderr, "dbg2       bounds[2]:      %f\n", bounds[2]);
-		fprintf(stderr, "dbg2       bounds[3]:      %f\n", bounds[3]);
-		fprintf(stderr, "dbg2       btime_i[0]:     %d\n", btime_i[0]);
-		fprintf(stderr, "dbg2       btime_i[1]:     %d\n", btime_i[1]);
-		fprintf(stderr, "dbg2       btime_i[2]:     %d\n", btime_i[2]);
-		fprintf(stderr, "dbg2       btime_i[3]:     %d\n", btime_i[3]);
-		fprintf(stderr, "dbg2       btime_i[4]:     %d\n", btime_i[4]);
-		fprintf(stderr, "dbg2       btime_i[5]:     %d\n", btime_i[5]);
-		fprintf(stderr, "dbg2       btime_i[6]:     %d\n", btime_i[6]);
-		fprintf(stderr, "dbg2       etime_i[0]:     %d\n", etime_i[0]);
-		fprintf(stderr, "dbg2       etime_i[1]:     %d\n", etime_i[1]);
-		fprintf(stderr, "dbg2       etime_i[2]:     %d\n", etime_i[2]);
-		fprintf(stderr, "dbg2       etime_i[3]:     %d\n", etime_i[3]);
-		fprintf(stderr, "dbg2       etime_i[4]:     %d\n", etime_i[4]);
-		fprintf(stderr, "dbg2       etime_i[5]:     %d\n", etime_i[5]);
-		fprintf(stderr, "dbg2       etime_i[6]:     %d\n", etime_i[6]);
-		fprintf(stderr, "dbg2       speedmin:       %f\n", speedmin);
-		fprintf(stderr, "dbg2       timegap:        %f\n", timegap);
-		fprintf(stderr, "dbg2       read_file:      %s\n", read_file);
-	}
-
-	/* if help desired then print it and exit */
-	if (help) {
-		fprintf(stderr, "\n%s\n", help_message);
-		fprintf(stderr, "\nusage: %s\n", usage_message);
-		exit(error);
-	}
+	int error = MB_ERROR_NO_ERROR;
 
 	/* initialize reading the segy file */
-	if (mb_segy_read_init(verbose, read_file, &mbsegyioptr, &asciiheader, &fileheader, &error) != MB_SUCCESS) {
-		mb_error(verbose, error, &message);
-		fprintf(stderr, "\nMBIO Error returned from function <mb_segy_read_init>:\n%s\n", message);
-		fprintf(stderr, "\nSEGY File <%s> not initialized for reading\n", read_file);
-		fprintf(stderr, "\nProgram <%s> Terminated\n", program_name);
-		exit(error);
+	void *mbsegyioptr;
+	struct mb_segyfileheader_struct fileheader;
+	{
+		struct mb_segyasciiheader_struct asciiheader;
+		if (mb_segy_read_init(verbose, read_file, &mbsegyioptr, &asciiheader, &fileheader, &error) != MB_SUCCESS) {
+			char *message;
+			mb_error(verbose, error, &message);
+			fprintf(stderr, "\nMBIO Error returned from function <mb_segy_read_init>:\n%s\n", message);
+			fprintf(stderr, "\nSEGY File <%s> not initialized for reading\n", read_file);
+			fprintf(stderr, "\nProgram <%s> Terminated\n", program_name);
+			exit(error);
+		}
 	}
 
-	/* Open output file if requested */
-	if (output_usefile == MB_YES) {
+	FILE *stream = verbose <= 1 ? stdout : stderr;
+
+	FILE *output = NULL;
+	if (output_usefile) {
+		char output_file[MB_PATH_MAXLINE];
 		strcpy(output_file, read_file);
 		strcat(output_file, ".sinf");
 		if ((output = fopen(output_file, "w")) == NULL)
@@ -252,14 +168,56 @@ int main(int argc, char **argv) {
 		output = stream;
 	}
 
-	/* read and print data */
-	nread = 0;
-	first = MB_YES;
+	double delaymin = 0.0;
+	double delaymax = 0.0;
+
+	double lonmin = 0.0;
+	double lonmax = 0.0;
+	double latmin = 0.0;
+	double latmax = 0.0;
+	double lonbeg = 0.0;
+	double latbeg = 0.0;
+	double lonend = 0.0;
+	double latend = 0.0;
+
+	double rangemin = 0.0;
+	double rangemax = 0.0;
+
+	double receiverelevationmin = 0.0;
+	double receiverelevationmax = 0.0;
+	double receiverwaterdepthmin = 0.0;
+	double receiverwaterdepthmax = 0.0;
+
+	int rpmin = 0;
+	int rpmax = 0;
+	int rptracemin = 0;
+	int rptracemax = 0;
+
+	int shotmin = 0;
+	int shotmax = 0;
+	int shottracemin = 0;
+	int shottracemax = 0;
+
+	double sourcedepthmin = 0.0;
+	double sourcedepthmax = 0.0;
+	double sourceelevationmin = 0.0;
+	double sourceelevationmax = 0.0;
+	double sourcewaterdepthmin = 0.0;
+	double sourcewaterdepthmax = 0.0;
+
+	int timbeg_i[7];
+	int timend_i[7];
+	int timbeg_j[5];
+	int timend_j[5];
+
+	int nread = 0;
+	bool first = true;
 	while (error <= MB_ERROR_NO_ERROR) {
-		/* reset error */
 		error = MB_ERROR_NO_ERROR;
 
 		/* read a trace */
+		struct mb_segytraceheader_struct traceheader;
+		float *trace;
 		status = mb_segy_read_trace(verbose, mbsegyioptr, &traceheader, &trace, &error);
 		/*fprintf(stderr,"read_file:%s record:%d shot:%d  %4.4d/%3.3d %2.2d:%2.2d:%2.2d.%3.3d samples:%d interval:%d\n",
 		    read_file,nread,traceheader.shot_num,
@@ -272,39 +230,45 @@ int main(int argc, char **argv) {
 			nread++;
 
 			/* get needed values */
+			int time_j[5];
 			time_j[0] = traceheader.year;
 			time_j[1] = traceheader.day_of_yr;
 			time_j[2] = traceheader.min + 60 * traceheader.hour;
 			time_j[3] = traceheader.sec;
 			time_j[4] = 1000 * traceheader.mils;
+			int time_i[7];
 			mb_get_itime(verbose, time_j, time_i);
+			double time_d;
 			mb_get_time(verbose, time_i, &time_d);
-			if (traceheader.elev_scalar < 0)
-				factor = 1.0 / ((float)(-traceheader.elev_scalar));
-			else
-				factor = (float)traceheader.elev_scalar;
-			if (traceheader.grp_elev != 0)
-				sonardepth = -factor * traceheader.grp_elev;
-			else if (traceheader.src_elev != 0)
-				sonardepth = -factor * traceheader.src_elev;
-			else if (traceheader.src_depth != 0)
-				sonardepth = factor * traceheader.src_depth;
-			else
-				sonardepth = 0.0;
-			if (traceheader.src_wbd != 0)
-				waterdepth = -traceheader.grp_elev;
-			else if (traceheader.grp_wbd != 0)
-				waterdepth = -traceheader.src_elev;
-			else
-				waterdepth = 0;
+			double factor;
+			/* if (traceheader.elev_scalar < 0) */
+			/* 	factor = 1.0 / ((float)(-traceheader.elev_scalar)); */
+			/* else */
+			/* 	factor = (float)traceheader.elev_scalar; */
+			/* if (traceheader.grp_elev != 0) */
+			/* 	sonardepth = -factor * traceheader.grp_elev; */
+			/* else if (traceheader.src_elev != 0) */
+			/* 	sonardepth = -factor * traceheader.src_elev; */
+			/* else if (traceheader.src_depth != 0) */
+			/* 	sonardepth = factor * traceheader.src_depth; */
+			/* else */
+			/* 	sonardepth = 0.0; */
+			/* if (traceheader.src_wbd != 0) */
+			/* 	waterdepth = -traceheader.grp_elev; */
+			/* else if (traceheader.grp_wbd != 0) */
+			/* 	waterdepth = -traceheader.src_elev; */
+			/* else */
+			/* 	waterdepth = 0; */
 			if (traceheader.coord_scalar < 0)
 				factor = 1.0 / ((float)(-traceheader.coord_scalar)) / 3600.0;
 			else
 				factor = (float)traceheader.coord_scalar / 3600.0;
+			double navlon;
 			if (traceheader.src_long != 0)
 				navlon = factor * ((float)traceheader.src_long);
 			else
 				navlon = factor * ((float)traceheader.grp_long);
+			double navlat;
 			if (traceheader.src_lat != 0)
 				navlat = factor * ((float)traceheader.src_lat);
 			else
@@ -331,16 +295,17 @@ int main(int argc, char **argv) {
 				factor = 1.0 / ((float)(-traceheader.elev_scalar));
 			else
 				factor = (float)traceheader.elev_scalar;
-			range = (double)traceheader.range;
-			receiverelevation = factor * ((double)traceheader.grp_elev);
-			sourceelevation = factor * ((double)traceheader.src_elev);
-			sourcedepth = factor * ((double)traceheader.src_depth);
-			sourcewaterdepth = factor * ((double)traceheader.src_wbd);
-			receiverwaterdepth = factor * ((double)traceheader.grp_wbd);
-			delay = 0.001 * ((double)traceheader.delay_mils);
+			const double range = (double)traceheader.range;
+			const double receiverelevation = factor * ((double)traceheader.grp_elev);
+			const double sourceelevation = factor * ((double)traceheader.src_elev);
+			const double sourcedepth = factor * ((double)traceheader.src_depth);
+			const double sourcewaterdepth = factor * ((double)traceheader.src_wbd);
+			const double receiverwaterdepth = factor * ((double)traceheader.grp_wbd);
+			const double delay = 0.001 * ((double)traceheader.delay_mils);
 
 			/* get initial values */
-			if (first == MB_YES) {
+			if (first) {
+				first = false;
 				shotmin = traceheader.shot_num;
 				shotmax = traceheader.shot_num;
 				shottracemin = traceheader.shot_tr;
@@ -372,8 +337,6 @@ int main(int argc, char **argv) {
 				latbeg = navlat;
 				lonend = navlon;
 				latend = navlat;
-				timbeg = time_d;
-				timend = time_d;
 				for (int i = 0; i < 7; i++) {
 					timbeg_i[i] = time_i[i];
 					timend_i[i] = time_i[i];
@@ -382,7 +345,6 @@ int main(int argc, char **argv) {
 					timbeg_j[i] = time_j[i];
 					timend_j[i] = time_j[i];
 				}
-				first = MB_NO;
 			}
 
 			/* get min max values */
@@ -405,7 +367,6 @@ int main(int argc, char **argv) {
 				}
 				lonend = navlon;
 				latend = navlat;
-				timend = time_d;
 				for (int i = 0; i < 7; i++) {
 					timend_i[i] = time_i[i];
 				}
@@ -427,17 +388,14 @@ int main(int argc, char **argv) {
 			}
 		}
 
-		/* reset first flag */
-		if (error == MB_ERROR_NO_ERROR && first == MB_YES) {
-			first = MB_NO;
+		if (error == MB_ERROR_NO_ERROR && first) {
+			first = false;
 		}
 	}
 
-	/* close the swath file */
 	status = mb_segy_close(verbose, &mbsegyioptr, &error);
 
-	/* output the information */
-	tracelength = 0.000001 * (double)(fileheader.sample_interval * fileheader.number_samples);
+	const double tracelength = 0.000001 * (double)(fileheader.sample_interval * fileheader.number_samples);
 	fprintf(output, "\nSEGY Data File:      %s\n", read_file);
 	fprintf(output, "\nFile Header Info:\n");
 	fprintf(output, "  Channels:                   %8d\n", fileheader.channels);


### PR DESCRIPTION
- Use stdbool
- Remove unused #defines
- Localize vars
- Add const
- Comment out unused code
- Use ternary if to make one line define and set for stream
- Remove redundant comments
- Call exit with the error define rather than an error variable
- Sort min/max variables
- Create scopes for getopt and mb_segy_read_init