### PR TITLE
mb7k2jstar.c mbcopy.c: Initialize string buffers.

### DIFF
--- a/src/utilities/mb7k2jstar.c
+++ b/src/utilities/mb7k2jstar.c
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
 	char output_file[MB_PATH_MAXLINE+12] = "";
 	bool output_file_set = false;
 
-	char route_file[MB_PATH_MAXLINE];
+	char route_file[MB_PATH_MAXLINE] = "";
 	bool route_file_set = false;
 
 	int smooth = 0;

--- a/src/utilities/mbcopy.c
+++ b/src/utilities/mbcopy.c
@@ -1762,7 +1762,7 @@ int main(int argc, char **argv) {
   /* MBIO merge control parameters */
   bool merge = false;
   int mformat = 0;
-  char mfile[MB_PATH_MAXLINE];
+  char mfile[MB_PATH_MAXLINE] = "";
   int mbeams_bath;
   int mbeams_amp;
   int mpixels_ss;


### PR DESCRIPTION
route_file and mfile showed up on debian testing with just -O2 (no -g)
as junk in the debug print messages.