### PR TITLE
mbio: misc cleanup

### DIFF
--- a/src/mbio/mbr_edgjstar.c
+++ b/src/mbio/mbr_edgjstar.c
@@ -238,6 +238,14 @@ int mbr_dem_edgjstar(int verbose, void *mbio_ptr, int *error) {
 }
 /*--------------------------------------------------------------------*/
 int mbr_rt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
+	if (verbose >= 2) {
+		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
+		fprintf(stderr, "dbg2  Input arguments:\n");
+		fprintf(stderr, "dbg2       verbose:    %d\n", verbose);
+		fprintf(stderr, "dbg2       mbio_ptr:   %p\n", (void *)mbio_ptr);
+		fprintf(stderr, "dbg2       store_ptr:  %p\n", (void *)store_ptr);
+	}
+
 	struct mbsys_jstar_message_struct message;
 	struct mbsys_jstar_channel_struct *sbp;
 	struct mbsys_jstar_channel_struct *ss;
@@ -246,11 +254,9 @@ int mbr_rt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	struct mbsys_jstar_dvl_struct *dvl;
 	struct mbsys_jstar_pressure_struct *pressure;
 	struct mbsys_jstar_sysinfo_struct *sysinfo;
-    struct mbsys_jstar_filetimestamp_struct *filetimestamp;
+	struct mbsys_jstar_filetimestamp_struct *filetimestamp;
 	struct mbsys_jstar_comment_struct *comment;
 	struct mbsys_jstar_ssold_struct ssold_tmp;
-	char buffer[MBSYS_JSTAR_SYSINFO_MAX];
-	char nmeastring[MB_COMMENT_MAXLINE];
 	int index;
 	int read_status;
 	int shortspersample;
@@ -266,14 +272,6 @@ int mbr_rt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	double depthofsensor, offset;
 	char **nap, *nargv[25], *string;
 	int nargc;
-
-	if (verbose >= 2) {
-		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
-		fprintf(stderr, "dbg2  Input arguments:\n");
-		fprintf(stderr, "dbg2       verbose:    %d\n", verbose);
-		fprintf(stderr, "dbg2       mbio_ptr:   %p\n", (void *)mbio_ptr);
-		fprintf(stderr, "dbg2       store_ptr:  %p\n", (void *)store_ptr);
-	}
 
 	/* get pointer to mbio descriptor */
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
@@ -301,6 +299,7 @@ int mbr_rt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	bool done = false;
 	while (!done) {
 		/* read message header */
+		char buffer[MBSYS_JSTAR_SYSINFO_MAX];
 		if ((read_status = fread(buffer, MBSYS_JSTAR_MESSAGE_SIZE, 1, mb_io_ptr->mbfp)) == 1) {
 			/* extract the message header values */
 			index = 0;
@@ -1498,6 +1497,7 @@ int mbr_rt_edgjstar(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 					index++;
 				}
 				nmea->nmea[message.size - 12] = 0;
+				char nmeastring[MB_COMMENT_MAXLINE];
 				strcpy(nmeastring, nmea->nmea);
 
 				time_d = ((double)nmea->seconds) + 0.001 * ((double)nmea->milliseconds);

--- a/src/mbio/mbr_kemkmall.c
+++ b/src/mbio/mbr_kemkmall.c
@@ -114,9 +114,6 @@ int mbr_info_kemkmall(int verbose, int *system, int *beams_bath_max, int *beams_
 }
 /*--------------------------------------------------------------------*/
 int mbr_alm_kemkmall(int verbose, void *mbio_ptr, int *error) {
-  char **bufferptr = NULL;
-  int *bufferalloc = NULL;
-
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
     fprintf(stderr, "dbg2  Input arguments:\n");
@@ -136,8 +133,8 @@ int mbr_alm_kemkmall(int verbose, void *mbio_ptr, int *error) {
   int status = mbsys_kmbes_alloc(verbose, mbio_ptr, &mb_io_ptr->store_data, error);
 
   /* allocate starting memory for data record buffer */
-  bufferptr = (char **)&mb_io_ptr->raw_data;
-  bufferalloc = (int *)&mb_io_ptr->structure_size;
+  char **bufferptr = (char **)&mb_io_ptr->raw_data;
+  int *bufferalloc = (int *)&mb_io_ptr->structure_size;
 
   *bufferptr = NULL;
   *bufferalloc = 0;
@@ -3686,6 +3683,13 @@ int mbr_kemkmall_index_data(int verbose, void *mbio_ptr, void *store_ptr, int *e
 /*--------------------------------------------------------------------*/
 
 int mbr_kemkmall_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
+  if (verbose >= 2) {
+    fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
+    fprintf(stderr, "dbg2  Input arguments:\n");
+    fprintf(stderr, "dbg2       verbose:    %d\n", verbose);
+    fprintf(stderr, "dbg2       mbio_ptr:   %p\n", (void *)mbio_ptr);
+    fprintf(stderr, "dbg2       store_ptr:  %p\n", (void *)store_ptr);
+  }
   struct mbsys_kmbes_index_table *dgm_index_table = NULL;
   struct mbsys_kmbes_index *dgm_index = NULL;
   struct mbsys_kmbes_header header;
@@ -3694,17 +3698,8 @@ int mbr_kemkmall_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
   char *buffer = NULL;
   int *bufferalloc = NULL;
   int *dgm_id = NULL;
-  int done = false;
   int jmrz, jmwc, jxmt, isounding;
   int numSoundings, numBackscatterSamples;
-
-  if (verbose >= 2) {
-    fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
-    fprintf(stderr, "dbg2  Input arguments:\n");
-    fprintf(stderr, "dbg2       verbose:    %d\n", verbose);
-    fprintf(stderr, "dbg2       mbio_ptr:   %p\n", (void *)mbio_ptr);
-    fprintf(stderr, "dbg2       store_ptr:  %p\n", (void *)store_ptr);
-  }
 
   /* get pointer to mbio descriptor */
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
@@ -3726,6 +3721,7 @@ int mbr_kemkmall_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
   *error = MB_ERROR_NO_ERROR;
 
   /* check index to see if more datagrams can be read */
+  bool done = false;
   if (mb_io_ptr->mbfp != NULL) {
     if (*dgm_id < dgm_index_table->dgm_count) {
       done = false;

--- a/src/mbio/mbsys_elacmk2.c
+++ b/src/mbio/mbsys_elacmk2.c
@@ -21,8 +21,6 @@
  *
  * Author:	D. W. Caress
  * Date:	August 20, 1994
- *
- *
  */
 
 #include <math.h>
@@ -178,8 +176,6 @@ int mbsys_elacmk2_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 }
 /*--------------------------------------------------------------------*/
 int mbsys_elacmk2_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-	int status = MB_SUCCESS;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -189,7 +185,7 @@ int mbsys_elacmk2_deall(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);
@@ -256,8 +252,6 @@ int mbsys_elacmk2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
                           double *navlat, double *speed, double *heading, int *nbath, int *namp, int *nss, char *beamflag,
                           double *bath, double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss,
                           double *ssacrosstrack, double *ssalongtrack, char *comment, int *error) {
-	double depthscale, dacrscale, daloscale, reflscale;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -305,10 +299,10 @@ int mbsys_elacmk2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		*nbath = store->beams_bath;
 		*namp = store->beams_bath;
 		*nss = 0;
-		depthscale = 0.01;
-		dacrscale = -0.01;
-		daloscale = 0.01;
-		reflscale = 1.0;
+		double depthscale = 0.01;
+		double dacrscale = -0.01;
+		double daloscale = 0.01;
+		double reflscale = 1.0;
 		for (int i = 0; i < store->beams_bath; i++) {
 			const int j = store->beams_bath - i - 1;
 			if (store->beams[j].quality == 1)
@@ -467,8 +461,6 @@ int mbsys_elacmk2_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
                          double navlat, double speed, double heading, int nbath, int namp, int nss, char *beamflag, double *bath,
                          double *amp, double *bathacrosstrack, double *bathalongtrack, double *ss, double *ssacrosstrack,
                          double *ssalongtrack, char *comment, int *error) {
-	double depthscale, dacrscale, daloscale, reflscale;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -540,10 +532,10 @@ int mbsys_elacmk2_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
 
 		/* insert distance and depth values into storage arrays */
 		if (store->beams_bath == nbath) {
-			depthscale = 0.01;
-			dacrscale = -0.01;
-			daloscale = 0.01;
-			reflscale = 1.0;
+			double depthscale = 0.01;
+			double dacrscale = -0.01;
+			double daloscale = 0.01;
+			double reflscale = 1.0;
 			for (int i = 0; i < store->beams_bath; i++) {
 				const int j = store->beams_bath - i - 1;
 				if (mb_beam_check_flag(beamflag[i])) {

--- a/src/mbio/mbsys_gsf.c
+++ b/src/mbio/mbsys_gsf.c
@@ -21,8 +21,6 @@
  *
  * Author:	D. W. Caress
  * Date:	March 5, 1998
- *
- *
  */
 
 #include <math.h>
@@ -38,8 +36,6 @@
 
 /*--------------------------------------------------------------------*/
 int mbsys_gsf_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-	int status = MB_SUCCESS;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -51,7 +47,7 @@ int mbsys_gsf_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_gsf_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_gsf_struct), store_ptr, error);
 	memset(*store_ptr, 0, sizeof(struct mbsys_gsf_struct));
 
 	if (verbose >= 2) {
@@ -93,7 +89,6 @@ int mbsys_gsf_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 }
 /*--------------------------------------------------------------------*/
 int mbsys_gsf_dimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbath, int *namp, int *nss, int *error) {
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");

--- a/src/mbio/mbsys_hdcs.c
+++ b/src/mbio/mbsys_hdcs.c
@@ -19,8 +19,6 @@
  *
  * Author:	D. W. Caress
  * Date:	March 16, 1999
- *
- *
  */
 
 #include <math.h>

--- a/src/mbio/mbsys_hs10.c
+++ b/src/mbio/mbsys_hs10.c
@@ -21,8 +21,6 @@
  *
  * Author:	D. W. Caress
  * Date:	December 4, 2000
- *
- *
  */
 
 #include <math.h>
@@ -37,8 +35,6 @@
 
 /*--------------------------------------------------------------------*/
 int mbsys_hs10_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-	int status = MB_SUCCESS;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -50,7 +46,7 @@ int mbsys_hs10_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_hs10_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_hs10_struct), store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);

--- a/src/mbio/mbsys_hsds.c
+++ b/src/mbio/mbsys_hsds.c
@@ -24,7 +24,6 @@
  *
  * Author:	D. W. Caress
  * Date:	March 2, 1993
- *
  */
 
 #include <math.h>
@@ -39,8 +38,6 @@
 
 /*--------------------------------------------------------------------*/
 int mbsys_hsds_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-	int status = MB_SUCCESS;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -52,7 +49,7 @@ int mbsys_hsds_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_hsds_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_hsds_struct), store_ptr, error);
 	memset(*store_ptr, 0, sizeof(struct mbsys_hsds_struct));
 
 	if (verbose >= 2) {
@@ -68,8 +65,6 @@ int mbsys_hsds_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 }
 /*--------------------------------------------------------------------*/
 int mbsys_hsds_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-	int status = MB_SUCCESS;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -79,7 +74,7 @@ int mbsys_hsds_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);

--- a/src/mbio/mbsys_hsmd.c
+++ b/src/mbio/mbsys_hsmd.c
@@ -23,8 +23,6 @@
  *
  * Author:	Dale Chayes
  * Date:	August 10, 1995
- *
- *
  */
 
 #include <math.h>
@@ -65,8 +63,6 @@ int mbsys_hsmd_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 }
 /*--------------------------------------------------------------------*/
 int mbsys_hsmd_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-	int status = MB_SUCCESS;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -76,7 +72,7 @@ int mbsys_hsmd_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);

--- a/src/mbio/mbsys_hysweep.c
+++ b/src/mbio/mbsys_hysweep.c
@@ -19,7 +19,6 @@
  *
  * Author:	D. W. Caress
  * Date:	December 23, 2011
- *
  */
 
 #include "mbsys_hysweep.h"

--- a/src/mbio/mbsys_image83p.c
+++ b/src/mbio/mbsys_image83p.c
@@ -20,13 +20,9 @@
  *      MBF_IMAGE83P : MBIO ID 191
  *      MBF_IMAGEMBA : MBIO ID 192
  *
- *
  * Author:	Vivek Reddy, Santa Clara University
  *       	D.W. Caress
  * Date:	May 5, 2008
- *
- *
- *
  */
 
 #include <math.h>

--- a/src/mbio/mbsys_jstar.c
+++ b/src/mbio/mbsys_jstar.c
@@ -21,7 +21,6 @@
  *
  * Author:	D. W. Caress
  * Date:	May 4, 2005
- *
  */
 
 #include <assert.h>

--- a/src/mbio/mbsys_ldeoih.c
+++ b/src/mbio/mbsys_ldeoih.c
@@ -20,7 +20,6 @@
  *
  * Author:  D. W. Caress
  * Date:  February 26, 1993
- *
  */
 
 #include <math.h>
@@ -102,7 +101,6 @@ int mbsys_ldeoih_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error
 }
 /*--------------------------------------------------------------------*/
 int mbsys_ldeoih_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
     fprintf(stderr, "dbg2  Input arguments:\n");

--- a/src/mbio/mbsys_mr1.c
+++ b/src/mbio/mbsys_mr1.c
@@ -20,8 +20,6 @@
  *
  * Author:	D. W. Caress
  * Date:	July 19, 1994
- *
- *
  */
 
 #include <math.h>
@@ -37,8 +35,6 @@
 
 /*--------------------------------------------------------------------*/
 int mbsys_mr1_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-	int status = MB_SUCCESS;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -50,7 +46,7 @@ int mbsys_mr1_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_mr1_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_mr1_struct), store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);
@@ -65,8 +61,6 @@ int mbsys_mr1_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 }
 /*--------------------------------------------------------------------*/
 int mbsys_mr1_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-	int status = MB_SUCCESS;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -76,7 +70,7 @@ int mbsys_mr1_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);

--- a/src/mbio/mbsys_mr1b.c
+++ b/src/mbio/mbsys_mr1b.c
@@ -20,9 +20,6 @@
  *
  * Author:	D. W. Caress
  * Date:	July 19, 1994
- *
- *
- *
  */
 
 #include <math.h>
@@ -38,8 +35,6 @@
 
 /*--------------------------------------------------------------------*/
 int mbsys_mr1b_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-	int status = MB_SUCCESS;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -51,7 +46,7 @@ int mbsys_mr1b_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 	struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
 	/* allocate memory for data structure */
-	status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_mr1b_struct), store_ptr, error);
+	const int status = mb_mallocd(verbose, __FILE__, __LINE__, sizeof(struct mbsys_mr1b_struct), store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);
@@ -66,8 +61,6 @@ int mbsys_mr1b_alloc(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 }
 /*--------------------------------------------------------------------*/
 int mbsys_mr1b_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) {
-	int status = MB_SUCCESS;
-
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
 		fprintf(stderr, "dbg2  Input arguments:\n");
@@ -77,7 +70,7 @@ int mbsys_mr1b_deall(int verbose, void *mbio_ptr, void **store_ptr, int *error) 
 	}
 
 	/* deallocate memory for data structure */
-	status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
+	const int status = mb_freed(verbose, __FILE__, __LINE__, (void **)store_ptr, error);
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);

--- a/src/mbio/mbsys_singlebeam.c
+++ b/src/mbio/mbsys_singlebeam.c
@@ -26,8 +26,6 @@
  *
  * Author:	D. W. Caress
  * Date:	April 13,  1999
- *
- *
  */
 
 #include <math.h>

--- a/src/mbio/mbsys_swathplus.c
+++ b/src/mbio/mbsys_swathplus.c
@@ -20,12 +20,11 @@
  *
  * Author:	David Finlayson and D. W. Caress
  * Date:	Aug 29, 2013
- *
- *
  */
 
 #include <assert.h>
 #include <math.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/mbio/mbsys_xse.c
+++ b/src/mbio/mbsys_xse.c
@@ -25,11 +25,10 @@
  * Author:	D. W. Caress
  * Date:	August 1,  1999
  * Additional Authors:	P. A. Cohen and S. Dzurenko
- *
- *
  */
 
 #include <math.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
mbr_edgjstar.c mbr_kemkmall.c mbsys_elacmk2.c mbsys_gsf.c mbsys_hdcs.c
mbsys_hs10.c mbsys_hsds.c mbsys_hsmd.c mbsys_hysweep.c
mbsys_image83p.c mbsys_jstar.c mbsys_ldeoih.c mbsys_mr1.c mbsys_mr1b.c
mbsys_singlebeam.c mbsys_swathplus.c mbsys_xse.c

- Localize variables / move "MBIO function <%s> called\n", __func__" debugging print to front of functions
- Remove extra comment lines
- Add const
- Add include of stdbool