### PR TITLE
utilities: Remove unused flag var and make it a bool in mbdefaults.

### DIFF
--- a/src/utilities/mb7k2jstar.c
+++ b/src/utilities/mb7k2jstar.c
@@ -120,7 +120,6 @@ int main(int argc, char **argv) {
 
 	/* process argument list */
 	{
-	int flag = 0;
 	int c;
 	while ((c = getopt(argc, argv, "A:a:B:b:CcF:f:G:g:I:i:L:l:MmO:o:R:r:S:s:T:t:XxVvHh")) != -1)
 		switch (c) {
@@ -162,7 +161,6 @@ int main(int argc, char **argv) {
 					extract_sbp = MB_YES;
 				}
 			}
-			flag++;
 			break;
 		case 'B':
 		case 'b': {
@@ -171,7 +169,6 @@ int main(int argc, char **argv) {
 				bottompickmode = MB7K2JSTAR_BOTTOMPICK_ALTITUDE;
 			else if (n == 1 && bottompickmode == MB7K2JSTAR_BOTTOMPICK_ARRIVAL)
 				bottompickthreshold = 0.5;
-			flag++;
 			break;
 		}
 		case 'C':
@@ -181,54 +178,44 @@ int main(int argc, char **argv) {
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
 			sscanf(optarg, "%d/%lf", &gainmode, &gainfactor);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d/%s", &startline, lineroot);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			checkroutebearing = MB_YES;
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", output_file);
 			output_file_set = MB_YES;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			sscanf(optarg, "%s", route_file);
 			route_file_set = MB_YES;
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%d", &smooth);
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%lf", &timeshift);
-			flag++;
 			break;
 		case 'X':
 		case 'x':
 			ssflip = MB_YES;
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mb7k2ss.c
+++ b/src/utilities/mb7k2ss.c
@@ -137,7 +137,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -402,7 +401,6 @@ int main(int argc, char **argv) {
 					target_kind = MB_DATA_SIDESCAN3;
 				}
 			}
-			flag++;
 			break;
 		case 'B':
 		case 'b':
@@ -412,7 +410,6 @@ int main(int argc, char **argv) {
 				bottompickmode = MB7K2SS_BOTTOMPICK_ALTITUDE;
 			else if (n == 1 && bottompickmode == MB7K2SS_BOTTOMPICK_ARRIVAL)
 				bottompickthreshold = 0.5;
-			flag++;
 			break;
 		}
 		case 'C':
@@ -426,73 +423,60 @@ int main(int argc, char **argv) {
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
 			sscanf(optarg, "%d/%lf", &gainmode, &gainfactor);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d/%s", &startline, lineroot);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			checkroutebearing = MB_YES;
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", output_file);
 			output_file_set = MB_YES;
-			flag++;
 			break;
 		case 'Q':
 		case 'q':
 			sscanf(optarg, "%s", timelist_file);
 			timelist_file_set = MB_YES;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			sscanf(optarg, "%s", route_file);
 			route_file_set = MB_YES;
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%d", &smooth);
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%s", topogridfile);
 			sslayoutmode = MB7K2SS_SS_3D_BOTTOM;
-			flag++;
 			break;
 		case 'U':
 		case 'u':
 			sscanf(optarg, "%lf", &rangethreshold);
-			flag++;
 			break;
 		case 'W':
 		case 'w':
 			sscanf(optarg, "%lf", &swath_width);
 			if (swath_width > 0.0)
 				swath_width_set = MB_YES;
-			flag++;
 			break;
 		case 'X':
 		case 'x':
 			ssflip = MB_YES;
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mb7kpreprocess.c
+++ b/src/utilities/mb7kpreprocess.c
@@ -76,7 +76,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -630,7 +629,6 @@ int main(int argc, char **argv) {
 		case 'A':
 		case 'a':
 			goodnavattitudeonly = MB_NO;
-			flag++;
 			break;
 		case 'B':
 		case 'b':
@@ -670,23 +668,19 @@ int main(int argc, char **argv) {
 			}
 			if (nscan > 0)
 				depth_offset_mode = MB_YES;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
 			sscanf(optarg, "%s", platform_file);
 			use_platform_file = MB_YES;
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'K':
 		case 'k':
@@ -725,30 +719,25 @@ int main(int argc, char **argv) {
 				kluge_beampatternsnelltweak = MB_YES;
 				kluge_beampatternsnellfactor = klugevalue;
 			}
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			mode = MB7KPREPROCESS_TIMESTAMPLIST;
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			sscanf(optarg, "%s", rockfile);
 			rockdata = MB_YES;
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			sscanf(optarg, "%s", insfile);
 			insdata = MB_YES;
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", ofile);
 			ofile_set = MB_YES;
-			flag++;
 			break;
 		case 'P':
 		case 'p':
@@ -766,7 +755,6 @@ int main(int argc, char **argv) {
 				else
 					sonardepthfilter = MB_NO;
 			}
-			flag++;
 			break;
 		case 'R':
 		case 'r':
@@ -775,7 +763,6 @@ int main(int argc, char **argv) {
 				       &rangeoffset[nrangeoffset]);
 				nrangeoffset++;
 			}
-			flag++;
 			break;
 		case 'S':
 		case 's':
@@ -798,7 +785,6 @@ int main(int argc, char **argv) {
 				else if (type == 5)
 					ss_source = source;
 			}
-			flag++;
 			break;
 		case 'T':
 		case 't':
@@ -817,13 +803,11 @@ int main(int argc, char **argv) {
 				sscanf(optarg, "%lf", &timelagconstant);
 				timelagmode = MB7KPREPROCESS_TIMELAG_CONSTANT;
 			}
-			flag++;
 			break;
 		case 'W':
 		case 'w':
 			sscanf(optarg, "%s", dslfile);
 			dsldata = MB_YES;
-			flag++;
 			break;
 		case 'Z':
 		case 'z':
@@ -883,7 +867,6 @@ int main(int argc, char **argv) {
 				if (n == 3)
 					rollpitch_offset_mode = MB_YES;
 			}
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbareaclean.c
+++ b/src/utilities/mbareaclean.c
@@ -190,7 +190,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -352,28 +351,23 @@ int main(int argc, char **argv) {
 		case 'B':
 		case 'b':
 			output_bad = MB_YES;
-			flag++;
 			break;
 		case 'D':
 		case 'd':
 			std_dev_filter = MB_YES;
 			sscanf(optarg, "%lf/%d", &std_dev_threshold, &std_dev_nmin);
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
 			output_good = MB_YES;
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
@@ -388,7 +382,6 @@ int main(int argc, char **argv) {
 				mediandensity_filter = MB_YES;
 				mediandensity_filter_nmax = i2;
 			}
-			flag++;
 			break;
 		}
 		case 'N':
@@ -404,7 +397,6 @@ int main(int argc, char **argv) {
 			max_beam = max_beam_no;
 			if (max_beam < min_beam)
 				max_beam = min_beam;
-			flag++;
 			break;
 		case 'P':
 		case 'p':
@@ -416,26 +408,22 @@ int main(int argc, char **argv) {
 				plane_fit_threshold = d1;
 			if (n > 1)
 				plane_fit_nmin = i1;
-			flag++;
 			break;
 		}
 		case 'R':
 		case 'r':
 			mb_get_bounds(optarg, areabounds);
 			areaboundsset = MB_YES;
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%lf", &binsize);
 			binsizeset = MB_YES;
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			use_detect = MB_YES;
 			sscanf(optarg, "%d", &flag_detect);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbauvloglist.c
+++ b/src/utilities/mbauvloglist.c
@@ -187,7 +187,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -321,28 +320,23 @@ int main(int argc, char **argv) {
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%s", printformat);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", file);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			sscanf(optarg, "%d", &output_mode);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			sscanf(optarg, "%s", nav_file);
 			nav_merge = MB_YES;
-			flag++;
 			break;
 		case 'O':
 		case 'o':
@@ -365,23 +359,19 @@ int main(int argc, char **argv) {
                 calc_ktime = MB_YES;
 			printfields[nprintfields].index = -1;
 			nprintfields++;
-			flag++;
 			break;
 		case 'P':
 		case 'p':
 			printheader = MB_YES;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			recalculate_ctd = MB_YES;
 			sscanf(optarg, "%d", &ctd_calibration_id);
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			angles_in_degrees = MB_YES;
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbauvnavusbl.c
+++ b/src/utilities/mbauvnavusbl.c
@@ -87,7 +87,6 @@ int main(int argc, char **argv) {
 		bool errflg = false;
 		int c;
 		bool help = false;
-		int flag = 0;
 	while ((c = getopt(argc, argv, "VvHhAaF:f:L:l:I:i:O:o:M:m:U:u:")) != -1)
 		switch (c) {
 		case 'H':
@@ -101,37 +100,30 @@ int main(int argc, char **argv) {
 		case 'A':
 		case 'a':
 			useaverage = MB_YES;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &navformat);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", ifile);
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", ofile);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			sscanf(optarg, "%d", &usblformat);
-			flag++;
 			break;
 		case 'U':
 		case 'u':
 			sscanf(optarg, "%s", ufile);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbbackangle.c
+++ b/src/utilities/mbbackangle.c
@@ -437,7 +437,6 @@ int main(int argc, char **argv) {
 		bool errflg = false;
 		int c;
 		bool help = false;
-		int flag = 0;
 
 	while ((c = getopt(argc, argv, "A:a:B:b:CcDdF:f:G:g:HhI:i:N:n:P:p:QqR:r:T:t:VvZ:z:")) != -1)
 		switch (c) {
@@ -448,7 +447,6 @@ int main(int argc, char **argv) {
 				sidescan_on = MB_YES;
 			if (ampkind == MBBACKANGLE_AMP)
 				amplitude_on = MB_YES;
-			flag++;
 			break;
 		case 'B':
 		case 'b':
@@ -460,24 +458,20 @@ int main(int argc, char **argv) {
 				if (n >= 3)
 					ssdepression = d2;
 			}
-			flag++;
 			break;
 		}
 		case 'C':
 		case 'c':
 			symmetry = MB_YES;
 			corr_symmetry = MBP_SSCORR_SYMMETRIC;
-			flag++;
 			break;
 		case 'D':
 		case 'd':
 			dump = MB_YES;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
@@ -510,7 +504,6 @@ int main(int argc, char **argv) {
 				gridssdx = 2.0 * gridssangle / (gridssn_columns - 1);
 				gridssdy = (gridssmax - gridssmin) / (gridssn_rows - 1);
 			}
-			flag++;
 			break;
 		}
 		case 'H':
@@ -520,33 +513,27 @@ int main(int argc, char **argv) {
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			sscanf(optarg, "%d/%lf", &nangles, &angle_max);
-			flag++;
 			break;
 		case 'P':
 		case 'p':
 			sscanf(optarg, "%d", &pings_avg);
-			flag++;
 			break;
 		case 'Q':
 		case 'q':
 			corr_slope = MB_YES;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			sscanf(optarg, "%lf", &ref_angle_default);
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%s", grid.file);
 			corr_topogrid = MB_YES;
-			flag++;
 			break;
 		case 'V':
 		case 'v':
@@ -555,7 +542,6 @@ int main(int argc, char **argv) {
 		case 'Z':
 		case 'z':
 			sscanf(optarg, "%lf", &altitude_default);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbclean.c
+++ b/src/utilities/mbclean.c
@@ -127,7 +127,6 @@ int main(int argc, char **argv) {
   bool errflg = false;
   int c;
   bool help = false;
-  int flag = 0;
 
   /* MBIO status variables */
   int status;
@@ -373,13 +372,11 @@ int main(int argc, char **argv) {
     case 'a':
       sscanf(optarg, "%lf", &deviation_max);
       check_deviation = MB_YES;
-      flag++;
       break;
     case 'B':
     case 'b':
       sscanf(optarg, "%lf/%lf", &depth_low, &depth_high);
       check_range = MB_YES;
-      flag++;
       break;
     case 'C':
     case 'c':
@@ -390,75 +387,62 @@ int main(int argc, char **argv) {
         slopemax = tan(slopemax);
       else if (slope_form == 2)
         slopemax = tan(DTR * slopemax);
-      flag++;
       break;
     case 'D':
     case 'd':
       sscanf(optarg, "%lf/%lf", &distancemin, &distancemax);
-      flag++;
       break;
     case 'E': // 2010/03/07 DY added the max acrosstrack filter
     case 'e':
       sscanf(optarg, "%lf", &max_acrosstrack);
       zap_long_across = MB_YES;
-      flag++;
       break;
     case 'F':
     case 'f':
       sscanf(optarg, "%d", &format);
-      flag++;
       break;
     case 'G':
     case 'g':
       sscanf(optarg, "%lf/%lf", &fraction_low, &fraction_high);
       check_fraction = MB_YES;
-      flag++;
       break;
     case 'K':
     case 'k':
       sscanf(optarg, "%lf", &range_min);
       check_range_min = MB_YES;
-      flag++;
       break;
     case 'I':
     case 'i':
       sscanf(optarg, "%s", read_file);
-      flag++;
       break;
     case 'L':
     case 'l':
       sscanf(optarg, "%d", &lonflip);
-      flag++;
       break;
     case 'M':
     case 'm':
       sscanf(optarg, "%d", &mode);
-      flag++;
       break;
     case 'N':
     case 'n':
       sscanf(optarg, "%lf", &ping_deviation_tolerance);
       check_ping_deviation = MB_YES;
-      flag++;
       break;
     case 'P':
     case 'p':
       sscanf(optarg, "%lf/%lf", &speed_low, &speed_high);
       check_speed_good = MB_YES;
-      flag++;
       break;
     case 'Q':
     case 'q':
       zap_rails = MB_YES;
       backup_dist = 0.0;
       sscanf(optarg, "%lf", &backup_dist);
-      flag++;
       break;
     case 'R':
     case 'r':
       zap_max_heading_rate = MB_YES;
       sscanf(optarg, "%lf", &max_heading_rate);
-      flag++;
       break;
     case 'S':
     case 's':
@@ -469,25 +453,21 @@ int main(int argc, char **argv) {
         spikemax = tan(DTR * spikemax);
       if (1 == slope_form)
         spikemax = tan(spikemax);
-      flag++;
       break;
     case 'T':
     case 't':
       fix_edit_timestamps = MB_YES;
       sscanf(optarg, "%lf", &tolerance);
-      flag++;
       break;
     case 'U':
     case 'u':
       sscanf(optarg, "%d", &num_good_min);
       check_num_good_min = MB_YES;
-      flag++;
       break;
     case 'W':
     case 'w':
       check_position_bounds = MB_YES;
       sscanf(optarg, "%lf/%lf/%lf/%lf", &west, &east, &south, &north);
-      flag++;
       break;
     case 'X':
     case 'x':
@@ -496,7 +476,6 @@ int main(int argc, char **argv) {
       if (n == 1)
         zap_beams_right = zap_beams_left;
       zap_beams = MB_YES;
-      flag++;
       break;
     }
     case 'Y':
@@ -524,13 +503,11 @@ int main(int argc, char **argv) {
         unflag_distance_right = distance_right;
         unflag_distance = MB_YES;
       }
-      flag++;
       break;
     }
     case 'Z':
     case 'z':
       check_zero_position = MB_YES;
-      flag++;
       break;
     case '?':
       errflg = true;

--- a/src/utilities/mbcopy.c
+++ b/src/utilities/mbcopy.c
@@ -1725,7 +1725,6 @@ int main(int argc, char **argv) {
   bool errflg = false;
   int c;
   bool help = false;
-  int flag = 0;
 
   /* MBIO status variables */
   int verbose = 0;
@@ -1883,25 +1882,21 @@ int main(int argc, char **argv) {
       sscanf(optarg, "%d/%d/%d/%d/%d/%lf", &btime_i[0], &btime_i[1], &btime_i[2], &btime_i[3], &btime_i[4], &seconds);
       btime_i[5] = (int)floor(seconds);
       btime_i[6] = 1000000 * (seconds - btime_i[5]);
-      flag++;
       break;
     case 'C':
     case 'c':
       sscanf(optarg, "%s", commentfile);
       insertcomments = MB_YES;
-      flag++;
       break;
     case 'D':
     case 'd':
       bathonly = MB_YES;
-      flag++;
       break;
     case 'E':
     case 'e':
       sscanf(optarg, "%d/%d/%d/%d/%d/%lf", &etime_i[0], &etime_i[1], &etime_i[2], &etime_i[3], &etime_i[4], &seconds);
       etime_i[5] = (int)floor(seconds);
       etime_i[6] = 1000000 * (seconds - btime_i[5]);
-      flag++;
       break;
     case 'F':
     case 'f':
@@ -1909,7 +1904,6 @@ int main(int argc, char **argv) {
       const int i = sscanf(optarg, "%d/%d/%d", &iformat, &oformat, &mformat);
       if (i == 1)
         oformat = iformat;
-      flag++;
       break;
     }
     case 'H':
@@ -1919,12 +1913,10 @@ int main(int argc, char **argv) {
     case 'I':
     case 'i':
       sscanf(optarg, "%s", ifile);
-      flag++;
       break;
     case 'L':
     case 'l':
       sscanf(optarg, "%d", &lonflip);
-      flag++;
       break;
     case 'M':
     case 'm':
@@ -1932,7 +1924,6 @@ int main(int argc, char **argv) {
       const int i = sscanf(optarg, "%s", mfile);
       if (i == 1)
         merge = MB_YES;
-      flag++;
       break;
     }
     case 'N':
@@ -1942,33 +1933,27 @@ int main(int argc, char **argv) {
     case 'O':
     case 'o':
       sscanf(optarg, "%s", ofile);
-      flag++;
       break;
     case 'P':
     case 'p':
       sscanf(optarg, "%d", &pings);
-      flag++;
       break;
     case 'Q':
     case 'q':
       sscanf(optarg, "%lf", &sleep_factor);
       use_sleep = MB_YES;
-      flag++;
       break;
     case 'R':
     case 'r':
       mb_get_bounds(optarg, bounds);
-      flag++;
       break;
     case 'S':
     case 's':
       sscanf(optarg, "%lf", &speedmin);
-      flag++;
       break;
     case 'T':
     case 't':
       sscanf(optarg, "%lf", &timegap);
-      flag++;
       break;
     case 'V':
     case 'v':

--- a/src/utilities/mbctdlist.c
+++ b/src/utilities/mbctdlist.c
@@ -154,7 +154,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int interp_status = MB_SUCCESS;
@@ -329,32 +328,26 @@ int main(int argc, char **argv) {
 		case 'A':
 		case 'a':
 			ascii = MB_NO;
-			flag++;
 			break;
 		case 'D':
 		case 'd':
 			sscanf(optarg, "%d", &decimate);
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
 			sscanf(optarg, "%s", delimiter);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
-			flag++;
 			break;
 		case 'O':
 		case 'o':
@@ -366,7 +359,6 @@ int main(int argc, char **argv) {
 		case 'z':
 			segment = MB_YES;
 			sscanf(optarg, "%s", segment_tag);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbdatalist.c
+++ b/src/utilities/mbdatalist.c
@@ -47,7 +47,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* command line option definitions */
 	/* mbdatalist
@@ -169,50 +168,42 @@ int main(int argc, char **argv) {
 			/* copy files */
 			else if (strcmp("copy", options[option_index].name) == 0) {
 				copyfiles = MB_YES;
-				flag++;
 			}
 
 			/* report datalists */
 			else if (strcmp("report", options[option_index].name) == 0) {
 				copyfiles = MB_YES;
-				flag++;
 			}
 
 			/* format */
 			else if (strcmp("format", options[option_index].name) == 0) {
 				sscanf(optarg, "%d", &format);
-				flag++;
 			}
 
 			/* input */
 			else if (strcmp("input", options[option_index].name) == 0) {
 				sscanf(optarg, "%s", read_file);
-				flag++;
 			}
 
 			/* make ancillary files */
 			else if (strcmp("make-ancilliary", options[option_index].name) == 0) {
 				force_update = MB_YES;
 				make_inf = MB_YES;
-				flag++;
 			}
 
 			/* update ancillary files */
 			else if (strcmp("update-ancilliary", options[option_index].name) == 0) {
 				make_inf = MB_YES;
-				flag++;
 			}
 
 			/* look for processed files */
 			else if (strcmp("processed", options[option_index].name) == 0) {
 				look_processed = MB_DATALIST_LOOK_YES;
-				flag++;
 			}
 
 			/* problem report */
 			else if (strcmp("problem", options[option_index].name) == 0) {
 				problem_report = MB_YES;
-				flag++;
 			}
 
 			/* bounds */
@@ -224,25 +215,21 @@ int main(int argc, char **argv) {
 			/* status report */
 			else if (strcmp("status", options[option_index].name) == 0) {
 				status_report = MB_YES;
-				flag++;
 			}
 
 			/* look for raw (unprocessed) files */
 			else if (strcmp("raw", options[option_index].name) == 0) {
 				look_processed = MB_DATALIST_LOOK_NO;
-				flag++;
 			}
 
 			/* removed file locks */
 			else if (strcmp("unlock", options[option_index].name) == 0) {
 				remove_locks = MB_YES;
-				flag++;
 			}
 
 			/* make datalistp file */
 			else if (strcmp("datalistp", options[option_index].name) == 0) {
 				make_datalistp = MB_YES;
-				flag++;
 			}
 
 			break;
@@ -251,17 +238,14 @@ int main(int argc, char **argv) {
 		case 'C':
 		case 'c':
 			copyfiles = MB_YES;
-			flag++;
 			break;
 		case 'D':
 		case 'd':
 			reportdatalists = MB_YES;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'H':
 		case 'h':
@@ -270,44 +254,36 @@ int main(int argc, char **argv) {
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			force_update = MB_YES;
 			make_inf = MB_YES;
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			make_inf = MB_YES;
-			flag++;
 			break;
 		case 'P':
 		case 'p':
 			look_processed = MB_DATALIST_LOOK_YES;
-			flag++;
 			break;
 		case 'Q':
 		case 'q':
 			problem_report = MB_YES;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			mb_get_bounds(optarg, bounds);
 			look_bounds = MB_YES;
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			status_report = MB_YES;
-			flag++;
 			break;
 		case 'U':
 		case 'u':
 			look_processed = MB_DATALIST_LOOK_NO;
-			flag++;
 			break;
 		case 'V':
 		case 'v':

--- a/src/utilities/mbdefaults.c
+++ b/src/utilities/mbdefaults.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
 	int error = MB_ERROR_NO_ERROR;
 	int verbose = 0;
 	bool help = false;
-	int flag = 0;
+	bool flag = false;
 	FILE *fp;
 	char file[MB_PATH_MAXLINE];
 	char psdisplay[MB_PATH_MAXLINE];
@@ -128,12 +128,12 @@ int main(int argc, char **argv) {
 		case 'B':
 		case 'b':
 			sscanf(optarg, "%d", &fileiobuffer);
-			flag++;
+			flag = true;
 			break;
 		case 'D':
 		case 'd':
 			sscanf(optarg, "%s", psdisplay);
-			flag++;
+			flag = true;
 			break;
 		case 'F':
 		case 'f':
@@ -146,12 +146,12 @@ int main(int argc, char **argv) {
 				fbtversion = 2;
 			else if (strncmp(argstring, "3", 1) == 0)
 				fbtversion = 3;
-			flag++;
+			flag = true;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", imgdisplay);
-			flag++;
+			flag = true;
 			break;
 		case 'H':
 		case 'h':
@@ -160,7 +160,7 @@ int main(int argc, char **argv) {
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
-			flag++;
+			flag = true;
 			break;
 		case 'M':
 		case 'm':
@@ -184,12 +184,12 @@ int main(int argc, char **argv) {
 			else if (optarg[0] == 'S' || optarg[0] == 'S')
 				/* n = */ sscanf(&optarg[1], "%lf", &slope_magnitude);
 
-			flag++;
+			flag = true;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%lf", &timegap);
-			flag++;
+			flag = true;
 			break;
 		case 'U':
 		case 'u':
@@ -202,7 +202,7 @@ int main(int argc, char **argv) {
 				uselockfiles = 1;
 			else if (strncmp(argstring, "0", 1) == 0)
 				uselockfiles = 0;
-			flag++;
+			flag = true;
 			break;
 		case 'V':
 		case 'v':
@@ -211,7 +211,7 @@ int main(int argc, char **argv) {
 		case 'W':
 		case 'w':
 			sscanf(optarg, "%s", mbproject);
-			flag++;
+			flag = true;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbextractsegy.c
+++ b/src/utilities/mbextractsegy.c
@@ -247,7 +247,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 	while ((c = getopt(argc, argv, "B:b:D:d:E:e:F:f:I:i:J:j:L:l:MmO:o:Q:q:R:r:S:s:T:t:U:u:Z:z:VvHh")) != -1)
 		switch (c) {
 		case 'H':
@@ -262,76 +261,62 @@ int main(int argc, char **argv) {
 		case 'b':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &btime_i[0], &btime_i[1], &btime_i[2], &btime_i[3], &btime_i[4], &btime_i[5]);
 			btime_i[6] = 0;
-			flag++;
 			break;
 		case 'E':
 		case 'e':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &etime_i[0], &etime_i[1], &etime_i[2], &etime_i[3], &etime_i[4], &etime_i[5]);
 			etime_i[6] = 0;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'J':
 		case 'j':
 			sscanf(optarg, "%lf/%lf/%lf", &xscale, &yscale, &maxwidth);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d/%s", &startline, lineroot);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			checkroutebearing = MB_YES;
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", output_file);
 			output_file_set = MB_YES;
-			flag++;
 			break;
 		case 'Q':
 		case 'q':
 			sscanf(optarg, "%s", timelist_file);
 			timelist_file_set = MB_YES;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			sscanf(optarg, "%s", route_file);
 			route_file_set = MB_YES;
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%d", &sampleformat);
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%lf", &timeshift);
-			flag++;
 			break;
 		case 'U':
 		case 'u':
 			sscanf(optarg, "%lf", &rangethreshold);
-			flag++;
 			break;
 		case 'Z':
 		case 'z':
 			sscanf(optarg, "%lf", &zmax);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbfilter.c
+++ b/src/utilities/mbfilter.c
@@ -621,7 +621,6 @@ int main(int argc, char **argv) {
 	bool errflg = 0;
 	int c;
 	bool help = 0;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -760,13 +759,11 @@ int main(int argc, char **argv) {
 			sscanf(optarg, "%d", &datakind);
 			if (datakind != MBFILTER_SS && datakind != MBFILTER_AMP)
 				datakind = MBFILTER_SS;
-			flag++;
 			break;
 		case 'B':
 		case 'b':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &btime_i[0], &btime_i[1], &btime_i[2], &btime_i[3], &btime_i[4], &btime_i[5]);
 			btime_i[6] = 0;
-			flag++;
 			break;
 		case 'C':
 		case 'c':
@@ -784,7 +781,6 @@ int main(int argc, char **argv) {
 				filters[num_filters].iteration = 1;
 			if (n >= 3)
 				num_filters++;
-			flag++;
 			break;
 		}
 		case 'D':
@@ -807,19 +803,16 @@ int main(int argc, char **argv) {
 				filters[num_filters].hipass_offset = 1000.0;
 			if (n >= 3)
 				num_filters++;
-			flag++;
 			break;
 		}
 		case 'E':
 		case 'e':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &etime_i[0], &etime_i[1], &etime_i[2], &etime_i[3], &etime_i[4], &etime_i[5]);
 			etime_i[6] = 0;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'H':
 		case 'h':
@@ -828,19 +821,16 @@ int main(int argc, char **argv) {
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			sscanf(optarg, "%d", &n_buffer_max);
 			if (n_buffer_max > MBFILTER_BUFFER_DEFAULT || n_buffer_max < 10)
 				n_buffer_max = MBFILTER_BUFFER_DEFAULT;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			mb_get_bounds(optarg, bounds);
-			flag++;
 			break;
 		case 'S':
 		case 's':
@@ -870,14 +860,12 @@ int main(int argc, char **argv) {
 				filters[num_filters].threshold = MB_NO;
 			if (n >= 3)
 				num_filters++;
-			flag++;
 			break;
 		}
 		case 'T':
 		case 't':
 			sscanf(optarg, "%lf/%lf", &threshold_lo, &threshold_hi);
 			apply_threshold = MB_YES;
-			flag++;
 			break;
 		case 'V':
 		case 'v':

--- a/src/utilities/mbgetesf.c
+++ b/src/utilities/mbgetesf.c
@@ -111,7 +111,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int status;
@@ -228,39 +227,32 @@ int main(int argc, char **argv) {
 		case 'b':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &btime_i[0], &btime_i[1], &btime_i[2], &btime_i[3], &btime_i[4], &btime_i[5]);
 			btime_i[6] = 0;
-			flag++;
 			break;
 		case 'E':
 		case 'e':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &etime_i[0], &etime_i[1], &etime_i[2], &etime_i[3], &etime_i[4], &etime_i[5]);
 			etime_i[6] = 0;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", ifile);
-			flag++;
 			break;
 		case 'K':
 		case 'k':
 			sscanf(optarg, "%d", &kluge);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			sscanf(optarg, "%d", &mode);
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", sofile);
 			sofile_set = MB_YES;
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbgrid.c
+++ b/src/utilities/mbgrid.c
@@ -440,7 +440,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -669,13 +668,11 @@ int main(int argc, char **argv) {
 		case 'A':
 		case 'a':
 			sscanf(optarg, "%d", &datatype);
-			flag++;
 			break;
 		case 'B':
 		case 'b':
 			sscanf(optarg, "%lf", &border);
 			setborder = MB_YES;
-			flag++;
 			break;
 		case 'C':
 		case 'c':
@@ -691,7 +688,6 @@ int main(int argc, char **argv) {
 				clipmode = MBGRID_INTERP_GAP;
 			else if (clipmode >= 3)
 				clipmode = MBGRID_INTERP_ALL;
-			flag++;
 			break;
 		}
 		case 'D':
@@ -700,7 +696,6 @@ int main(int argc, char **argv) {
 			const int n = sscanf(optarg, "%d/%d", &xdim, &ydim);
 			if (n == 2)
 				set_dimensions = MB_YES;
-			flag++;
 			break;
 		}
 		case 'E':
@@ -715,7 +710,6 @@ int main(int argc, char **argv) {
 				set_spacing = MB_YES;
 			if (n < 3)
 				strcpy(units, "meters");
-			flag++;
 			break;
 		}
 		case 'F':
@@ -733,7 +727,6 @@ int main(int argc, char **argv) {
           minormax_weighted_mean_threshold = dvalue;
         }
       }
-			flag++;
 			break;
 		}
 		case 'G':
@@ -753,7 +746,6 @@ int main(int argc, char **argv) {
 					gridkind = MBGRID_GMTGRD;
 				}
 			}
-			flag++;
 			break;
 		case 'H':
 		case 'h':
@@ -762,50 +754,41 @@ int main(int argc, char **argv) {
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", filelist);
-			flag++;
 			break;
 		case 'J':
 		case 'j':
 			sscanf(optarg, "%s", projection_pars);
 			projection_pars_f = MB_YES;
-			flag++;
 			break;
 		case 'K':
 		case 'k':
 			sscanf(optarg, "%s", backgroundfile);
 			if ((grdrasterid = atoi(backgroundfile)) <= 0)
 				grdrasterid = -1;
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			more = MB_YES;
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			use_NaN = MB_YES;
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", fileroot);
-			flag++;
 			break;
 		case 'P':
 		case 'p':
 			sscanf(optarg, "%d", &pings);
-			flag++;
 			break;
 		case 'Q':
 		case 'q':
 			bathy_in_feet = MB_YES;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
@@ -818,17 +801,14 @@ int main(int argc, char **argv) {
 				mb_get_bounds(optarg, gbnd);
 				gbndset = MB_YES;
 			}
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%lf", &speedmin);
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%lf", &tension);
-			flag++;
 			break;
 		case 'U':
 		case 'u':
@@ -839,7 +819,6 @@ int main(int argc, char **argv) {
 				timediff = fabs(timediff);
 				first_in_stays = MB_NO;
 			}
-			flag++;
 			break;
 		case 'V':
 		case 'v':
@@ -848,12 +827,10 @@ int main(int argc, char **argv) {
 		case 'W':
 		case 'w':
 			sscanf(optarg, "%lf", &scale);
-			flag++;
 			break;
 		case 'X':
 		case 'x':
 			sscanf(optarg, "%lf", &extend);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbhistogram.c
+++ b/src/utilities/mbhistogram.c
@@ -106,7 +106,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -203,29 +202,24 @@ int main(int argc, char **argv) {
 		case 'A':
 		case 'a':
 			sscanf(optarg, "%d", &mode);
-			flag++;
 			break;
 		case 'B':
 		case 'b':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &btime_i[0], &btime_i[1], &btime_i[2], &btime_i[3], &btime_i[4], &btime_i[5]);
 			btime_i[6] = 0;
-			flag++;
 			break;
 		case 'D':
 		case 'd':
 			sscanf(optarg, "%lf/%lf", &value_min, &value_max);
-			flag++;
 			break;
 		case 'E':
 		case 'e':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &etime_i[0], &etime_i[1], &etime_i[2], &etime_i[3], &etime_i[4], &etime_i[5]);
 			etime_i[6] = 0;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
@@ -238,42 +232,34 @@ int main(int argc, char **argv) {
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			sscanf(optarg, "%d", &nintervals);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			sscanf(optarg, "%d", &nbins);
-			flag++;
 			break;
 		case 'P':
 		case 'p':
 			sscanf(optarg, "%d", &pings);
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			mb_get_bounds(optarg, bounds);
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%lf", &speedmin);
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%lf", &timegap);
-			flag++;
 			break;
 		case 'V':
 		case 'v':

--- a/src/utilities/mbhsdump.c
+++ b/src/utilities/mbhsdump.c
@@ -48,7 +48,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -164,12 +163,10 @@ int main(int argc, char **argv) {
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", file);
-			flag++;
 			break;
 		case 'O':
 		case 'o':
@@ -188,7 +185,6 @@ int main(int argc, char **argv) {
 				mb_data_standby_list = MB_YES;
 			if (kind == MB_DATA_NAV_SOURCE)
 				mb_data_nav_source_list = MB_YES;
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbhysweeppreprocess.c
+++ b/src/utilities/mbhysweeppreprocess.c
@@ -71,7 +71,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -326,7 +325,6 @@ int main(int argc, char **argv) {
 					offset_nav_z = offset_z;
 				}
 			}
-			flag++;
 			break;
 		case 'B':
 		case 'b':
@@ -337,7 +335,6 @@ int main(int argc, char **argv) {
 				offset_sonar_pitch = offset_pitch;
 				offset_sonar_heading = offset_heading;
 			}
-			flag++;
 			break;
 		case 'D':
 		case 'd':
@@ -346,29 +343,24 @@ int main(int argc, char **argv) {
 				sonardepthdata = MB_YES;
 				strcpy(sonardepthfile, buffer);
 			}
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
 			sscanf(optarg, "%s", platform_file);
 			use_platform_file = MB_YES;
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'J':
 		case 'j':
 			sscanf(optarg, "%s", proj4command);
 			projection_set = MB_YES;
-			flag++;
 			break;
 		case 'K':
 		case 'k':
@@ -377,17 +369,14 @@ int main(int argc, char **argv) {
 				kluge_force_attitude_compensation = MB_YES;
 			else if (klugemode == 2)
 				kluge_flip_attitude_sign = MB_YES;
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			mode = MBHYSWEEPPREPROCESS_TIMESTAMPLIST;
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			sscanf(optarg, "%d", &navformat);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
@@ -396,13 +385,11 @@ int main(int argc, char **argv) {
 				navdata = MB_YES;
 				strcpy(navfile, buffer);
 			}
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", ofile);
 			ofile_set = MB_YES;
-			flag++;
 			break;
 		case 'T':
 		case 't':
@@ -414,7 +401,6 @@ int main(int argc, char **argv) {
 				sscanf(optarg, "%lf", &timelagconstant);
 				timelagmode = MBHYSWEEPPREPROCESS_TIMELAG_CONSTANT;
 			}
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbinfo.c
+++ b/src/utilities/mbinfo.c
@@ -282,7 +282,6 @@ int main(int argc, char **argv) {
 
 	/* process argument list */
         {
-	int flag = 0;
 	int c;
 	while ((c = getopt(argc, argv, "VvHhB:b:CcE:e:F:f:GgI:i:L:l:M:m:NnOoP:p:R:r:S:s:T:t:WwX:x:")) != -1)
 		switch (c) {
@@ -290,28 +289,23 @@ int main(int argc, char **argv) {
 		case 'b':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &btime_i[0], &btime_i[1], &btime_i[2], &btime_i[3], &btime_i[4], &btime_i[5]);
 			btime_i[6] = 0;
-			flag++;
 			break;
 		case 'C':
 		case 'c':
 			comments = MB_YES;
-			flag++;
 			break;
 		case 'E':
 		case 'e':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &etime_i[0], &etime_i[1], &etime_i[2], &etime_i[3], &etime_i[4], &etime_i[5]);
 			etime_i[6] = 0;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
 			good_nav_only = MB_YES;
-			flag++;
 			break;
 		case 'H':
 		case 'h':
@@ -320,30 +314,25 @@ int main(int argc, char **argv) {
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
 			lonflip_set = MB_YES;
 			lonflip_use = lonflip;
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			sscanf(optarg, "%d/%d", &mask_nx, &mask_ny);
 			coverage_mask = MB_YES;
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			print_notices = MB_YES;
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			output_usefile = MB_YES;
-			flag++;
 			break;
 		case 'P':
 		case 'p':
@@ -352,22 +341,18 @@ int main(int argc, char **argv) {
 				pings_read = 1;
 			if (pings_read > MBINFO_MAXPINGS)
 				pings_read = MBINFO_MAXPINGS;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			mb_get_bounds(optarg, bounds);
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%lf", &speedmin);
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%lf", &timegap);
-			flag++;
 			break;
 		case 'V':
 		case 'v':
@@ -384,7 +369,6 @@ int main(int argc, char **argv) {
 				errflg = true;
 				fprintf(stderr, "Invalid output format for inf file");
 			}
-			flag++;
 			break;
 		default:
 			errflg = true;

--- a/src/utilities/mbkongsbergpreprocess.c
+++ b/src/utilities/mbkongsbergpreprocess.c
@@ -87,7 +87,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -405,13 +404,11 @@ int main(int argc, char **argv) {
 		case 'C':
 		case 'c':
 			output_counts = MB_YES;
-			flag++;
 			break;
 		case 'D':
 		case 'd':
 			sscanf(optarg, "%s", odir);
 			odir_set = MB_YES;
-			flag++;
 			break;
 		case 'E':
 		case 'e':
@@ -438,28 +435,23 @@ int main(int argc, char **argv) {
 			}
 			if (nscan > 0)
 				sonardepthlever = MB_YES;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'K':
 		case 'k':
 			sscanf(optarg, "%d", &klugemode);
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", ofile);
 			ofile_set = MB_YES;
-			flag++;
 			break;
 		case 'P':
 		case 'p':
@@ -489,7 +481,6 @@ int main(int argc, char **argv) {
 			else if (optarg[0] == 'U' || optarg[0] == 'u') {
 				nscan = sscanf(&(optarg[1]), "%d", &depthsensor_mode);
 			}
-			flag++;
 			break;
 		case 'S':
 		case 's':
@@ -502,7 +493,6 @@ int main(int argc, char **argv) {
 				attitude_source = source;
 			else if (type == 4)
 				sonardepth_source = source;
-			flag++;
 			break;
 		case 'T':
 		case 't':
@@ -514,12 +504,10 @@ int main(int argc, char **argv) {
 				sscanf(optarg, "%lf", &timelagconstant);
 				timelagmode = MBKONSBERGPREPROCESS_TIMELAG_CONSTANT;
 			}
-			flag++;
 			break;
 		case 'W':
 		case 'w':
 			sscanf(optarg, "%d", &watercolumnmode);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mblist.c
+++ b/src/utilities/mblist.c
@@ -754,7 +754,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -1014,18 +1013,15 @@ int main(int argc, char **argv) {
 		case 'a':
 			ascii = MB_NO;
 			netcdf_cdl = MB_NO;
-			flag++;
 			break;
 		case 'B':
 		case 'b':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &btime_i[0], &btime_i[1], &btime_i[2], &btime_i[3], &btime_i[4], &btime_i[5]);
 			btime_i[6] = 0;
-			flag++;
 			break;
 		case 'C':
 		case 'c':
 			netcdf = MB_YES;
-			flag++;
 			break;
 		case 'D':
 		case 'd':
@@ -1038,44 +1034,36 @@ int main(int argc, char **argv) {
 				beam_set = MBLIST_SET_ALL;
 			else if (dump_mode == DUMP_MODE_SS)
 				pixel_set = MBLIST_SET_ALL;
-			flag++;
 			break;
 		case 'E':
 		case 'e':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &etime_i[0], &etime_i[1], &etime_i[2], &etime_i[3], &etime_i[4], &etime_i[5]);
 			etime_i[6] = 0;
-			flag++;
 			break;
 		case 'G':
 		case 'g':
 			sscanf(optarg, "%s", delimiter);
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'J':
 		case 'j':
 			sscanf(optarg, "%s", projection_pars);
 			use_projection = MB_YES;
-			flag++;
 			break;
 		case 'K':
 		case 'k':
 			sscanf(optarg, "%d", &decimate);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
@@ -1090,7 +1078,6 @@ int main(int argc, char **argv) {
 				sscanf(optarg, "%d/%d", &beam_start, &beam_end);
 				beam_set = MBLIST_SET_ON;
 			}
-			flag++;
 			break;
 		case 'N':
 		case 'n':
@@ -1101,7 +1088,6 @@ int main(int argc, char **argv) {
 				sscanf(optarg, "%d/%d", &pixel_start, &pixel_end);
 				pixel_set = MBLIST_SET_ON;
 			}
-			flag++;
 			break;
 		case 'O':
 		case 'o':
@@ -1111,32 +1097,26 @@ int main(int argc, char **argv) {
 					if (list[n_list] == '^')
 						use_projection = MB_YES;
 				}
-			flag++;
 			break;
 		case 'P':
 		case 'p':
 			sscanf(optarg, "%d", &pings);
-			flag++;
 			break;
 		case 'Q':
 		case 'q':
 			check_values = MBLIST_CHECK_OFF_RAW;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			mb_get_bounds(optarg, bounds);
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%lf", &speedmin);
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%lf", &timegap);
-			flag++;
 			break;
 		case 'U':
 		case 'u':
@@ -1147,7 +1127,6 @@ int main(int argc, char **argv) {
 				if (check_values < MBLIST_CHECK_ON || check_values > MBLIST_CHECK_OFF_FLAGNAN)
 					check_values = MBLIST_CHECK_ON;
 			}
-			flag++;
 			break;
 		case 'W':
 		case 'w':
@@ -1167,7 +1146,6 @@ int main(int argc, char **argv) {
 				segment_mode = MBLIST_SEGMENT_MODE_DATALIST;
 			else
 				segment_mode = MBLIST_SEGMENT_MODE_TAG;
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbmosaic.c
+++ b/src/utilities/mbmosaic.c
@@ -1046,7 +1046,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -1290,12 +1289,10 @@ int main(int argc, char **argv) {
 			sscanf(optarg, "%d", &datatype);
 			if (optarg[1] == 'f' || optarg[1] == 'F')
 				usefiltered = MB_YES;
-			flag++;
 			break;
 		case 'B':
 		case 'b':
 			sscanf(optarg, "%lf", &border);
-			flag++;
 			break;
 		case 'C':
 		case 'c':
@@ -1314,7 +1311,6 @@ int main(int argc, char **argv) {
 			if (n < 3) {
 				tension = 0.0;
 			}
-			flag++;
 			break;
 		}
 		case 'D':
@@ -1323,7 +1319,6 @@ int main(int argc, char **argv) {
 			const int n = sscanf(optarg, "%d/%d", &xdim, &ydim);
 			if (n == 2)
 				set_dimensions = MB_YES;
-			flag++;
 			break;
 		}
 		case 'E':
@@ -1338,14 +1333,12 @@ int main(int argc, char **argv) {
 				set_spacing = MB_YES;
 			if (n < 3)
 				strcpy(units, "meters");
-			flag++;
 			break;
 		}
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%lf/%d", &priority_range, &weight_priorities);
 			grid_mode = MBMOSAIC_AVERAGE;
-			flag++;
 			break;
 		case 'G':
 		case 'g':
@@ -1364,7 +1357,6 @@ int main(int argc, char **argv) {
 					gridkind = MBMOSAIC_GMTGRD;
 				}
 			}
-			flag++;
 			break;
 		case 'H':
 		case 'h':
@@ -1373,38 +1365,31 @@ int main(int argc, char **argv) {
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", filelist);
-			flag++;
 			break;
 		case 'J':
 		case 'j':
 			sscanf(optarg, "%s", projection_pars);
 			projection_pars_f = MB_YES;
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			more = MB_YES;
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			use_NaN = MB_YES;
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", fileroot);
-			flag++;
 			break;
 		case 'P':
 		case 'p':
 			sscanf(optarg, "%d", &pings);
-			flag++;
 			break;
 		case 'R':
 		case 'r':
@@ -1417,18 +1402,15 @@ int main(int argc, char **argv) {
 				mb_get_bounds(optarg, gbnd);
 				gbndset = MB_YES;
 			}
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%lf", &speedmin);
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%s", topogridfile);
 			usetopogrid = MB_YES;
-			flag++;
 			break;
 		case 'U':
 		case 'u':
@@ -1446,7 +1428,6 @@ int main(int argc, char **argv) {
 				if ((priority_mode & MBMOSAIC_PRIORITY_AZIMUTH) == 0)
 					priority_mode += MBMOSAIC_PRIORITY_AZIMUTH;
 			}
-			flag++;
 			break;
 		}
 		case 'V':
@@ -1456,12 +1437,10 @@ int main(int argc, char **argv) {
 		case 'W':
 		case 'w':
 			sscanf(optarg, "%lf", &scale);
-			flag++;
 			break;
 		case 'X':
 		case 'x':
 			sscanf(optarg, "%lf", &extend);
-			flag++;
 			break;
 		case 'Y':
 		case 'y':
@@ -1515,7 +1494,6 @@ int main(int argc, char **argv) {
 		case 'Z':
 		case 'z':
 			sscanf(optarg, "%lf", &altitude_default);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbnavlist.c
+++ b/src/utilities/mbnavlist.c
@@ -113,7 +113,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -270,60 +269,49 @@ int main(int argc, char **argv) {
 		case 'A':
 		case 'a':
 			ascii = MB_NO;
-			flag++;
 			break;
 		case 'B':
 		case 'b':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &btime_i[0], &btime_i[1], &btime_i[2], &btime_i[3], &btime_i[4], &btime_i[5]);
 			btime_i[6] = 0;
-			flag++;
 			break;
 		case 'D':
 		case 'd':
 			sscanf(optarg, "%d", &decimate);
-			flag++;
 			break;
 		case 'E':
 		case 'e':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &etime_i[0], &etime_i[1], &etime_i[2], &etime_i[3], &etime_i[4], &etime_i[5]);
 			etime_i[6] = 0;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
 			sscanf(optarg, "%s", delimiter);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'J':
 		case 'j':
 			sscanf(optarg, "%s", projection_pars);
 			use_projection = MB_YES;
-			flag++;
 			break;
 		case 'K':
 		case 'k':
 			sscanf(optarg, "%d", &data_kind);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			sscanf(optarg, "%d", &aux_nav_channel);
-			flag++;
 			break;
 		case 'O':
 		case 'o':
@@ -333,22 +321,18 @@ int main(int argc, char **argv) {
 					if (list[n_list] == '^')
 						use_projection = MB_YES;
 				}
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			mb_get_bounds(optarg, bounds);
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%lf", &speedmin);
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%lf", &timegap);
-			flag++;
 			break;
 		case 'Z':
 		case 'z':
@@ -360,7 +344,6 @@ int main(int argc, char **argv) {
 				segment_mode = MBNAVLIST_SEGMENT_MODE_DATALIST;
 			else
 				segment_mode = MBNAVLIST_SEGMENT_MODE_TAG;
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbneptune2esf.c
+++ b/src/utilities/mbneptune2esf.c
@@ -301,7 +301,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int status;
@@ -456,28 +455,23 @@ int main(int argc, char **argv) {
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			sscanf(optarg, "%d", &mode);
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", output_file);
 			output_file_set = MB_YES;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			sscanf(optarg, "%s", rulesfile);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbprocess.c
+++ b/src/utilities/mbprocess.c
@@ -434,7 +434,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -779,45 +778,37 @@ int main(int argc, char **argv) {
 		case 'V':
 		case 'v':
 			verbose++;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
 			mbp_format_specified = MB_YES;
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			mbp_ifile_specified = MB_YES;
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			strip_comments = MB_YES;
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			mbp_ofile_specified = MB_YES;
 			sscanf(optarg, "%s", mbp_ofile);
-			flag++;
 			break;
 		case 'P':
 		case 'p':
 			checkuptodate = MB_NO;
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			printfilestatus = MB_YES;
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			testonly = MB_YES;
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbps.c
+++ b/src/utilities/mbps.c
@@ -77,7 +77,6 @@ int main(int argc, char **argv) {
 	int errflg = 0;
 	int c;
 	int help = 0;
-	int flag = 0;
 
 	/*ALBERTO definitions */
 	int gap = 1;
@@ -191,86 +190,70 @@ int main(int argc, char **argv) {
 		case 'A':
 		case 'a':
 			sscanf(optarg, "%lf", &alpha);
-			flag++;
 			break;
 		case 'B':
 		case 'b':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &btime_i[0], &btime_i[1], &btime_i[2], &btime_i[3], &btime_i[4], &btime_i[5]);
 			btime_i[6] = 0;
-			flag++;
 			break;
 		case 'D':
 		case 'd':
 			sscanf(optarg, "%c", &viewdir);
-			flag++;
 			break;
 		case 'E':
 		case 'e':
 			sscanf(optarg, "%d/%d/%d/%d/%d/%d", &etime_i[0], &etime_i[1], &etime_i[2], &etime_i[3], &etime_i[4], &etime_i[5]);
 			etime_i[6] = 0;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
 			sscanf(optarg, "%d", &gap);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", file);
-			flag++;
 			break;
 		case 'K':
 		case 'k':
 			sscanf(optarg, "%lf", &eta);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			sscanf(optarg, "%d", &num_pings_max);
 			if (num_pings_max < 2 || num_pings_max > MBPS_MAXPINGS)
 				num_pings_max = MBPS_MAXPINGS;
-			flag++;
 			break;
 		case 'P':
 		case 'p':
 			sscanf(optarg, "%d", &pings);
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%lf", &speedmin);
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%s", title);
-			flag++;
 			break;
 		case 'X':
 		case 'x':
 			sscanf(optarg, "%lf", &ve);
-			flag++;
 			break;
 		case 'W':
 		case 'w':
 			sscanf(optarg, "%lf", &meters_per_inch);
-			flag++;
 			break;
 		case 'Y':
 		case 'y':
 			display_stats = MB_NO;
-			flag++;
 			break;
 		case 'Z':
 		case 'z':
 			display_scales = MB_NO;
-			flag++;
 			break;
 		case '?':
 			errflg++;

--- a/src/utilities/mbrollbias.c
+++ b/src/utilities/mbrollbias.c
@@ -216,7 +216,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -346,32 +345,26 @@ int main(int argc, char **argv) {
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			mb_get_bounds(optarg, bounds);
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d/%d", &iformat, &jformat);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", ifile);
-			flag++;
 			break;
 		case 'J':
 		case 'j':
 			sscanf(optarg, "%s", jfile);
-			flag++;
 			break;
 		case 'D':
 		case 'd':
 			sscanf(optarg, "%d/%d", &xdim, &ydim);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbrolltimelag.c
+++ b/src/utilities/mbrolltimelag.c
@@ -54,7 +54,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -171,45 +170,37 @@ int main(int argc, char **argv) {
 		case 'C':
 		case 'c':
 			sscanf(optarg, "%lf", &rthreshold);
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", swathdata);
-			flag++;
 			break;
 		case 'K':
 		case 'k':
 			sscanf(optarg, "%d", &kind);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			sscanf(optarg, "%d", &npings);
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", outroot);
 			outroot_defined = MB_YES;
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%d", &navchannel);
 			if (navchannel > 0)
 				kind = MB_DATA_NONE;
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			sscanf(optarg, "%d/%lf/%lf", &nlag, &lagstart, &lagend);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbroutetime.c
+++ b/src/utilities/mbroutetime.c
@@ -57,7 +57,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -164,28 +163,23 @@ int main(int argc, char **argv) {
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", output_file);
 			output_file_set = MB_YES;
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			sscanf(optarg, "%s", route_file);
-			flag++;
 			break;
 		case 'U':
 		case 'u':
 			sscanf(optarg, "%lf", &rangethreshold);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbrphsbias.c
+++ b/src/utilities/mbrphsbias.c
@@ -100,7 +100,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int status;
@@ -243,24 +242,20 @@ int main(int argc, char **argv) {
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'R':
 		case 'r':
 			mb_get_bounds(optarg, areabounds);
 			areaboundsset = MB_YES;
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%lf", &binsize);
 			binsizeset = MB_YES;
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbsegygrid.c
+++ b/src/utilities/mbsegygrid.c
@@ -209,7 +209,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -355,7 +354,6 @@ int main(int argc, char **argv) {
 			const int n = sscanf(optarg, "%lf/%lf", &shotscale, &timescale);
 			if (n == 2)
 				scale2distance = MB_YES;
-			flag++;
 			break;
 		}
 		case 'B':
@@ -365,7 +363,6 @@ int main(int argc, char **argv) {
 			if (n < 2)
 				agcwindow = 0.0;
 			agcmode = MB_YES;
-			flag++;
 			break;
 		}
 		case 'C':
@@ -374,18 +371,15 @@ int main(int argc, char **argv) {
 			const int n = sscanf(optarg, "%d", &geometrymode);
 			if (n < 1)
 				geometrymode = MBSEGYGRID_GEOMETRY_VERTICAL;
-			flag++;
 			break;
 		}
 		case 'D':
 		case 'd':
 			/* n = */ sscanf(optarg, "%d/%d", &decimatex, &decimatey);
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			/* n = */ sscanf(optarg, "%d/%lf", &filtermode, &filterwindow);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
@@ -395,18 +389,15 @@ int main(int argc, char **argv) {
 				gaindelay = 0.0;
 			if (n < 3)
 				gainwindow = 0.0;
-			flag++;
 			break;
 		}
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", segyfile);
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", fileroot);
-			flag++;
 			break;
 		case 'R':
 		case 'r':
@@ -422,7 +413,6 @@ int main(int argc, char **argv) {
 				endlon = 0.0;
 				endlat = 0.0;
 			}
-			flag++;
 			break;
 		}
 		case 'S':
@@ -443,7 +433,6 @@ int main(int argc, char **argv) {
             else {
                 tracemode_set = MB_YES;
             }
-			flag++;
 			break;
 		}
 		case 'T':
@@ -452,13 +441,11 @@ int main(int argc, char **argv) {
 			const int n = sscanf(optarg, "%lf/%lf", &timesweep, &timedelay);
 			if (n < 2)
 				timedelay = 0.0;
-			flag++;
 			break;
 		}
 		case 'W':
 		case 'w':
 			/* n = */ sscanf(optarg, "%d/%lf/%lf", &windowmode, &windowstart, &windowend);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbsegylist.c
+++ b/src/utilities/mbsegylist.c
@@ -155,7 +155,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -268,40 +267,33 @@ int main(int argc, char **argv) {
 		case 'A':
 		case 'a':
 			ascii = MB_NO;
-			flag++;
 			break;
 		case 'D':
 		case 'd':
 			sscanf(optarg, "%d", &decimate);
-			flag++;
 			break;
 		case 'G':
 		case 'g':
 			sscanf(optarg, "%s", delimiter);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", file);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			sscanf(optarg, "%d", &lonflip);
-			flag++;
 			break;
 		case 'O':
 		case 'o':
 			for (int j = 0, n_list = 0; j < (int)strlen(optarg); j++, n_list++)
 				if (n_list < MAX_OPTIONS)
 					list[n_list] = optarg[j];
-			flag++;
 			break;
 		case 'Z':
 		case 'z':
 			segment = MB_YES;
 			sscanf(optarg, "%s", segment_tag);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbsegypsd.c
+++ b/src/utilities/mbsegypsd.c
@@ -195,7 +195,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -311,33 +310,27 @@ int main(int argc, char **argv) {
 			n = sscanf(optarg, "%lf/%lf", &shotscale, &frequencyscale);
 			if (n == 2)
 				scale2distance = MB_YES;
-			flag++;
 			break;
 		case 'D':
 		case 'd':
 			n = sscanf(optarg, "%d", &decimatex);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", segyfile);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			logscale = MB_YES;
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			n = sscanf(optarg, "%d", &nfft);
-			flag++;
 			break;
 		case 'G':
 		case 'O':
 		case 'o':
 			sscanf(optarg, "%s", fileroot);
-			flag++;
 			break;
 		case 'S':
 		case 's':
@@ -353,19 +346,16 @@ int main(int argc, char **argv) {
 			if (n < 1) {
 				tracemode = MBSEGYPSD_USESHOT;
 			}
-			flag++;
 			break;
 		case 'T':
 		case 't':
 			n = sscanf(optarg, "%lf/%lf", &timesweep, &timedelay);
 			if (n < 2)
 				timedelay = 0.0;
-			flag++;
 			break;
 		case 'W':
 		case 'w':
 			n = sscanf(optarg, "%d/%lf/%lf", &windowmode, &windowstart, &windowend);
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbset.c
+++ b/src/utilities/mbset.c
@@ -66,7 +66,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 	int pargc = 0;
 	char **pargv = NULL;
 
@@ -115,27 +114,22 @@ int main(int argc, char **argv) {
 		case 'E':
 		case 'e':
 			explicit = MB_YES;
-			flag++;
 			break;
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'L':
 		case 'l':
 			lookforfiles++;
-			flag++;
 			break;
 		case 'N':
 		case 'n':
 			removembnavadjust++;
-			flag++;
 			break;
 		case 'P':
 		case 'p':
@@ -157,7 +151,6 @@ int main(int argc, char **argv) {
 				strcpy(pargv[pargc], optarg);
 				pargc++;
 			}
-			flag++;
 			break;
 		case '?':
 			errflg = true;

--- a/src/utilities/mbsvplist.c
+++ b/src/utilities/mbsvplist.c
@@ -82,7 +82,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int verbose = 0;
@@ -241,17 +240,14 @@ int main(int argc, char **argv) {
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &format);
-			flag++;
 			break;
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", read_file);
-			flag++;
 			break;
 		case 'M':
 		case 'm':
 			sscanf(optarg, "%d", &svp_printmode);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
@@ -272,7 +268,6 @@ int main(int argc, char **argv) {
 		case 'r':
 			mb_get_bounds(optarg, ssv_bounds);
 			ssv_bounds_set = MB_YES;
-			flag++;
 			break;
 		case 'S':
 		case 's':

--- a/src/utilities/mbsvpselect.c
+++ b/src/utilities/mbsvpselect.c
@@ -1482,7 +1482,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	int error = MB_ERROR_NO_ERROR;
 
@@ -1503,7 +1502,6 @@ int main(int argc, char **argv) {
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", datalist);
-			flag++;
 			break;
 		case 'N':
 		case 'n':
@@ -1563,12 +1561,10 @@ int main(int argc, char **argv) {
 					}
 				}
 			}
-			flag++;
 			break;
 		case 'S':
 		case 's':
 			sscanf(optarg, "%s", svplist);
-			flag++;
 			break;
 		case 'V':
 		case 'v':

--- a/src/utilities/mbswplspreprocess.c
+++ b/src/utilities/mbswplspreprocess.c
@@ -180,7 +180,6 @@ static void default_options(options *opts) {
 /*----------------------------------------------------------------------*/
 static int parse_options(int verbose, int argc, char **argv, options *opts, int *error) {
 	int c;
-	int flag = 0;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  function <%s> called\n", __func__);
@@ -204,7 +203,6 @@ static int parse_options(int verbose, int argc, char **argv, options *opts, int 
 		case 'F':
 		case 'f':
 			sscanf(optarg, "%d", &(opts->format));
-			flag++;
 			break;
 		case 'G':
 		case 'g':
@@ -217,13 +215,11 @@ static int parse_options(int verbose, int argc, char **argv, options *opts, int 
 		case 'I':
 		case 'i':
 			sscanf(optarg, "%s", &opts->read_file[0]);
-			flag++;
 			break;
 		case 'J':
 		case 'j':
 			sscanf(optarg, "%s", &opts->proj4command[0]);
 			opts->projection_set = MB_YES;
-			flag++;
 			break;
 		case 'N':
 		case 'n':
@@ -233,7 +229,6 @@ static int parse_options(int verbose, int argc, char **argv, options *opts, int 
 		case 'o':
 			sscanf(optarg, "%s", &opts->basename[0]);
 			opts->ofile_set = MB_YES;
-			flag++;
 			break;
 		case 'R':
 		case 'r':

--- a/src/utilities/mbvoxelclean.c
+++ b/src/utilities/mbvoxelclean.c
@@ -99,7 +99,6 @@ int main(int argc, char **argv) {
 	bool errflg = false;
 	int c;
 	bool help = false;
-	int flag = 0;
 
 	/* MBIO status variables */
 	int status;
@@ -325,13 +324,11 @@ int main(int argc, char **argv) {
 			/* input */
 			else if (strcmp("input", options[option_index].name) == 0) {
 				sscanf(optarg, "%s", read_file);
-				flag++;
 			}
 
 			/* format */
 			else if (strcmp("format", options[option_index].name) == 0) {
 				sscanf(optarg, "%d", &format);
-				flag++;
 			}
 
 			/* voxel-size */
@@ -345,50 +342,42 @@ int main(int argc, char **argv) {
                         voxel_size_z = d1;
                     }
                 }
-				flag++;
 			}
 
 			/* occupy-threshold */
 			else if (strcmp("occupy-threshold", options[option_index].name) == 0) {
 				sscanf(optarg, "%d", &occupy_threshold);
-				flag++;
 			}
 
 			/* count-flagged */
 			else if (strcmp("count-flagged", options[option_index].name) == 0) {
 				count_flagged = MB_YES;
-				flag++;
 			}
 
 			/* flag-empty */
 			else if (strcmp("flag-empty", options[option_index].name) == 0) {
 				empty_mode = MBVC_EMPTY_FLAG;
-				flag++;
 			}
 
 			/* ignore-empty */
 			else if (strcmp("ignore-empty", options[option_index].name) == 0) {
 				empty_mode = MBVC_EMPTY_IGNORE;
-				flag++;
 			}
 
 			/* unflag-occupied files */
 			else if (strcmp("unflag-occupied", options[option_index].name) == 0) {
 				occupied_mode = MBVC_OCCUPIED_UNFLAG;
-				flag++;
 			}
 
 			/* ignore-occupied */
 			else if (strcmp("ignore-occupied", options[option_index].name) == 0) {
 				occupied_mode = MBVC_OCCUPIED_IGNORE;
-				flag++;
 			}
 
 			/* range-minimum  */
 			else if (strcmp("range-minimum", options[option_index].name) == 0) {
 				apply_range_minimum = MB_YES;
 				sscanf(optarg, "%lf", &range_minimum);
-				flag++;
 			}
 
 			/* range-maximum */


### PR DESCRIPTION
Started with:

```#!bash
  perl -i -ne '/\tflag\+\+\;/ or print' *.c
  perl -i -ne '/ flag\+\+\;/ or print' *.c
  perl -i -ne '/int flag \=/ or print' *.c
```