### PR TITLE
mb_time.c: Basic range check of the time_i inputs to mb_get_time.

### DIFF
--- a/src/mbio/mb_time.c
+++ b/src/mbio/mb_time.c
@@ -48,6 +48,26 @@ int mb_get_time(int verbose, int time_i[7], double *time_d) {
 		fprintf(stderr, "dbg2       *time_d: %f\n", *time_d);
 	}
 
+	const int year = time_i[0];
+	const int month = time_i[1];
+	const int day = time_i[2];
+	const int hour = time_i[3];
+	const int minute = time_i[4];
+	const int second = time_i[5];
+	const int microsec = time_i[6];
+
+	// See http://www.cplusplus.com/reference/ctime/tm/
+	if (year < 1930 || year > 3000 ||
+	    month < 1 || month > 12 ||
+	    day < 1 || day > 31 ||
+	    hour < 0 || hour > 23 ||
+	    minute < 0 || minute > 59 ||
+	    second < 0 || second > 59 ||  // Do not handle leap seconds
+	    microsec < 0 || microsec > 999999) {
+		fprintf(stderr, "ERROR: invalid time\n");
+		return MB_FAILURE;
+	}
+
 	/* get time */
 	int yearday = yday[time_i[1] - 1];
 	if (((time_i[0] % 4 == 0 && time_i[0] % 100 != 0) || time_i[0] % 400 == 0) && (time_i[1] > 2))

--- a/test/mbio/mb_time_test.cc
+++ b/test/mbio/mb_time_test.cc
@@ -80,6 +80,76 @@ TEST(MbGetTime, Positive) {
   EXPECT_DOUBLE_EQ(1515506236.1370959, t);
 }
 
+TEST(MbGetTime, Invalid) {
+  const double expected_t = -1.0;
+  double t = expected_t;
+  // Year
+  {
+    int time[7] = {1929, 1, 9, 13, 57, 16, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  {
+    int time[7] = {3001, 1, 9, 13, 57, 16, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  // Month
+  {
+    int time[7] = {2018, 0, 9, 13, 57, 16, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  {
+    int time[7] = {2018, 13, 9, 13, 57, 16, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  // Day
+  {
+    int time[7] = {2018, 1, 0, 13, 57, 16, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  {
+    int time[7] = {2018, 1, 32, 13, 57, 16, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  // Hour
+  {
+    int time[7] = {2018, 1, 9, -1, 57, 16, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  {
+    int time[7] = {2018, 1, 9, 24, 57, 16, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  // Minute
+  {
+    int time[7] = {2018, 1, 9, 13, -1, 16, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  {
+    int time[7] = {2018, 1, 9, 13, 60, 16, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  // Second
+  {
+    int time[7] = {2018, 1, 9, 13, 57, -1, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  {
+    int time[7] = {2018, 1, 9, 13, 57, 60, 137096};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  // Microsec
+  {
+    int time[7] = {2018, 1, 9, 13, 57, 16, -1};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  {
+    int time[7] = {2018, 1, 9, 13, 57, 16, 1000000};
+    EXPECT_EQ(MB_FAILURE, mb_get_time(0, time, &t));
+  }
+  // t is unchanged
+  EXPECT_EQ(expected_t, t);
+}
+
 TEST(MbGetDate, Basic) {
   double t = 0.0;
   int time[7] = {-1, -1, -1, -1, -1, -1, -1};


### PR DESCRIPTION
It is certainly possible to catch more invalid times than this and it
will flag leap seconds as bad.  This will prevent a buffer overflow of yday.

It's not clear what the time input is supposed to be.  Is it UTC, UT1, GPS,
or other?

- https://www.nist.gov/pml/time-and-frequency-division/nist-time-frequently-asked-questions-- faq
http://leapsecond.com/java/gpsclock.htm

Fixes #794