### PR TITLE
Trying to fix build problem for mbsvpselect between proj4 and proj6

### DIFF
--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -613,6 +613,11 @@ int mb_proj_init(int verbose, char *projection, void **pjptr, int *error);
 int mb_proj_free(int verbose, void **pjptr, int *error);
 int mb_proj_forward(int verbose, void *pjptr, double lon, double lat, double *easting, double *northing, int *error);
 int mb_proj_inverse(int verbose, void *pjptr, double easting, double northing, double *lon, double *lat, int *error);
+int mb_geod_init(int verbose, double radius_equatorial, double flattening, void **g_ptr, int *error);
+int mb_geod_free(int verbose, void **g_ptr, int *error);
+int mb_geod_inverse(int verbose, void *g_ptr,
+                    double lat1, double lon1, double lat2, double lon2,
+                    double *distance, double *azimuth1, double *azimuth2, int *error);
 
 /* mb_spline function prototypes */
 int mb_spline_init(int verbose, const double *x, const double *y, int n, double yp1, double ypn, double *y2, int *error);

--- a/src/utilities/mbsvpselect.cc
+++ b/src/utilities/mbsvpselect.cc
@@ -951,15 +951,20 @@ void read_list(char *list, char *list_2) {
 			       "interpretation \n");
 	}
 	int n = 0;
-	struct geod_geodesic g;
+	//struct geod_geodesic g;
+  // isolated geod calls into mb_geod functions in mb_proj.c - DWC January 11, 2020
+  void *g_ptr = nullptr;
 	double azi1, azi2;
+  int error = MB_ERROR_NO_ERROR;
 
   // WGS84 ellipsoid parameters
   const double radius_equatorial = 6378137.0;
   const double radius_polar = 6356752.314245;
   const double flattening = 0.00335281066;
 
-	geod_init(&g, radius_equatorial, flattening);
+	//geod_init(&g, radius_equatorial, flattening);
+  // isolated geod calls into mb_geod functions in mb_proj.c - DWC January 11, 2020
+  mb_geod_init(verbose, radius_equatorial, flattening, &g_ptr, &error);
 	size = surveyLines_total;
 	for (int i = 0; i < size; i++) {
 #ifdef _WIN32
@@ -980,8 +985,11 @@ void read_list(char *list, char *list_2) {
 				}
 				double temp_dist = 0.0;
 				for (int j = 0; j < size_2; j++) {
-					geod_inverse(&g, inf_hold[i].ave_lat, inf_hold[i].ave_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
-					             &azi1, &azi2);
+					//geod_inverse(&g, inf_hold[i].ave_lat, inf_hold[i].ave_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
+					//             &azi1, &azi2);
+					mb_geod_inverse(verbose, g_ptr, inf_hold[i].ave_lat, inf_hold[i].ave_lon,
+                          svp_hold[j].s_lat, svp_hold[j].s_lon,
+                          &dist[0][j], &azi1, &azi2, &error);
 					if (j == 0) {
 						temp_dist = dist[0][j];
 					}
@@ -1027,8 +1035,11 @@ void read_list(char *list, char *list_2) {
 				}
 				double temp_dist = 0.0;
 				for (int j = 0; j < size_2; j++) {
-					geod_inverse(&g, inf_hold[i].s_lat, inf_hold[i].s_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
-					             &azi1, &azi2);
+					//geod_inverse(&g, inf_hold[i].s_lat, inf_hold[i].s_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
+					//             &azi1, &azi2);
+					mb_geod_inverse(verbose, g_ptr, inf_hold[i].s_lat, inf_hold[i].s_lon,
+                        svp_hold[j].s_lat, svp_hold[j].s_lon,
+                        &dist[0][j], &azi1, &azi2, &error);
 					if (j == 0) {
 						temp_dist = dist[0][j];
 					}
@@ -1074,8 +1085,11 @@ void read_list(char *list, char *list_2) {
 				}
 				double temp_dist = 0.0;
 				for (int j = 0; j < size_2; j++) {
-					geod_inverse(&g, inf_hold[i].e_lat, inf_hold[i].e_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
-					             &azi1, &azi2);
+					//geod_inverse(&g, inf_hold[i].e_lat, inf_hold[i].e_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
+					//             &azi1, &azi2);
+					mb_geod_inverse(verbose, g_ptr, inf_hold[i].e_lat, inf_hold[i].e_lon,
+                          svp_hold[j].s_lat, svp_hold[j].s_lon,
+                          &dist[0][j], &azi1, &azi2, &error);
 					if (j == 0) {
 						temp_dist = dist[0][j];
 					}
@@ -1187,8 +1201,11 @@ void read_list(char *list, char *list_2) {
 
 					/* dist[i][j] = distVincenty(inf_hold[i].ave_lat, inf_hold[i].ave_lon,
 					 svp_hold[j].s_lat, svp_hold[j].s_lon); */
-					geod_inverse(&g, inf_hold[i].ave_lat, inf_hold[i].ave_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
-					             &azi1, &azi2);
+					//geod_inverse(&g, inf_hold[i].ave_lat, inf_hold[i].ave_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
+					//             &azi1, &azi2);
+					mb_geod_inverse(verbose, g_ptr, inf_hold[i].ave_lat, inf_hold[i].ave_lon,
+                          svp_hold[j].s_lat, svp_hold[j].s_lon,
+                          &dist[0][j], &azi1, &azi2, &error);
 					if (verbose == 1)
 						printf("Time difference number %d is : %lf\n", j, time_hold[0][j]);
 					printf("position difference number %d is : %lf\n", j, dist[0][j]);
@@ -1282,8 +1299,11 @@ void read_list(char *list, char *list_2) {
 					min_hold[0][j] = abs(inf_hold[i].s_datum_time.tm_min - svp_hold[j].svp_datum_time.tm_min);
 					time_hold[0][j] = fabs(difftime(inf_hold[i].s_Time, svp_hold[j].svp_Time));
 					// processing distance differences
-					geod_inverse(&g, inf_hold[i].ave_lat, inf_hold[i].ave_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
-					             &azi1, &azi2);
+					//geod_inverse(&g, inf_hold[i].ave_lat, inf_hold[i].ave_lon, svp_hold[j].s_lat, svp_hold[j].s_lon, &dist[0][j],
+					//             &azi1, &azi2);
+					mb_geod_inverse(verbose, g_ptr, inf_hold[i].ave_lat, inf_hold[i].ave_lon,
+                          svp_hold[j].s_lat, svp_hold[j].s_lon,
+                          &dist[0][j], &azi1, &azi2, &error);
 					dist[0][j] -= p_4_range;
 					// if the SVP is within the range
 					puts("==================================================");
@@ -1440,6 +1460,7 @@ void read_list(char *list, char *list_2) {
 			}
 		}
 	}
+  mb_geod_free(verbose, &g_ptr, &error);
 	free(inf_hold);
 	free(svp_hold);
 	fclose(fDatalist);


### PR DESCRIPTION
Build failed on Centos 7 w/ proj 4.8 due to lack of proj header file geodesic.h.
The proposed fix is to isolate the geod_*() calls into mb_proj.c and use the existing #ifdef structure there to handle using proj 4 or 6. The new mb_geod_*() functions have been added to mb_proj.c, mb_define.h and arc now called by mbsvpselect.