### PR TITLE
Move merror.h include from mb_io.h to mbtrnpp.c.

### DIFF
--- a/src/mbio/mb_io.h
+++ b/src/mbio/mb_io.h
@@ -28,14 +28,6 @@
 #include "mb_status.h"
 #include "mb_process.h"
 
-#ifdef MBTRN_ENABLED
-#include "r7k-reader.h"
-#include "r7kc.h"
-#include "msocket.h"
-#include "mfile.h"
-#include "merror.h"
-#endif
-
 /* ---------------------------------------------------------------------------*/
 /* Survey Platform definitions and structures for the
  * mb_platform_*() functions */

--- a/src/mbtrnutils/mbtrnpp.c
+++ b/src/mbtrnutils/mbtrnpp.c
@@ -44,6 +44,7 @@
 #include "mbsys_ldeoih.h"
 #include "mbsys_kmbes.h"
 
+#include "merror.h"
 #include "mconfig.h"
 #include "r7kc.h"
 #include "msocket.h"


### PR DESCRIPTION
Based on include-what-you-use (IWYU), mb_io.h should not have anything
from mbtrn.  Of all the mbtrn includes in mb_io.h, only merror.h was
needed in mbtrnpp.c.

Found while trying to add a test for mb_read_init() in #795