### PR TITLE
utilities: Cleanup in prep for converting C to C++

### DIFF
--- a/src/utilities/mb7kpreprocess.c
+++ b/src/utilities/mb7kpreprocess.c
@@ -1235,9 +1235,11 @@ int main(int argc, char **argv) {
 		 * set sensor 0 (multibeam) for a single first offsets are
 		 * for transmit array, second for receive array
 		 */
-		if (status == MB_SUCCESS)
-			status = mb_platform_add_sensor(verbose, (void *)platform, MB_SENSOR_TYPE_SONAR_MULTIBEAM, NULL, "Reson", NULL,
+		if (status == MB_SUCCESS) {
+			mb_longname manufacturer = "Reson";
+			status = mb_platform_add_sensor(verbose, (void *)platform, MB_SENSOR_TYPE_SONAR_MULTIBEAM, NULL, manufacturer, NULL,
 			                                MB_SENSOR_CAPABILITY1_NONE, MB_SENSOR_CAPABILITY2_TOPOGRAPHY_MULTIBEAM, 2, 0, &error);
+		}
 		if (status == MB_SUCCESS)
 			status =
 			    mb_platform_set_sensor_offset(verbose, (void *)platform, 0, 0, multibeam_offset_mode, mbtransmit_offset_x,
@@ -2801,7 +2803,7 @@ int main(int argc, char **argv) {
 					    time_i[0], time_i[1], time_i[2], time_i[3], time_i[4], time_i[5], time_i[6], header->RecordNumber);
 
 				if (platform == NULL) {
-					status = mb_extract_platform(verbose, imbio_ptr, istore_ptr, &kind, (void *)&platform, &error);
+					status = mb_extract_platform(verbose, imbio_ptr, istore_ptr, &kind, (void **)&platform, &error);
 
 					/* deal with error */
 					if (status == MB_FAILURE) {

--- a/src/utilities/mbareaclean.c
+++ b/src/utilities/mbareaclean.c
@@ -1051,7 +1051,7 @@ int main(int argc, char **argv) {
 				/* apply median filter only if there are enough soundings */
 				if (binnum >= median_filter_nmin) {
 					/* run qsort */
-					qsort((void *)bindepths, binnum, sizeof(double), (void *)mb_double_compare);
+					qsort((void *)bindepths, binnum, sizeof(double), mb_double_compare);
 					const double median_depth = bindepths[binnum / 2];
 					double median_depth_low;
 					double median_depth_high;

--- a/src/utilities/mbclean.c
+++ b/src/utilities/mbclean.c
@@ -1322,7 +1322,7 @@ int main(int argc, char **argv) {
                     }
                   }
                 }
-                qsort((char *)list, nlist, sizeof(double), (void *)mb_double_compare);
+                qsort((char *)list, nlist, sizeof(double), mb_double_compare);
                 median = list[nlist / 2];
                 if (verbose >= 2) {
                   fprintf(stderr, "\ndbg2  depth statistics:\n");

--- a/src/utilities/mbfilter.c
+++ b/src/utilities/mbfilter.c
@@ -260,7 +260,7 @@ int hipass_median(int verbose, int n, double *val, double *wgt, double *hipass) 
 
 	/* sort values and get median value */
 	if (n > 0) {
-		qsort((char *)val, n, sizeof(double), (void *)mb_double_compare);
+		qsort((char *)val, n, sizeof(double), mb_double_compare);
 		*hipass = val[0] - val[n / 2];
 	}
 
@@ -374,7 +374,7 @@ int smooth_median(int verbose, double original, bool apply_threshold, double thr
 
 	/* sort values and get median value */
 	if (n > 0) {
-		qsort((char *)val, n, sizeof(double), (void *)mb_double_compare);
+		qsort((char *)val, n, sizeof(double), mb_double_compare);
 		*smooth = val[n / 2];
 	}
 

--- a/src/utilities/mbgrid.c
+++ b/src/utilities/mbgrid.c
@@ -3366,7 +3366,7 @@ int main(int argc, char **argv) {
 				kgrid = i * gydim + j;
 				if (cnt[kgrid] > 0) {
 					value = data[kgrid];
-					qsort((char *)value, cnt[kgrid], sizeof(double), (void *)mb_double_compare);
+					qsort((char *)value, cnt[kgrid], sizeof(double), mb_double_compare);
 					// TODO(schwehr): grid_mode always has to be MBGRID_MEDIAN_FILTER here.
 					if (grid_mode == MBGRID_MEDIAN_FILTER) {
 						grid[kgrid] = value[cnt[kgrid] / 2];

--- a/src/utilities/mbkongsbergpreprocess.c
+++ b/src/utilities/mbkongsbergpreprocess.c
@@ -1477,7 +1477,7 @@ int main(int argc, char **argv) {
 						nmedian++;
 					}
 					if (nmedian > 0) {
-						qsort((char *)median, nmedian, sizeof(double), (void *)mb_double_compare);
+						qsort((char *)median, nmedian, sizeof(double), mb_double_compare);
 						dat_sonardepth_sonardepthfilter[i] = median[nmedian / 2];
 					}
 				}
@@ -1536,7 +1536,7 @@ int main(int argc, char **argv) {
 						nmedian++;
 					}
 					if (nmedian > 0) {
-						qsort((char *)median, nmedian, sizeof(double), (void *)mb_double_compare);
+						qsort((char *)median, nmedian, sizeof(double), mb_double_compare);
 						dat_sonardepth_sonardepthfilter[i] = median[nmedian / 2];
 					}
 				}

--- a/src/utilities/mbnavlist.c
+++ b/src/utilities/mbnavlist.c
@@ -729,6 +729,7 @@ int main(int argc, char **argv) {
 								break;
 							case 'm': /* time in decimal seconds since
 							        first record */
+							{
 								if (first_m) {
 									time_d_ref = time_d;
 									first_m = false;
@@ -736,6 +737,7 @@ int main(int argc, char **argv) {
 								double b = time_d - time_d_ref;
 								printsimplevalue(verbose, b, 0, 6, ascii, &invert_next_value, &signflip_next_value, &error);
 								break;
+							}
 							case 'P': /* pitch */
 								printsimplevalue(verbose, pitch, 6, 3, ascii, &invert_next_value, &signflip_next_value, &error);
 								break;
@@ -757,11 +759,11 @@ int main(int argc, char **argv) {
 								break;
 							case 'T': /* yyyy/mm/dd/hh/mm/ss time string */
 								seconds = time_i[5] + 1e-6 * time_i[6];
-								if (ascii)
+								if (ascii) {
 									printf("%.4d/%.2d/%.2d/%.2d/%.2d/%9.6f", time_i[0], time_i[1], time_i[2], time_i[3],
 									       time_i[4], seconds);
-								else {
-									b = time_i[0];
+								} else {
+									double b = time_i[0];
 									fwrite(&b, sizeof(double), 1, stdout);
 									b = time_i[1];
 									fwrite(&b, sizeof(double), 1, stdout);
@@ -777,11 +779,11 @@ int main(int argc, char **argv) {
 								break;
 							case 't': /* yyyy mm dd hh mm ss time string */
 								seconds = time_i[5] + 1e-6 * time_i[6];
-								if (ascii)
+								if (ascii) {
 									printf("%.4d %.2d %.2d %.2d %.2d %9.6f", time_i[0], time_i[1], time_i[2], time_i[3],
 									       time_i[4], seconds);
-								else {
-									b = time_i[0];
+								} else {
+									double b = time_i[0];
 									fwrite(&b, sizeof(double), 1, stdout);
 									b = time_i[1];
 									fwrite(&b, sizeof(double), 1, stdout);
@@ -797,10 +799,10 @@ int main(int argc, char **argv) {
 								break;
 							case 'U': /* unix time in seconds since 1/1/70 00:00:00 */
 								time_u = (int)time_d;
-								if (ascii)
+								if (ascii) {
 									printf("%ld", time_u);
-								else {
-									b = time_u;
+								} else {
+									double b = time_u;
 									fwrite(&b, sizeof(double), 1, stdout);
 								}
 								break;
@@ -810,10 +812,10 @@ int main(int argc, char **argv) {
 									time_u_ref = time_u;
 									first_u = false;
 								}
-								if (ascii)
+								if (ascii) {
 									printf("%ld", time_u - time_u_ref);
-								else {
-									b = time_u - time_u_ref;
+								} else {
+									double b = time_u - time_u_ref;
 									fwrite(&b, sizeof(double), 1, stdout);
 								}
 								break;
@@ -855,9 +857,8 @@ int main(int argc, char **argv) {
 								minutes = 60.0 * (dlon - degrees);
 								if (ascii) {
 									printf("%3d %11.8f%c", degrees, minutes, hemi);
-								}
-								else {
-									b = degrees;
+								} else {
+									double b = degrees;
 									if (hemi == 'W')
 										b = -b;
 									fwrite(&b, sizeof(double), 1, stdout);
@@ -870,8 +871,7 @@ int main(int argc, char **argv) {
 									dlat = navlat;
 									printsimplevalue(verbose, dlat, 15, 10, ascii, &invert_next_value, &signflip_next_value,
 									                 &error);
-								}
-								else {
+								} else {
 									const double dnorthing = navnorthing;
 									printsimplevalue(verbose, dnorthing, 15, 3, ascii, &invert_next_value, &signflip_next_value,
 									                 &error);
@@ -883,16 +883,15 @@ int main(int argc, char **argv) {
 								if (dlat < 0.0) {
 									hemi = 'S';
 									dlat = -dlat;
-								}
-								else
+								} else {
 									hemi = 'N';
+								}
 								degrees = (int)dlat;
 								minutes = 60.0 * (dlat - degrees);
 								if (ascii) {
 									printf("%3d %11.8f%c", degrees, minutes, hemi);
-								}
-								else {
-									b = degrees;
+								} else {
+									double b = degrees;
 									if (hemi == 'S')
 										b = -b;
 									fwrite(&b, sizeof(double), 1, stdout);

--- a/src/utilities/mbsvpselect.c
+++ b/src/utilities/mbsvpselect.c
@@ -733,7 +733,7 @@ int read_recursive2(char *fname) {
 		return counter;
 	}
 
-	char *ret = strchr(result, ' ');
+	const char *ret = strchr(result, ' ');
 	if (ret == NULL) {
 		char file2[1024] = {""};
 		my_strcpy(file2, original);
@@ -968,11 +968,12 @@ void read_list(char *list, char *list_2) {
 		if (p_flag == 0) {
 			switch (inf_hold[i].flag) {
 			case 0:
+			{
 				if (verbose == 1) {
 					puts("\n\n========N check passed no 0.0 position was found===========\n\n");
 					printf("\nCalculating the distances to all svp profiles for %s\n", inf_hold[i].file_name);
 				}
-				double temp_dist = 0;
+				double temp_dist = 0.0;
 				for (int j = 0; j < size_2; j++) {
 					geod_inverse(&g, inf_hold[i].ave_lat, inf_hold[i].ave_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
 					             &azi1, &azi2);
@@ -1010,13 +1011,16 @@ void read_list(char *list, char *list_2) {
 				printf("%s\n", all_in_sys);
 				/* int shellstatus = */ system(all_in_sys);
 				break;
+			}
 			case 1:
+			{
 				if (verbose == 1) {
 					puts("\n\n=====================N check:   0.0 position was found=====================\n\n");
 					printf("\nThe file %s has no navigation information at the start position and the svp profile will be "
 					       "assigned to the end point of the file\n",
 					       inf_hold[i].file_name);
 				}
+				double temp_dist = 0.0;
 				for (int j = 0; j < size_2; j++) {
 					geod_inverse(&g, inf_hold[i].s_lat, inf_hold[i].s_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
 					             &azi1, &azi2);
@@ -1054,13 +1058,16 @@ void read_list(char *list, char *list_2) {
 				printf("%s\n", all_in_sys);
 				/* int shellstatus = */ system(all_in_sys);
 				break;
+			}
 			case 2:
+			{
 				if (verbose == 1) {
 					puts("\n\n==============N check:   0.0 position was found===================\n\n");
 					printf("\nThe file %s has no navigation information at the end position and the svp profile will be assigned "
 					       "to the start point of the file\n",
 					       inf_hold[i].file_name);
 				}
+				double temp_dist = 0.0;
 				for (int j = 0; j < size_2; j++) {
 					geod_inverse(&g, inf_hold[i].e_lat, inf_hold[i].e_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
 					             &azi1, &azi2);
@@ -1097,7 +1104,9 @@ void read_list(char *list, char *list_2) {
 				/* int shellstatus = */ system(all_in_sys);
 				fprintf(fresult, "%s\n", "=============================================================");
 				break;
+			}
 			case 3:
+			{
 				if (verbose == 1) {
 					puts("\n\n==============N check:   0.0 position was found====================\n\n");
 					printf("\n!!!The file %s has no navigation information and no svp will be assigned to it!!!\n",
@@ -1107,12 +1116,12 @@ void read_list(char *list, char *list_2) {
 					fprintf(fresult, "%s\n", "NaN");
 				}
 				break;
+			}
 
 			default:
 				break;
 			} /* switch */
-		}
-		else {
+		} else {
 			if (p_flag == 1) /* calculate the nearest in time */
 			{
 				if (verbose == 1) {
@@ -1163,8 +1172,8 @@ void read_list(char *list, char *list_2) {
 					printf("\nCalculating the nearest svp in position within %d time period for for %s\n", p_3_time,
 					       inf_hold[i].file_name);
 				}
-				double temp_dist = 0;
-				double temp_dist2 = 0;
+				double temp_dist = 0.0;
+				double temp_dist2 = 0.0;
 				int count = 0;
 				int n_pos_time = 0;
 				int n_pos = 0;
@@ -1437,11 +1446,8 @@ void read_list(char *list, char *list_2) {
 int main(int argc, char **argv) {
 	int error = MB_ERROR_NO_ERROR;
 
-	char datalist[BUFSIZ];
-	char svplist[BUFSIZ];
-
-	my_strcpy(datalist, "datalist.mb-1");
-	my_strcpy(svplist, "svplist.mb-1");
+	char datalist[BUFSIZ] = "datalist.mb-1";
+	char svplist[BUFSIZ] = "svplist.mb-1";
 
 	{
 		bool errflg = false;


### PR DESCRIPTION
- Remove (void*) cast from mb_double_compare in qsort calls
  mb_double_compare has the correct signature
- Fix the cast in calling mb_extract_platform()
- C++ doesn't allow writable string literals
- Combine definition and initialization of strings
- Initialize double with a double literal
- Create a scope inside of case to localize variable declaration
- strchr returns a const char *