### PR TITLE
initial notes for usage of dockerized MB-System and launcher script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,11 @@
-# TODO likely more stuff to be ignored
-*/.git
+# TODO likely more stuff that could be ignored
+.git
+.gitignore
+.github
+.travis.yml
+ci
+docker
+
+# NOTE: there's unfortunately no "global dockerignore" mechanism AFAICT,
+# so I'm for now adding some other local stuff under my env here:
+.idea

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,8 +5,7 @@ See https://github.com/dwcaress/MB-System/issues/807
 ## Status
 
 - Basic setup functional
-- Some basic GUI tests OK on MacOS
-- This README is still preliminary as well
+- Some basic GUI tests OK on MacOS and CentOS 7
 
 ## Dockerfile
 
@@ -86,4 +85,3 @@ Status: preliminary (some notes [here](gui/README.md)).
 - Use current host directory mapped as "home" directory
 - List file with "pointers" to locations
 - Windows
-- keep using separate repo for now

--- a/docker/user/README.md
+++ b/docker/user/README.md
@@ -83,7 +83,4 @@ The launcher, however, is also intended to help set up the host environment
 prior to running the MB-System programs, in particular those with a GUI.
 Example:
 
-    $ ./mbsystem.sh -gui mbnavadjust
-
-> NOTE: the `-gui` option is temporary.
-
+    $ ./mbsystem.sh mbnavadjust

--- a/docker/user/README.md
+++ b/docker/user/README.md
@@ -1,0 +1,89 @@
+# Using the dockerized MB-System
+
+Notes for the end user about using the dockerized MB-System.
+
+**Status**: WIP, preliminary notes.  Feedback most welcome.
+
+## Requirements
+
+The core requirements on your host system are:
+
+- Docker engine
+- X11 server
+
+Additionally:
+
+- on MacOS:
+    - [socat](http://www.dest-unreach.org/socat/)
+
+- on Windows 10:
+    - (TODO)
+
+
+The dockerized MB-system has been tested on ...
+
+
+## The MB-System docker image
+
+The MB-System docker image is available at
+https://hub.docker.com/repository/docker/mbari/mbsystem.
+
+Note that proper releases of the image are indicated with tags having an
+`x.y.z` prefix, for example, `5.7.6beta32`.
+Typically, you will be using the most recent of such available tags.
+
+The complete image designation has the form `mbari/mbsystem:<tag>`, 
+for example, `mbari/mbsystem:5.7.6beta32`.
+In the following we will assume that such image designation is captured
+in the `$MBSYSTEM_IMAGE` environment variable:
+
+    $ export MBSYSTEM_IMAGE=mbari/mbsystem:5.7.6beta32
+
+### Getting the image
+    
+The launcher script (see below) will download the image if not already
+available locally, but you can get it beforehand with an explicit
+`git pull` command: 
+
+    $ docker pull $MBSYSTEM_IMAGE
+    5.7.6beta32: Pulling from mbari/mbsystem
+    ab5ef0e58194: Already exists
+    a145630667c7: Already exists
+    785c505a04fc: Already exists
+    71848de57f0d: Already exists
+    6d6760671aa6: Already exists
+    ded91f515ba2: Already exists
+    a3267f0a1277: Already exists
+    77cffdf7b54a: Pull complete
+    48a2a54358a4: Pull complete
+    5b675a116cbe: Pull complete
+    Digest: sha256:548ce9f5980d9b8a25efc415a2e20882647b2ad63d805fd48797375818cb33ce
+    Status: Downloaded newer image for mbari/mbsystem:5.7.6beta32
+    docker.io/mbari/mbsystem:5.7.6beta32
+
+### The launcher script
+
+The included `mbsystem.sh` script is basically a wrapper around the
+`docker` command to help run any of the MB-System programs.
+At this point, the script has a focus on Linux and MacOS hosts.
+
+TODO: Windows 10.
+
+Relying on the `MBSYSTEM_IMAGE` environment variable as defined above,
+you just need to indicate the desired program and any arguments
+to `mbsystem.sh`, for example:
+
+    $ ./mbsystem.sh mbabsorption -h
+
+In this case, this is equivalent to:
+
+    $ docker run -it --rm $MBSYSTEM_IMAGE mbabsorption -h
+    
+The launcher, however, is also intended to help set up the host environment
+prior to running the MB-System programs, in particular those with a GUI.
+Example:
+
+    $ ./mbsystem.sh -gui mbnavadjust
+
+> NOTE: the `-gui` option is temporary.
+

--- a/docker/user/mbsystem.sh
+++ b/docker/user/mbsystem.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# mbsystem.sh: A laucher script for the dockerized MB-System programs.
+#
+# Status: PRELIMINARY
+#
+
+function log {
+    echo -e "::: $1"
+}
+
+function error {
+    echo -e "$1"
+    exit "$2"
+}
+
+if [ -z "$MBSYSTEM_IMAGE" ]; then
+    error "Required MBSYSTEM_IMAGE env var undefined" 1
+fi
+
+unset ISGUI
+
+# TODO see if given program (below) is one of the graphical ones
+#  to do the associated preparation.
+#  For now, let's handle a special `-gui` option for this:
+if [ "$1" = "-gui" ]; then
+    ISGUI=1
+    shift
+fi
+
+pgm=$1
+if [ -z "$pgm" ]; then
+    # TODO show list of available programs?
+    error "MB-System program not given" 2
+fi
+shift
+
+# Build the command to be run:
+
+CMDPREFIX="docker run -it --rm"
+
+# Map current directory to /opt/MBSWorkDir:
+CMDPREFIX="$CMDPREFIX -v $(pwd):/opt/MBSWorkDir"
+
+# TODO determine host environment, in particular for any needed
+#  preparations for the GUI programs.
+#  Initially testing with MacOS and linux.
+# Using a generic `os` variable for this:
+log "OSTYPE=$OSTYPE"
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    os="linux"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    os="macos"
+else
+    echo "TODO $OSTYPE"
+    exit 3
+fi
+
+if [ $ISGUI ]; then
+    if [ "$os" = "linux" ]; then
+        if [ -z "$DISPLAY" ]; then
+            error "Required DISPLAY env var undefined" 4
+        fi
+        CMDPREFIX="${CMDPREFIX} -e DISPLAY --net=host"
+
+    elif [ "$os" = "macos" ]; then
+        socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\" &
+        socat_pid=$!
+        log "socat PID=$socat_pid"
+        ip=$(ifconfig en0 | grep "inet " | sed 's/.*inet \([0-9\.]*\).*/\1/g')
+        xhost + "${ip}"
+        export DISPLAY=${ip}:0
+        CMDPREFIX="${CMDPREFIX} -e DISPLAY"
+    else
+        # should not happen
+        error "Unexpected os=$os" 99
+    fi
+fi
+
+# final complete command to run:
+CMD="$CMDPREFIX $MBSYSTEM_IMAGE $pgm $@"
+log "running $CMD"
+$CMD
+
+if [ $ISGUI ]; then
+    if [ "$os" = "macos" ]; then
+        kill $socat_pid
+    fi
+fi

--- a/docker/user/mbsystem.sh
+++ b/docker/user/mbsystem.sh
@@ -18,33 +18,35 @@ if [ -z "$MBSYSTEM_IMAGE" ]; then
     error "Required MBSYSTEM_IMAGE env var undefined" 1
 fi
 
-unset ISGUI
-
-# TODO see if given program (below) is one of the graphical ones
-#  to do the associated preparation.
-#  For now, let's handle a special `-gui` option for this:
-if [ "$1" = "-gui" ]; then
-    ISGUI=1
-    shift
-fi
-
 pgm=$1
 if [ -z "$pgm" ]; then
-    # TODO show list of available programs?
+    # TODO show help message including list of available programs?
     error "MB-System program not given" 2
 fi
 shift
+
+# The graphical programs per https://www.mbari.org/products/research-software/mb-system/mb-system-youtube-tutorials/:
+#   mbedit, mbeditviz, mbvelocitytool, mbgrdviz and mbnavedit
+# plus: mbnavadjust  (TODO probably others?)
+ISGUI=0
+if [ "$pgm" = "mbedit" ] ||
+   [ "$pgm" = "mbeditviz" ] ||
+   [ "$pgm" = "mbnavadjust" ] ||
+   [ "$pgm" = "mbvelocitytool" ] ||
+   [ "$pgm" = "mbgrdviz" ] ||
+   [ "$pgm" = "mbnavedit" ]; then
+    ISGUI=1
+fi
 
 # Build the command to be run:
 
 CMDPREFIX="docker run -it --rm"
 
+# Set running user:
+CMDPREFIX="$CMDPREFIX --user $(id -u)"
+
 # Map current directory to /opt/MBSWorkDir:
 CMDPREFIX="$CMDPREFIX -v $(pwd):/opt/MBSWorkDir"
-
-# TODO determine running user.
-# For now, add this in general:
-CMDPREFIX="$CMDPREFIX --user $(id -u)"
 
 # TODO determine host environment, in particular for any needed
 #  preparations for the GUI programs.

--- a/docker/user/mbsystem.sh
+++ b/docker/user/mbsystem.sh
@@ -42,6 +42,10 @@ CMDPREFIX="docker run -it --rm"
 # Map current directory to /opt/MBSWorkDir:
 CMDPREFIX="$CMDPREFIX -v $(pwd):/opt/MBSWorkDir"
 
+# TODO determine running user.
+# For now, add this in general:
+CMDPREFIX="$CMDPREFIX --user $(id -u)"
+
 # TODO determine host environment, in particular for any needed
 #  preparations for the GUI programs.
 #  Initially testing with MacOS and linux.


### PR DESCRIPTION
Here's an initial launcher script intended to facilitate running the dockerized programs, plus some user oriented instructions (all preliminary and of course subject to be moved to wherever this would make more sense once there's a more final version of the the docker image).

Along with this I started doing GUI tests on a CentOS 7 and will later on do some similar tests on a Windows 10 VM (that I just requested IS to create).
