### PR TITLE
Disable osx travis build as gmt-config not found (#974).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,20 +135,21 @@ matrix:
       - OS_TAG=7
       - DOCKER_IMAGE=zberkowitz/mbsystem-deps:centos-7
 
-  - os: osx
-    name: MB-System build on Mac OSX
-    env:
-      - TRAVIS_CONFIG=build_osx
-      - CFLAGS="-I/opt/X11/include -L/opt/X11/lib" 
-    addons:
-      homebrew:
-        packages:
-          - proj
-          - gdal
-          - netcdf
-          - fftw
-          - gmt
-          - openmotif
+  # TODO(#974): gmt-config is not found.
+  # - os: osx
+  #   name: MB-System build on Mac OSX
+  #   env:
+  #     - TRAVIS_CONFIG=build_osx
+  #     - CFLAGS="-I/opt/X11/include -L/opt/X11/lib" 
+  #   addons:
+  #     homebrew:
+  #       packages:
+  #         - proj
+  #         - gdal
+  #         - netcdf
+  #         - fftw
+  #         - gmt
+  #         - openmotif
 #
 #
 #  MB-System builds and tests for development configs


### PR DESCRIPTION
See #974 for description of the failure