### PR TITLE
Minor fixes to pass tests on Ubuntu Bionic/Xenial

### DIFF
--- a/src/utilities/mbctdlist.cc
+++ b/src/utilities/mbctdlist.cc
@@ -147,7 +147,7 @@ int main(int argc, char **argv) {
 	int decimate = 1;
 	char read_file[MB_PATH_MAXLINE] = "datalist.mb-1";
 	bool segment = false;
-	char segment_tag[MB_PATH_MAXLINE];
+	char segment_tag[MB_PATH_MAXLINE] = "\0";
 
 	{
 		bool errflg = false;

--- a/test/utilities/mbconfig_test.py
+++ b/test/utilities/mbconfig_test.py
@@ -79,7 +79,7 @@ class MbconfigTest(unittest.TestCase):
     self.assertRegex(output, version_id_regex)
 
     match = re.search(version_id_regex, output)
-    version_id = int(match[0])
+    version_id = int(match.group(0))
     self.assertGreater(version_id, 50700000)
 
   def testVersionMajor(self):


### PR DESCRIPTION
Two minor fixes to pass unit tests I'm seeing fail on ubuntu bionic and xenial

mbctdlist.cc was printing illegal UTF-8 characters due to an uninitialized character array which caused it's unit test to fail.  Simply initialized the first element to '\0' in this case, but could use memset to set the whole array if wanted.

mbconfig_test.py:  subscriptable 'Match' objects were introduced in python 3.6 and xenial ships with 3.5.  Switched to the longer form but equivalent '.group()' method to get at the matching text in the test