### PR TITLE
utilities: Cleanup

### DIFF
--- a/src/utilities/mbclean.c
+++ b/src/utilities/mbclean.c
@@ -53,6 +53,7 @@
  * program mbclean (v. 1.0) by David Caress.
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/utilities/mbcopy.c
+++ b/src/utilities/mbcopy.c
@@ -25,6 +25,7 @@
 
 #include <getopt.h>
 #include <math.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/utilities/mbctdlist.c
+++ b/src/utilities/mbctdlist.c
@@ -29,6 +29,7 @@
 
 #include <getopt.h>
 #include <math.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/utilities/mbvoxelclean.c
+++ b/src/utilities/mbvoxelclean.c
@@ -43,6 +43,7 @@
 
 #include <getopt.h>
 #include <math.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
mbclean.c mbcopy.c mbctdlist.c mbswplspreprocess.c mbvoxelclean.c

- Add stdbool include for files that use true/false
  - grep -l false *.c  | xargs grep -L '#include <stdbool.h>'
- Localize vars
- Combine definition and initialization