### PR TITLE
mbstripnan.cc: isnan -> std::isnan and minor cleanup

### DIFF
--- a/src/deprecated/mbstripnan.cc
+++ b/src/deprecated/mbstripnan.cc
@@ -22,14 +22,10 @@
  * MBARI
  */
 
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
 #include <unistd.h>
-
-#if defined(_WIN32) && !defined(isnan)
-#define isnan(x) _isnan(x)
-#endif
 
 struct node {
 	double lon;
@@ -44,10 +40,10 @@ int main() {
 	struct node n;
         const size_t chunk = sizeof(n);
 	while ((fread(&n, chunk, 1, stdin) != chunk)) {
-		if (isnan(n.lon) || isnan(n.lat) || isnan(n.height)) {
+		if (std::isnan(n.lon) || std::isnan(n.lat) || std::isnan(n.height)) {
 			continue;
 		}
 		fwrite(&n, chunk, 1, stdout);
 	}
-	exit(0);
+	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Based on issue found in PR #830 building on centos.
Why the old version is working, it's best to go ahead
and make the code correct since it's simple fix.
Converted the C headers to C++, removed the windows hack,
and converted exit(0) to EXIT_SUCCESS.