### PR TITLE
Prepping for release 5.7.6beta24

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,7 +22,7 @@ and each distribution corresponds to a discrete Github release tag. Releases tha
 include "beta" in the tag name are preliminary and generally not announced.
 Distributions that do not include "beta" in the tag name correspond to the major,
 announced releases.
-- Version 5.7.6beta23    January 15, 2020
+- Version 5.7.6beta24    January 16, 2020
 - Version 5.7.6beta23    January 11, 2020
 - Version 5.7.6beta21    December 12, 2019
 - Version 5.7.6beta20    November 26, 2019
@@ -339,7 +339,7 @@ MB-SYSTEM VERSION 5.7 RELEASE NOTES:
 
 -------------------------------------------------------------------------------
 
------> 5.7.6beta24 (January 15, 2020)
+-----> 5.7.6beta24 (January 16, 2020)
 
 Build system: The configure.ac file now uses the AX_CXX_COMPILE_STDCXX(11) macro
 to require that the code conform to the C++11 standard. Some preprocessor

--- a/configure
+++ b/configure
@@ -3766,7 +3766,7 @@ $as_echo "#define HAVE_CXX11 1" >>confdefs.h
 
 
 
-$as_echo "#define VERSION_DATE \"15 January 2020\"" >>confdefs.h
+$as_echo "#define VERSION_DATE \"16 January 2020\"" >>confdefs.h
 
 
 ac_aux_dir=
@@ -19640,9 +19640,9 @@ if test "$GOT_PROJ" = "yes" ; then
         $as_echo "PROJ library location specified: $proj_libdir - check if libproj is there..."
     save_LDFLAGS=$LDFLAGS
     LDFLAGS="$LDFLAGS -L$proj_libdir"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for proj_create in -lproj" >&5
-$as_echo_n "checking for proj_create in -lproj... " >&6; }
-if ${ac_cv_lib_proj_proj_create+:} false; then :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for proj_normalize_for_visualization in -lproj" >&5
+$as_echo_n "checking for proj_normalize_for_visualization in -lproj... " >&6; }
+if ${ac_cv_lib_proj_proj_normalize_for_visualization+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
@@ -19656,27 +19656,27 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char proj_create ();
+char proj_normalize_for_visualization ();
 int
 main ()
 {
-return proj_create ();
+return proj_normalize_for_visualization ();
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_proj_proj_create=yes
+  ac_cv_lib_proj_proj_normalize_for_visualization=yes
 else
-  ac_cv_lib_proj_proj_create=no
+  ac_cv_lib_proj_proj_normalize_for_visualization=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_proj_proj_create" >&5
-$as_echo "$ac_cv_lib_proj_proj_create" >&6; }
-if test "x$ac_cv_lib_proj_proj_create" = xyes; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_proj_proj_normalize_for_visualization" >&5
+$as_echo "$ac_cv_lib_proj_proj_normalize_for_visualization" >&6; }
+if test "x$ac_cv_lib_proj_proj_normalize_for_visualization" = xyes; then :
   FOUND_PROJ_LIB=yes
 else
   FOUND_PROJ_LIB=no
@@ -19684,7 +19684,7 @@ fi
 
     if test "$FOUND_PROJ_LIB" = "yes"; then
         FOUND_PROJ6=yes
-        $as_echo "Found PROJ 5/6 library libproj"
+        $as_echo "Found PROJ library libproj from version 6.1 or later"
     else
         { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pj_init_plus in -lproj" >&5
 $as_echo_n "checking for pj_init_plus in -lproj... " >&6; }
@@ -19730,7 +19730,7 @@ fi
 
         if test "$FOUND_PROJ_LIB" = "yes"; then
             FOUND_PROJ4=yes
-            $as_echo "Found PROJ 4 library libproj"
+            $as_echo "Found PROJ library libproj with PROJ4 api available"
         fi
     fi
     if test "$FOUND_PROJ_LIB" = "no"; then
@@ -19932,9 +19932,9 @@ else
 $as_echo "yes" >&6; }
 	FOUND_PROJ_LIB=yes
 fi
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for proj_create in -lproj" >&5
-$as_echo_n "checking for proj_create in -lproj... " >&6; }
-if ${ac_cv_lib_proj_proj_create+:} false; then :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for proj_normalize_for_visualization in -lproj" >&5
+$as_echo_n "checking for proj_normalize_for_visualization in -lproj... " >&6; }
+if ${ac_cv_lib_proj_proj_normalize_for_visualization+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
@@ -19948,27 +19948,27 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char proj_create ();
+char proj_normalize_for_visualization ();
 int
 main ()
 {
-return proj_create ();
+return proj_normalize_for_visualization ();
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_proj_proj_create=yes
+  ac_cv_lib_proj_proj_normalize_for_visualization=yes
 else
-  ac_cv_lib_proj_proj_create=no
+  ac_cv_lib_proj_proj_normalize_for_visualization=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_proj_proj_create" >&5
-$as_echo "$ac_cv_lib_proj_proj_create" >&6; }
-if test "x$ac_cv_lib_proj_proj_create" = xyes; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_proj_proj_normalize_for_visualization" >&5
+$as_echo "$ac_cv_lib_proj_proj_normalize_for_visualization" >&6; }
+if test "x$ac_cv_lib_proj_proj_normalize_for_visualization" = xyes; then :
   FOUND_PROJ_LIB=yes
 else
   FOUND_PROJ_LIB=no
@@ -19976,7 +19976,7 @@ fi
 
     if test "$FOUND_PROJ_LIB" = "yes"; then
         FOUND_PROJ6=yes
-        $as_echo "Found PROJ 5/6 library libproj"
+        $as_echo "Found PROJ library libproj from version 6.1 or later"
     else
         { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pj_init_plus in -lproj" >&5
 $as_echo_n "checking for pj_init_plus in -lproj... " >&6; }
@@ -20022,7 +20022,7 @@ fi
 
         if test "$FOUND_PROJ_LIB" = "yes"; then
             FOUND_PROJ4=yes
-            $as_echo "Found PROJ 4 library libproj"
+            $as_echo "Found PROJ library libproj with PROJ4 api available"
         fi
     fi
     if test "$FOUND_PROJ_LIB" = "no"; then
@@ -20033,9 +20033,9 @@ fi
 fi
 if test "$FOUND_PROJ_LIB" = "no" ; then
         $as_echo "Did not find PROJ library pkg-config package, looking in the other usual places..."
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for proj_create in -lproj" >&5
-$as_echo_n "checking for proj_create in -lproj... " >&6; }
-if ${ac_cv_lib_proj_proj_create+:} false; then :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for proj_normalize_for_visualization in -lproj" >&5
+$as_echo_n "checking for proj_normalize_for_visualization in -lproj... " >&6; }
+if ${ac_cv_lib_proj_proj_normalize_for_visualization+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
@@ -20049,27 +20049,27 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char proj_create ();
+char proj_normalize_for_visualization ();
 int
 main ()
 {
-return proj_create ();
+return proj_normalize_for_visualization ();
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_proj_proj_create=yes
+  ac_cv_lib_proj_proj_normalize_for_visualization=yes
 else
-  ac_cv_lib_proj_proj_create=no
+  ac_cv_lib_proj_proj_normalize_for_visualization=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_proj_proj_create" >&5
-$as_echo "$ac_cv_lib_proj_proj_create" >&6; }
-if test "x$ac_cv_lib_proj_proj_create" = xyes; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_proj_proj_normalize_for_visualization" >&5
+$as_echo "$ac_cv_lib_proj_proj_normalize_for_visualization" >&6; }
+if test "x$ac_cv_lib_proj_proj_normalize_for_visualization" = xyes; then :
   FOUND_PROJ_LIB=yes
 else
   FOUND_PROJ_LIB=no
@@ -20077,7 +20077,7 @@ fi
 
     if test "$FOUND_PROJ_LIB" = "yes"; then
       FOUND_PROJ6=yes
-      $as_echo "Found PROJ 5/6 library libproj"
+      $as_echo "Found PROJ library libproj from version 6.1 or later"
     else
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pj_init_plus in -lproj" >&5
 $as_echo_n "checking for pj_init_plus in -lproj... " >&6; }
@@ -20123,7 +20123,7 @@ fi
 
       if test "$FOUND_PROJ_LIB" = "yes" ; then
         FOUND_PROJ4=yes
-        $as_echo "Found PROJ 4 library libproj"
+        $as_echo "Found PROJ library libproj with PROJ4 api available"
       fi
     fi
     if test "$FOUND_PROJ_LIB" = "yes" ; then
@@ -20179,7 +20179,7 @@ fi
 FOUND_PROJ_HEADERS="no"
 if test "$FOUND_PROJ_HEADER_projh" = "yes"; then
     FOUND_PROJ_HEADERS="yes"
-  $as_echo "Found PROJ header proj.h"
+  $as_echo "Found PROJ 5/6 header proj.h"
 fi
 ac_fn_c_check_header_mongrel "$LINENO" "proj_api.h" "ac_cv_header_proj_api_h" "$ac_includes_default"
 if test "x$ac_cv_header_proj_api_h" = xyes; then :
@@ -20191,7 +20191,7 @@ fi
 
 if test "$FOUND_PROJ_HEADER_proj_apih" = "yes"; then
   FOUND_PROJ_HEADERS="yes"
-  $as_echo "Found PROJ header proj_api.h"
+  $as_echo "Found PROJ 4 header proj_api.h"
 fi
 if test "$FOUND_PROJ_HEADERS" = "no" ; then
   if test "$GOT_PROJ" = "yes" ; then
@@ -24317,9 +24317,9 @@ else
     $as_echo "Byteswapping: Disabled"
 fi
 if test $FOUND_PROJ6 = yes; then
-    $as_echo "PROJ: Using PROJ 5/6 API"
+    $as_echo "PROJ: Using PROJ library libproj with version 6.1 or later API"
 else
-    $as_echo "PROJ: Using PROJ 4 API (will not build mbsvpselect)"
+    $as_echo "PROJ: Using PROJ library libproj with version 4 API (will not build mbsvpselect)"
 fi
 
 $as_echo "libgmt_CPPFLAGS:     $libgmt_CPPFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AC_LANG(C)
 dnl Require c++11
 AX_CXX_COMPILE_STDCXX(11)
 
-AC_DEFINE(VERSION_DATE, "15 January 2020", [Set VERSION_DATE define in mb_config.h])
+AC_DEFINE(VERSION_DATE, "16 January 2020", [Set VERSION_DATE define in mb_config.h])
 
 dnl Check system arch
 AC_CANONICAL_HOST
@@ -336,15 +336,15 @@ if test "$GOT_PROJ" = "yes" ; then
     AS_ECHO(["PROJ library location specified: $proj_libdir - check if libproj is there..."])
     save_LDFLAGS=$LDFLAGS
     LDFLAGS="$LDFLAGS -L$proj_libdir"
-    AC_CHECK_LIB([proj], [proj_create], [FOUND_PROJ_LIB=yes], [FOUND_PROJ_LIB=no], )
+    AC_CHECK_LIB([proj], [proj_normalize_for_visualization], [FOUND_PROJ_LIB=yes], [FOUND_PROJ_LIB=no], )
     if test "$FOUND_PROJ_LIB" = "yes"; then
         FOUND_PROJ6=yes
-        AS_ECHO(["Found PROJ 5/6 library libproj"])
+        AS_ECHO(["Found PROJ library libproj from version 6.1 or later"])
     else
         AC_CHECK_LIB([proj], [pj_init_plus], [FOUND_PROJ_LIB=yes], [FOUND_PROJ_LIB=no], )
         if test "$FOUND_PROJ_LIB" = "yes"; then
             FOUND_PROJ4=yes
-            AS_ECHO(["Found PROJ 4 library libproj"])
+            AS_ECHO(["Found PROJ library libproj with PROJ4 api available"])
         fi
     fi
     if test "$FOUND_PROJ_LIB" = "no"; then
@@ -357,15 +357,15 @@ else
     dnl Look for pkg-config PROJ package...
     AS_ECHO(["Look for pkg-config PROJ package..."])
     PKG_CHECK_MODULES([libproj], [proj], [FOUND_PROJ_LIB=yes], [FOUND_PROJ_LIB=no])
-    AC_CHECK_LIB([proj], [proj_create], [FOUND_PROJ_LIB=yes], [FOUND_PROJ_LIB=no], )
+    AC_CHECK_LIB([proj], [proj_normalize_for_visualization], [FOUND_PROJ_LIB=yes], [FOUND_PROJ_LIB=no], )
     if test "$FOUND_PROJ_LIB" = "yes"; then
         FOUND_PROJ6=yes
-        AS_ECHO(["Found PROJ 5/6 library libproj"])
+        AS_ECHO(["Found PROJ library libproj from version 6.1 or later"])
     else
         AC_CHECK_LIB([proj], [pj_init_plus], [FOUND_PROJ_LIB=yes], [FOUND_PROJ_LIB=no], )
         if test "$FOUND_PROJ_LIB" = "yes"; then
             FOUND_PROJ4=yes
-            AS_ECHO(["Found PROJ 4 library libproj"])
+            AS_ECHO(["Found PROJ library libproj with PROJ4 api available"])
         fi
     fi
     if test "$FOUND_PROJ_LIB" = "no"; then
@@ -377,15 +377,15 @@ fi
 if test "$FOUND_PROJ_LIB" = "no" ; then
     dnl Did not find PROJ library pkg-config package, looking in the other usual places...
     AS_ECHO(["Did not find PROJ library pkg-config package, looking in the other usual places..."])
-    AC_CHECK_LIB([proj], [proj_create], [FOUND_PROJ_LIB=yes], [FOUND_PROJ_LIB=no],)
+    AC_CHECK_LIB([proj], [proj_normalize_for_visualization], [FOUND_PROJ_LIB=yes], [FOUND_PROJ_LIB=no],)
     if test "$FOUND_PROJ_LIB" = "yes"; then
       FOUND_PROJ6=yes
-      AS_ECHO(["Found PROJ 5/6 library libproj"])
+      AS_ECHO(["Found PROJ library libproj from version 6.1 or later"])
     else
       AC_CHECK_LIB([proj], [pj_init_plus], [FOUND_PROJ_LIB=yes], [FOUND_PROJ_LIB=no], )
       if test "$FOUND_PROJ_LIB" = "yes" ; then
         FOUND_PROJ4=yes
-        AS_ECHO(["Found PROJ 4 library libproj"])
+        AS_ECHO(["Found PROJ library libproj with PROJ4 api available"])
       fi
     fi
     if test "$FOUND_PROJ_LIB" = "yes" ; then
@@ -427,12 +427,12 @@ FOUND_PROJ_HEADERS="no"
 if test "$FOUND_PROJ_HEADER_projh" = "yes"; then
   dnl Found PROJ6 headers
   FOUND_PROJ_HEADERS="yes"
-  AS_ECHO(["Found PROJ header proj.h"])
+  AS_ECHO(["Found PROJ 5/6 header proj.h"])
 fi
 AC_CHECK_HEADER(proj_api.h, [FOUND_PROJ_HEADER_proj_apih=yes], [FOUND_PROJ_HEADER_proj_apih=no],)
 if test "$FOUND_PROJ_HEADER_proj_apih" = "yes"; then
   FOUND_PROJ_HEADERS="yes"
-  AS_ECHO(["Found PROJ header proj_api.h"])
+  AS_ECHO(["Found PROJ 4 header proj_api.h"])
 fi
 if test "$FOUND_PROJ_HEADERS" = "no" ; then
   if test "$GOT_PROJ" = "yes" ; then
@@ -1101,9 +1101,9 @@ else
     AS_ECHO(["Byteswapping: Disabled"])
 fi
 if test $FOUND_PROJ6 = yes; then
-    AS_ECHO(["PROJ: Using PROJ 5/6 API"])
+    AS_ECHO(["PROJ: Using PROJ library libproj with version 6.1 or later API"])
 else
-    AS_ECHO(["PROJ: Using PROJ 4 API (will not build mbsvpselect)"])
+    AS_ECHO(["PROJ: Using PROJ library libproj with version 4 API (will not build mbsvpselect)"])
 fi
 
 AS_ECHO(["libgmt_CPPFLAGS:     $libgmt_CPPFLAGS"])

--- a/libtool
+++ b/libtool
@@ -1,6 +1,6 @@
 #! /bin/sh
 # Generated automatically by config.status (mbsystem) 5.7.6beta24
-# Libtool was configured on host haxby.shore.mbari.org:
+# Libtool was configured on host Haxby.local:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/src/mbio/mb_config.h
+++ b/src/mbio/mb_config.h
@@ -119,7 +119,7 @@
 #define VERSION "5.7.6beta24"
 
 /* Set VERSION_DATE define in mb_config.h */
-#define VERSION_DATE "15 January 2020"
+#define VERSION_DATE "16 January 2020"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/src/mbio/mb_proj.c
+++ b/src/mbio/mb_proj.c
@@ -47,6 +47,7 @@
 /*--------------------------------------------------------------------*/
 // If necessary use the obsolete PROJ 4 API
 #ifdef USE_PROJ4_API
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
 
 /*--------------------------------------------------------------------*/
 


### PR DESCRIPTION
Going back to approach in which MB-System starts using the Proj 6 API when the function proj_normalize_for_visualization() is available, which started with Proj release 6.1.0. If proj_normalize_for_visualization() is not available, MB-System will use the deprecated Proj 4 API. This effectively bypasses the API changes made for Proj releases 5.0 through 6.0.