### PR TITLE
mb_buffer.c: Reenable found checks and set kind to MB_DATA_NONE when there is an error

### DIFF
--- a/src/mbio/mb_buffer.c
+++ b/src/mbio/mb_buffer.c
@@ -495,7 +495,7 @@ int mb_buffer_get_next_data(int verbose, void *buff_ptr, void *mbio_ptr, int sta
 	}
 
 	/* extract the data */
-	/* if (found) */ {
+	if (found) {
 		char comment[200];
 		int kind;
 		status = mb_buffer_extract(verbose, buff_ptr, mbio_ptr, *id, &kind, time_i, time_d, navlon, navlat, speed, heading, nbath,
@@ -584,7 +584,7 @@ int mb_buffer_get_next_nav(int verbose, void *buff_ptr, void *mbio_ptr, int star
 	}
 
 	/* extract the data */
-	/* if (found) */ {
+	if (found) {
 		int kind;
 		status = mb_buffer_extract_nav(verbose, buff_ptr, mbio_ptr, *id, &kind, time_i, time_d, navlon, navlat, speed, heading,
 		                               draft, roll, pitch, heave, error);
@@ -642,10 +642,10 @@ int mb_buffer_extract(int verbose, void *buff_ptr, void *mbio_ptr, int id, int *
 	int status = MB_SUCCESS;
 	char *store_ptr = NULL;
 	if (id < 0 || id >= buff->nbuffer) {
+		*kind = MB_DATA_NONE;
 		status = MB_FAILURE;
 		*error = MB_ERROR_BAD_BUFFER_ID;
-	}
-	else {
+	} else {
 		store_ptr = buff->buffer[id];
 		*kind = buff->buffer_kind[id];
 		*error = MB_ERROR_NO_ERROR;
@@ -729,10 +729,10 @@ int mb_buffer_extract_nav(int verbose, void *buff_ptr, void *mbio_ptr, int id, i
 	int status = MB_SUCCESS;
 	char *store_ptr;
 	if (id < 0 || id >= buff->nbuffer) {
+		*kind = MB_DATA_NONE;
 		status = MB_FAILURE;
 		*error = MB_ERROR_BAD_BUFFER_ID;
-	}
-	else {
+	} else {
 		store_ptr = buff->buffer[id];
 		*kind = buff->buffer_kind[id];
 		*error = MB_ERROR_NO_ERROR;


### PR DESCRIPTION


Issues found with clang static analyzer (CSA) version 9.

This is my first use of CSA on MB-System, so here is what the command
and warnings look like:

```
scan-build-9 make mb_buffer.lo

mb_buffer.c:492:3: warning: Value stored to 'status' is never read
                status = MB_FAILURE;
                ^        ~~~~~~~~~~
mb_buffer.c:581:3: warning: Value stored to 'status' is never read
                status = MB_FAILURE;
                ^        ~~~~~~~~~~
mb_buffer.c:664:3: warning: 3rd function call argument is an uninitialized value
                fprintf(stderr, "dbg2       kind:       %d\n", *kind);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mb_buffer.c:750:3: warning: 3rd function call argument is an uninitialized value
                fprintf(stderr, "dbg2       kind:       %d\n", *kind);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```