### PR TITLE
mbaux: Cleanup

### DIFF
--- a/src/mbaux/mb_aux.h
+++ b/src/mbaux/mb_aux.h
@@ -21,8 +21,6 @@
  *
  * Name change:  mb_countour.h changed to mb_aux.h
  * Date:  October 13, 2009
- *
- *
  */
 
 #ifndef MB_AUX_H_

--- a/src/mbaux/mb_readwritegrd.c
+++ b/src/mbaux/mb_readwritegrd.c
@@ -232,7 +232,7 @@ int mb_read_gmt_grd(int verbose, char *grdfile, int *grid_projection_mode, char 
             kx2 = (i + 1) * (*n_rows) + j;
             ii++;
           } else {
-            kx2 = k; 
+            kx2 = k;
           }
 
           int jj = 0;

--- a/src/mbaux/mb_truecont.c
+++ b/src/mbaux/mb_truecont.c
@@ -1431,8 +1431,9 @@ int mb_ocontour(int verbose, struct swath *data, int *error) {
   }
 
   /* get min max of bathymetry */
-  double bath_min;
-  double bath_max;
+  // TODO(schwehr): Better to set min to DBL_MAX and max to -DBL_MAX?
+  double bath_min = 0.0;  // -Wmaybe-uninitialized
+  double bath_max = 0.0;  // -Wmaybe-uninitialized
   bool extreme_start = false;
   for (int i = 0; i < data->npings; i++) {
     struct ping *ping = &data->pings[i];

--- a/src/mbaux/mb_xgraphics.c
+++ b/src/mbaux/mb_xgraphics.c
@@ -291,7 +291,7 @@ void xg_justify(void *xgid, char *string, int *width, int *ascent, int *descent)
  **********************************************************************/
 void xg_setclip(void *xgid, int x, int y, int width, int height) {
 	/* set up rectangle */
-	XRectangle rectangle[1] = {x, y, width, height};
+	XRectangle rectangle[1] = {{x, y, width, height}};
 
 	/* set clip rectangle */
 	struct xg_graphic *graphic = (struct xg_graphic *)xgid;

--- a/src/mbaux/mb_zgrid.c
+++ b/src/mbaux/mb_zgrid.c
@@ -267,7 +267,7 @@ int mb_zgrid(float *z, int *nx, int *ny, float *x1, float *y1, float *dx, float 
 	float x, y, delzm;
 	float dzmax, dzrms;
 	int im, jm;
-	float dzrms8;
+	float dzrms8 = 0.0f;  // TODO(schwehr): -Wmaybe-uninitialized
 	float z00;
 	float dz;
 	float ze;


### PR DESCRIPTION
- Remove trailing whitespace
- Remove extra comment lines
- Initialize variables that triggered `-Wmaybe-uninitialized`
- Set the proper structure for initializing `XRectangle[]`