### PR TITLE
Change handling of fixed files in mbnavadjust

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,7 +20,7 @@ include "beta" in the tag name are preliminary and generally not announced.
 Distributions that do not include "beta" in the tag name correspond to the major,
 announced releases. The source distributions associated with all releases, major or beta, are equally accessible as tarballs through the Github interface.
 
-- Version 5.7.6beta33    May 4, 2020
+- Version 5.7.6beta33    May 5, 2020
 - Version 5.7.6beta32    April 22, 2020
 - Version 5.7.6beta31    March 2, 2020
 - Version 5.7.6beta30    February 20, 2020
@@ -345,7 +345,13 @@ announced releases. The source distributions associated with all releases, major
 ### MB-System Version 5.7 Release Notes:
 --
 
-#### 5.7.6beta33 (May 4, 2020)
+#### 5.7.6beta33 (May 5, 2020)
+
+Mbnavadjust: Changed handling of fixed surveys when updating the project grid
+or applying the solution. Previously the files of fixed surveys were ignored,
+even if they previously had been adjusted before being set to fixed. Now, the
+unchanged *.na0 file will be output and the navadjust state will be updated
+so that mbprocess will apply the unchanged navigation.
 
 Mbcopy: A compile failure occurs for src/utilities/mbcopy.cc on Windows as
 reported by Joaquim Luis. The issue is that under Visual Studio C++ some

--- a/configure
+++ b/configure
@@ -3799,7 +3799,7 @@ $as_echo "#define HAVE_CXX11 1" >>confdefs.h
 
 
 
-$as_echo "#define VERSION_DATE \"4 May 2020\"" >>confdefs.h
+$as_echo "#define VERSION_DATE \"5 May 2020\"" >>confdefs.h
 
 
 ac_aux_dir=

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ AC_LANG(C)
 dnl Require c++11
 AX_CXX_COMPILE_STDCXX(11)
 
-AC_DEFINE(VERSION_DATE, "4 May 2020", [Set VERSION_DATE define in mb_config.h])
+AC_DEFINE(VERSION_DATE, "5 May 2020", [Set VERSION_DATE define in mb_config.h])
 
 dnl Check system arch
 AC_CANONICAL_HOST

--- a/src/mbio/mb_config.h
+++ b/src/mbio/mb_config.h
@@ -125,7 +125,7 @@
 #define VERSION "5.7.6beta33"
 
 /* Set VERSION_DATE define in mb_config.h */
-#define VERSION_DATE "4 May 2020"
+#define VERSION_DATE "5 May 2020"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/src/mbnavadjust/mbnavadjust_prog.c
+++ b/src/mbnavadjust/mbnavadjust_prog.c
@@ -10373,11 +10373,11 @@ int mbnavadjust_updategrid() {
     if ((afp = fopen(apath, "w")) != NULL) {
       for (int i = 0; i < project.num_files; i++) {
         file = &project.files[i];
-        if (file->status != MBNA_FILE_FIXEDNAV) {
+        //if (file->status != MBNA_FILE_FIXEDNAV) {
           for (int j = 0; j < file->num_sections; j++) {
             fprintf(afp, "nvs_%4.4d_%4.4d.mb71 71\n", file->id, j);
           }
-        }
+        //}
       }
       fclose(afp);
     }
@@ -10420,13 +10420,15 @@ int mbnavadjust_updategrid() {
         file = &project.files[ifile];
         sprintf(npath, "%s/nvs_%4.4d.mb166", project.datadir, ifile);
         sprintf(apath, "%s/nvs_%4.4d.na%d", project.datadir, ifile, file->output_id);
+        /*
         if (file->status == MBNA_FILE_FIXEDNAV) {
           sprintf(message, " > Not outputting updated nav to fixed file %s\n", apath);
           do_info_add(message, false);
           if (mbna_verbose == 0)
             fprintf(stderr, "%s", message);
         }
-        else if ((nfp = fopen(npath, "r")) == NULL) {
+        else */
+        if ((nfp = fopen(npath, "r")) == NULL) {
           status = MB_FAILURE;
           error = MB_ERROR_OPEN_FAIL;
           sprintf(message, " > Unable to read initial nav file %s\n", npath);
@@ -10552,15 +10554,6 @@ ifile, isection, isnav);
                           factor * (section->snav_z_offset[isnav + 1] - section->snav_z_offset[isnav]);
 
                 /* write the updated nav out */
-                /* printing this string twice because in some situations the first
-                    print has the time_d value come out as "nan" - this is the worst sort
-                    of kluge for a real but mysterious bug - apologies to all who find this
-                    - DWC 18 Aug 2007 R/V Atlantis Cobb Segment JDF Ridge */
-//                sprintf(ostring,
-//                        "%4.4d %2.2d %2.2d %2.2d %2.2d %2.2d.%6.6d %16.6f %.10f %.10f %.2f %.2f %.3f %.2f %.2f "
-//                        "%.2f %.3f\r\n",
-//                        time_i[0], time_i[1], time_i[2], time_i[3], time_i[4], time_i[5], time_i[6], time_d,
-//                        navlon, navlat, heading, speed, draft, roll, pitch, heave, zoffset);
                 sprintf(ostring,
                         "%4.4d %2.2d %2.2d %2.2d %2.2d %2.2d.%6.6d %16.6f %.10f %.10f %.2f %.2f %.3f %.2f %.2f "
                         "%.2f %.3f\r\n",
@@ -10681,13 +10674,14 @@ int mbnavadjust_applynav() {
       sprintf(npath, "%s/nvs_%4.4d.mb166", project.datadir, ifile);
       sprintf(apath, "%s/nvs_%4.4d.na%d", project.datadir, ifile, file->output_id);
       sprintf(opath, "%s.na%d", file->path, file->output_id);
+      /*
       if (file->status == MBNA_FILE_FIXEDNAV) {
         sprintf(message, " > Not outputting updated nav to fixed file %s\n", opath);
         do_info_add(message, false);
         if (mbna_verbose == 0)
           fprintf(stderr, "%s", message);
-      }
-      else if ((nfp = fopen(npath, "r")) == NULL) {
+      } else */
+      if ((nfp = fopen(npath, "r")) == NULL) {
         status = MB_FAILURE;
         error = MB_ERROR_OPEN_FAIL;
         sprintf(message, " > Unable to read initial nav file %s\n", npath);
@@ -10830,15 +10824,6 @@ ifile, isection, isnav);
                         factor * (section->snav_z_offset[isnav + 1] - section->snav_z_offset[isnav]);
 
               /* write the updated nav out */
-              /* printing this string twice because in some situations the first
-                  print has the time_d value come out as "nan" - this is the worst sort
-                  of kluge for a real but mysterious bug - apologies to all who find this
-                  - DWC 18 Aug 2007 R/V Atlantis Cobb Segment JDF Ridge */
-//              sprintf(ostring,
-//                      "%4.4d %2.2d %2.2d %2.2d %2.2d %2.2d.%6.6d %16.6f %.10f %.10f %.2f %.2f %.3f %.2f %.2f %.2f "
-//                      "%.3f\r\n",
-//                      time_i[0], time_i[1], time_i[2], time_i[3], time_i[4], time_i[5], time_i[6], time_d, navlon,
-//                      navlat, heading, speed, draft, roll, pitch, heave, zoffset);
               sprintf(ostring,
                       "%4.4d %2.2d %2.2d %2.2d %2.2d %2.2d.%6.6d %16.6f %.10f %.10f %.2f %.2f %.3f %.2f %.2f %.2f "
                       "%.3f\r\n",


### PR DESCRIPTION
Mbnavadjust: Changed handling of fixed surveys when updating the project grid
or applying the solution. Previously the files of fixed surveys were ignored,
even if they previously had been adjusted before being set to fixed. Now, the
unchanged *.na0 file will be output and the navadjust state will be updated
so that mbprocess will apply the unchanged navigation.