### PR TITLE
Fix format MBF_OICGEODA (141) and MBF_OICMBARI (142)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,7 +20,7 @@ include "beta" in the tag name are preliminary and generally not announced.
 Distributions that do not include "beta" in the tag name correspond to the major,
 announced releases. The source distributions associated with all releases, major or beta, are equally accessible as tarballs through the Github interface.
 
-- Version 5.7.6beta32    April 12, 2020
+- Version 5.7.6beta32    April 13, 2020
 - Version 5.7.6beta31    March 2, 2020
 - Version 5.7.6beta30    February 20, 2020
 - Version 5.7.6beta29    February 17, 2020
@@ -343,7 +343,7 @@ announced releases. The source distributions associated with all releases, major
 --
 ### MB-System Version 5.7 Release Notes:
 --
-#### 5.7.6beta32 (April 9, 2020)
+#### 5.7.6beta32 (April 13, 2020)
 
 General (mb_define.h, mb_format.c, mb_format.h): Added definition of format=-2
 as recursive imagelists. Analagous to datalists, this construct supports timestamped
@@ -369,6 +369,12 @@ Mbset: changed output to clearly indicate when parameter files are created
 mb_pr_compare() to mb_process.c that can be used in mbset.c to check
 whether the modified process parameter structure actually differs from
 the original structure.
+
+Formats MBF_OICGEODA (141) and MBF_OICMBARI (142): Fixed support for old OIC
+format DSL120 interferometric sonar data. Processing of these data now works
+with mbpreprocess and mbprocess again. The sidescan data were compromised
+by treating unsigned amplitude values as signed, and treating null samples as
+valid.
 
 Testing: Reinstated OSX test build as part of the Travis CI runs triggered by
 commits to the Github repository.

--- a/configure
+++ b/configure
@@ -3766,7 +3766,7 @@ $as_echo "#define HAVE_CXX11 1" >>confdefs.h
 
 
 
-$as_echo "#define VERSION_DATE \"12 April 2020\"" >>confdefs.h
+$as_echo "#define VERSION_DATE \"13 April 2020\"" >>confdefs.h
 
 
 ac_aux_dir=

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ AC_LANG(C)
 dnl Require c++11
 AX_CXX_COMPILE_STDCXX(11)
 
-AC_DEFINE(VERSION_DATE, "12 April 2020", [Set VERSION_DATE define in mb_config.h])
+AC_DEFINE(VERSION_DATE, "13 April 2020", [Set VERSION_DATE define in mb_config.h])
 
 dnl Check system arch
 AC_CANONICAL_HOST

--- a/libtool
+++ b/libtool
@@ -67,13 +67,13 @@ PATH_SEPARATOR=":"
 
 # The host system.
 host_alias=
-host=x86_64-apple-darwin18.7.0
-host_os=darwin18.7.0
+host=x86_64-apple-darwin17.7.0
+host_os=darwin17.7.0
 
 # The build system.
 build_alias=
-build=x86_64-apple-darwin18.7.0
-build_os=darwin18.7.0
+build=x86_64-apple-darwin17.7.0
+build_os=darwin17.7.0
 
 # A sed program that does not truncate output.
 SED="/usr/bin/sed"
@@ -165,7 +165,7 @@ lock_old_archive_extraction=yes
 LTCC="gcc"
 
 # LTCC compiler flags.
-LTCFLAGS="-I/opt/local/include"
+LTCFLAGS="-g -I/opt/X11/include"
 
 # Take the output of nm and produce a listing of raw symbols and C names.
 global_symbol_pipe="sed -n -e 's/^.*[	 ]\\([BCDEGRST][BCDEGRST]*\\)[	 ][	 ]*_\\([_A-Za-z][_A-Za-z0-9]*\\)\$/\\1 _\\2 \\2/p' | sed '/ __gnu_lto/d'"
@@ -282,7 +282,7 @@ finish_eval=""
 hardcode_into_libs=no
 
 # Compile-time system search path for libraries.
-sys_lib_search_path_spec="/Applications/Xcode-10.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/10.0.0  /usr/local/lib"
+sys_lib_search_path_spec="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/10.0.0  /usr/local/lib"
 
 # Detected run-time system search path for libraries.
 sys_lib_dlsearch_path_spec="/usr/local/lib /lib /usr/lib"
@@ -305,7 +305,7 @@ striplib="strip -x"
 
 
 # The linker used to build libraries.
-LD="/Applications/Xcode-10.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld"
+LD="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld"
 
 # How to create reloadable object files.
 reload_flag=" -r"
@@ -11658,7 +11658,7 @@ build_old_libs=`case $build_libtool_libs in yes) echo no;; *) echo yes;; esac`
 # ### BEGIN LIBTOOL TAG CONFIG: CXX
 
 # The linker used to build libraries.
-LD="/Applications/Xcode-10.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld"
+LD="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld"
 
 # How to create reloadable object files.
 reload_flag=" -r"

--- a/src/mbio/mb_config.h
+++ b/src/mbio/mb_config.h
@@ -74,10 +74,10 @@
 #define MBSYSTEM_CONFIG_DEFINED 1
 
 /* Set MBSYSTEM_INSTALL_PREFIX define in mb_config.h */
-#define MBSYSTEM_INSTALL_PREFIX "NONE"
+#define MBSYSTEM_INSTALL_PREFIX "/usr/local"
 
 /* Set MBSYSTEM_OTPS_LOCATION define in mb_config.h */
-#define MBSYSTEM_OTPS_LOCATION "/usr/local/OTPS2"
+#define MBSYSTEM_OTPS_LOCATION "/usr/local/opt/otps"
 
 /* Build libmbtnav */
 #define MBTNAV_ENABLED 1
@@ -86,7 +86,7 @@
 #define MBTRN_ENABLED 1
 
 /* Build graphical tools */
-/* #undef MBUTILS_ENABLED */
+#define MBUTILS_ENABLED 1
 
 /* Name of package */
 #define PACKAGE "mbsystem"
@@ -116,13 +116,13 @@
 #define STDC_HEADERS 1
 
 /* Build unit tests */
-/* #undef TEST_ENABLED */
+#define TEST_ENABLED 1
 
 /* Version number of package */
 #define VERSION "5.7.6beta32"
 
 /* Set VERSION_DATE define in mb_config.h */
-#define VERSION_DATE "12 April 2020"
+#define VERSION_DATE "13 April 2020"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/src/mbio/mb_format.c
+++ b/src/mbio/mb_format.c
@@ -2636,7 +2636,7 @@ int mb_get_format(int verbose, char *filename, char *fileroot, int *format, int 
     }
   }
 
-  /* look for a Imagex multibeam .83p format convention*/
+  /* look for a Imagex multibeam .83p format convention */
   if (!found) {
     int i;
     if (strlen(filename) >= 5)
@@ -2659,7 +2659,7 @@ int mb_get_format(int verbose, char *filename, char *fileroot, int *format, int 
     }
   }
 
-  /* look for an R2R navigation format convention*/
+  /* look for an R2R navigation format convention */
   if (!found) {
     int i;
     if (strlen(filename) >= 8)
@@ -2682,7 +2682,7 @@ int mb_get_format(int verbose, char *filename, char *fileroot, int *format, int 
     }
   }
 
-  /* look for a HYSWEEP *.HSX file format convention*/
+  /* look for a HYSWEEP *.HSX file format convention */
   if (!found) {
     int i;
     if (strlen(filename) >= 5)
@@ -2705,7 +2705,30 @@ int mb_get_format(int verbose, char *filename, char *fileroot, int *format, int 
     }
   }
 
-  /* look for a SEA SWATHplus *.sxi file format convention*/
+  /* look for an OIC *.oic file format convention */
+  if (!found) {
+    int i;
+    if (strlen(filename) >= 5)
+      i = strlen(filename) - 4;
+    else
+      i = 0;
+    if ((suffix = strstr(&filename[i], ".oic")) != NULL)
+      suffix_len = 4;
+    else if ((suffix = strstr(&filename[i], ".OIC")) != NULL)
+      suffix_len = 4;
+    else
+      suffix_len = 0;
+    if (suffix_len == 4) {
+      if (fileroot != NULL) {
+        strncpy(fileroot, filename, strlen(filename) - suffix_len);
+        fileroot[strlen(filename) - suffix_len] = '\0';
+      }
+      *format = MBF_OICGEODA;
+      found = true;
+    }
+  }
+
+  /* look for a SEA SWATHplus *.sxi file format convention */
   if (!found) {
     int i;
     if (strlen(filename) >= 5)
@@ -2728,7 +2751,7 @@ int mb_get_format(int verbose, char *filename, char *fileroot, int *format, int 
     }
   }
 
-  /* look for a SEA SWATHplus *.sxp file format convention*/
+  /* look for a SEA SWATHplus *.sxp file format convention */
   if (!found) {
     int i;
     if (strlen(filename) >= 5)
@@ -2751,7 +2774,7 @@ int mb_get_format(int verbose, char *filename, char *fileroot, int *format, int 
     }
   }
 
-  /* look for a 3DatDepth *.raa file format convention*/
+  /* look for a 3DatDepth *.raa file format convention */
   if (!found) {
     int i;
     if (strlen(filename) >= 5)
@@ -2793,7 +2816,7 @@ int mb_get_format(int verbose, char *filename, char *fileroot, int *format, int 
         }
   }
 
-  /* look for a WASSP *.000 file format convention*/
+  /* look for a WASSP *.000 file format convention */
   if (!found) {
     int i;
     if (strlen(filename) >= 5)
@@ -2814,7 +2837,7 @@ int mb_get_format(int verbose, char *filename, char *fileroot, int *format, int 
     }
   }
 
-  /* look for a WASSP *.nwsf file format convention*/
+  /* look for a WASSP *.nwsf file format convention */
   if (!found) {
     int i;
     if (strlen(filename) >= 6)

--- a/src/mbio/mbr_oicgeoda.c
+++ b/src/mbio/mbr_oicgeoda.c
@@ -225,7 +225,7 @@ int mbr_rt_oicgeoda(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char buffer[MBF_OICGEODA_HEADER_SIZE] = "";
 	int read_size;
 	int data_size;
-	char *char_ptr;
+	mb_u_char *char_ptr;
 	short *short_ptr;
 	int *int_ptr;
 	float *float_ptr;
@@ -630,7 +630,7 @@ int mbr_rt_oicgeoda(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			fprintf(stderr, "dbg5       num samples: %d\n", header->channel[i].num_samples);
 			if (header->channel[i].size == OIC_SIZE_CHAR) {
 				fprintf(stderr, "dbg5       size:      char (1 byte)\n");
-				char_ptr = (char *)data->raw[i];
+				char_ptr = (mb_u_char *)data->raw[i];
 				for (int j = 0; j < header->channel[i].num_samples; j++) {
 					fprintf(stderr, "dbg5      %5d  %5d\n", j, char_ptr[j]);
 				}
@@ -880,7 +880,7 @@ int mbr_rt_oicgeoda(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			ichan = header->ss_chan_port;
 			sample_interval = header->fish_ping_period / header->channel[ichan].num_samples;
 			if (header->channel[ichan].size == OIC_SIZE_CHAR)
-				char_ptr = (char *)data->raw[ichan];
+				char_ptr = (mb_u_char *)data->raw[ichan];
 			else if (header->channel[ichan].size == OIC_SIZE_SHORT)
 				short_ptr = (short *)data->raw[ichan];
 			else if (header->channel[ichan].size == OIC_SIZE_INT)
@@ -890,11 +890,20 @@ int mbr_rt_oicgeoda(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			for (int i = header->fish_altitude_samples + 1; i < header->channel[ichan].num_samples; i++) {
 				const int j = header->channel[ichan].num_samples - i + header->fish_altitude_samples;
 				if (header->channel[ichan].size == OIC_SIZE_CHAR)
-					data->ss[j] = char_ptr[i];
+          if (char_ptr[i] != 0)
+					  data->ss[j] = char_ptr[i];
+          else
+            data->ss[j] = MB_SIDESCAN_NULL;
 				else if (header->channel[ichan].size == OIC_SIZE_SHORT)
-					data->ss[j] = short_ptr[i];
+          if (short_ptr[i] != 0)
+					  data->ss[j] = short_ptr[i];
+          else
+            data->ss[j] = MB_SIDESCAN_NULL;
 				else if (header->channel[ichan].size == OIC_SIZE_INT)
-					data->ss[j] = int_ptr[i];
+          if (int_ptr[i] != 0)
+					  data->ss[j] = int_ptr[i];
+          else
+            data->ss[j] = MB_SIDESCAN_NULL;
 				else if (header->channel[ichan].size == OIC_SIZE_FLOAT)
 					data->ss[j] = float_ptr[i];
 				beta = 180.0 - asin(((double)header->fish_altitude_samples) / ((double)i)) / DTR;
@@ -913,7 +922,7 @@ int mbr_rt_oicgeoda(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			ichan = header->ss_chan_stbd;
 			sample_interval = header->fish_ping_period / header->channel[ichan].num_samples;
 			if (header->channel[ichan].size == OIC_SIZE_CHAR)
-				char_ptr = (char *)data->raw[ichan];
+				char_ptr = (mb_u_char *)data->raw[ichan];
 			else if (header->channel[ichan].size == OIC_SIZE_SHORT)
 				short_ptr = (short *)data->raw[ichan];
 			else if (header->channel[ichan].size == OIC_SIZE_INT)
@@ -1137,7 +1146,7 @@ int mbr_wt_oicgeoda(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 	char buffer[MBF_OICGEODA_HEADER_SIZE] = "";
 	int write_size;
 	int data_size;
-	char *char_ptr;
+	mb_u_char *char_ptr;
 	short *short_ptr;
 	int *int_ptr;
 	float *float_ptr;
@@ -1388,7 +1397,7 @@ int mbr_wt_oicgeoda(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			fprintf(stderr, "dbg5       num samples: %d\n", header->channel[i].num_samples);
 			if (header->channel[i].size == OIC_SIZE_CHAR) {
 				fprintf(stderr, "dbg5       size:      char (1 byte)\n");
-				char_ptr = (char *)data->raw[i];
+				char_ptr = (mb_u_char *)data->raw[i];
 				for (int j = 0; j < header->channel[i].num_samples; j++) {
 					fprintf(stderr, "dbg5      %5d  %5d\n", j, char_ptr[j]);
 				}

--- a/src/utilities/mbpreprocess.cc
+++ b/src/utilities/mbpreprocess.cc
@@ -2286,6 +2286,8 @@ int main(int argc, char **argv) {
       oformat = MBF_IMAGEMBA;
     else if (iformat == MBF_3DWISSLR)
       oformat = MBF_3DWISSLP;
+    else if (iformat == MBF_OICGEODA)
+      oformat = MBF_OICMBARI;
     else
       oformat = iformat;
 


### PR DESCRIPTION
Formats MBF_OICGEODA (141) and MBF_OICMBARI (142): Fixed support for old OIC
format DSL120 interferometric sonar data. Processing of these data now works
with mbpreprocess and mbprocess again. The sidescan data were compromised
by treating unsigned amplitude values as signed, and treating null samples as
valid.