### PR TITLE
Fixed build problem with change to src/utilities/Makefile.am

### DIFF
--- a/src/utilities/Makefile.am
+++ b/src/utilities/Makefile.am
@@ -61,6 +61,7 @@ if BUILD_GSF
 AM_CPPFLAGS += -I${top_srcdir}/src/gsf
 endif
 AM_CPPFLAGS += $(MBTRNINCDIR)
+AM_CPPFLAGS += ${libproj_CPPFLAGS}
 AM_CPPFLAGS += ${libgmt_CPPFLAGS}
 AM_CPPFLAGS += ${libnetcdf_CPPFLAGS}
 AM_CPPFLAGS += ${libfftw_CPPFLAGS}

--- a/src/utilities/Makefile.in
+++ b/src/utilities/Makefile.in
@@ -562,8 +562,8 @@ top_srcdir = @top_srcdir@
 include_HEADERS = levitus.h
 AM_CFLAGS = ${libgmt_CFLAGS} ${libnetcdf_CFLAGS}
 AM_CPPFLAGS = -I${top_srcdir}/src/mbio -I${top_srcdir}/src/mbaux \
-	$(am__append_1) $(MBTRNINCDIR) ${libgmt_CPPFLAGS} \
-	${libnetcdf_CPPFLAGS} ${libfftw_CPPFLAGS}
+	$(am__append_1) $(MBTRNINCDIR) ${libproj_CPPFLAGS} \
+	${libgmt_CPPFLAGS} ${libnetcdf_CPPFLAGS} ${libfftw_CPPFLAGS}
 AM_LDFLAGS = 
 mbconfig_SOURCES = mbconfig.cc
 mbabsorption_SOURCES = mbabsorption.cc


### PR DESCRIPTION
The build was failing at src/utilities/mbsvpselect.cc due to a failure to file geodesic.h. This was fixed by adding libproj_CPPFLAGS to AM_CPPFLAGS in src/utilities/Makefile.am, and then resconstruct the build system.