### PR TITLE
Fixes mbnavadjust crash and crash on Windows writing GMT grids

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -347,6 +347,14 @@ announced releases. The source distributions associated with all releases, major
 ### MB-System Version 5.7 Release Notes:
 --
 
+Mbnavadjust: Fixed crash on Linux when executing the Auto Set Vertical Offset
+function (didn't dimension arrays large enough).
+
+Writing GMT grids: Fixed crash reported by Joaquim Luis on Windows when writing
+GMT grids - the problem was a function call that caused GDAL to allocate a string
+but then it allowing that pointer to be freed in GMT functions. The solution is
+to copy the string and free the pointer using a GDAL call.
+
 #### 5.7.6beta36 (May 17, 2020)
 
 Mbgrd3obj: Had to add #ifdef's on GMT version because the number of parameters

--- a/ci/travis/build_linux/script.sh
+++ b/ci/travis/build_linux/script.sh
@@ -7,4 +7,4 @@ fi
 
 echo "Building MB-System..."
 # DOCKER_IMAGE="zberkowitz/mbsystem-deps:${OS}-${OS_TAG}"
-docker exec -e CC="${CC}" -e CXX="${CXX}" -e CFLAGS="${CFLAGS}" -t ${BUILD_CONTAINER_NAME} bash -c "./configure ${MBSYSTEM_CONFIGURE_ARGS} --enable-test && make && make check"
+docker exec -e CC="${CC}" -e CXX="${CXX}" -e CFLAGS="${CFLAGS}" -t ${BUILD_CONTAINER_NAME} bash -c "./configure ${MBSYSTEM_CONFIGURE_ARGS} --enable-test && make && make V=1 VERBOSE=1 check"

--- a/libtool
+++ b/libtool
@@ -1,6 +1,6 @@
 #! /bin/sh
 # Generated automatically by config.status (mbsystem) 5.7.6beta36
-# Libtool was configured on host tharp.shore.mbari.org:
+# Libtool was configured on host mbari1944.shore.mbari.org:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/libtool
+++ b/libtool
@@ -1,6 +1,6 @@
 #! /bin/sh
 # Generated automatically by config.status (mbsystem) 5.7.6beta36
-# Libtool was configured on host mbari1944.shore.mbari.org:
+# Libtool was configured on host mbari1900.shore.mbari.org:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/src/mbaux/mb_readwritegrd.c
+++ b/src/mbaux/mb_readwritegrd.c
@@ -466,12 +466,15 @@ int mb_write_gmt_grd(int verbose, const char *grdfile, float *grid,
   {
     OGRErr eErr = OGRERR_NONE;
     OGRSpatialReferenceH hSRS = OSRNewSpatialReference(NULL);
+    char *pszResult = NULL;
     if ((eErr = OSRImportFromEPSG(hSRS, epsgid)) != OGRERR_NONE) {
       fprintf(stderr, "Did not get the SRS from input EPSG  %d\n", epsgid);
     }
-    if ((eErr = OSRExportToProj4(hSRS, &header->ProjRefPROJ4)) != OGRERR_NONE) {
+    if ((eErr = OSRExportToProj4(hSRS, &pszResult)) != OGRERR_NONE) {
       fprintf(stderr, "Failed to convert the SRS to Proj syntax\n");
     }
+    header->ProjRefPROJ4 = strdup(pszResult);
+    CPLFree(pszResult);
     OSRDestroySpatialReference(hSRS);
   }
   fprintf(stderr,"header->ProjRefPROJ4:%s\n", header->ProjRefPROJ4);

--- a/src/mbnavadjust/mbnavadjust_prog.c
+++ b/src/mbnavadjust/mbnavadjust_prog.c
@@ -6203,8 +6203,8 @@ int mbnavadjust_autosetsvsvertical() {
     ncols = 3 * nnav;
     nrows_ba = nblockties + nblockglobalties + 3;
     ncols_ba = 3 * nblock;
-    nrows_alloc = nrows_ba; // MAX(nrows, nrows_ba);
-    ncols_alloc = ncols_ba; // MAX(ncols, ncols_ba);
+    nrows_alloc = MAX(nrows, nrows_ba);
+    ncols_alloc = MAX(ncols, ncols_ba);
     fprintf(stderr, "\nMBnavadjust block average inversion preparation:\n");
     fprintf(stderr, "     nblock:            %d\n", nblock);
     fprintf(stderr, "     nblockties:        %d\n", nblockties);

--- a/test/utilities/Makefile.in
+++ b/test/utilities/Makefile.in
@@ -113,11 +113,11 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 =
+am__v_GEN_1 = 
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
-am__v_at_1 =
+am__v_at_1 = 
 SOURCES =
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
@@ -729,7 +729,7 @@ check-TESTS: $(check_SCRIPTS)
 	trs_list=`for i in $$bases; do echo $$i.trs; done`; \
 	log_list=`echo $$log_list`; trs_list=`echo $$trs_list`; \
 	$(MAKE) $(AM_MAKEFLAGS) $(TEST_SUITE_LOG) TEST_LOGS="$$log_list"; \
-	result=$$?; pwd; ls; cat mbbackangle_test.log mbgrid_test.log mbprocess_test.log; exit $$?;
+	exit $$?;
 recheck: all $(check_SCRIPTS)
 	@test -z "$(TEST_SUITE_LOG)" || rm -f $(TEST_SUITE_LOG)
 	@set +e; $(am__set_TESTS_bases); \

--- a/test/utilities/Makefile.in
+++ b/test/utilities/Makefile.in
@@ -113,11 +113,11 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 = 
+am__v_GEN_1 =
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
-am__v_at_1 = 
+am__v_at_1 =
 SOURCES =
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
@@ -729,7 +729,7 @@ check-TESTS: $(check_SCRIPTS)
 	trs_list=`for i in $$bases; do echo $$i.trs; done`; \
 	log_list=`echo $$log_list`; trs_list=`echo $$trs_list`; \
 	$(MAKE) $(AM_MAKEFLAGS) $(TEST_SUITE_LOG) TEST_LOGS="$$log_list"; \
-	exit $$?;
+	result=$$?; pwd; ls; cat mbbackangle_test.log mbgrid_test.log mbprocess_test.log; exit $$?;
 recheck: all $(check_SCRIPTS)
 	@test -z "$(TEST_SUITE_LOG)" || rm -f $(TEST_SUITE_LOG)
 	@set +e; $(am__set_TESTS_bases); \


### PR DESCRIPTION
Mbnavadjust: Fixed crash on Linux when executing the Auto Set Vertical Offset
function (didn't dimension arrays large enough).

Writing GMT grids: Fixed crash reported by Joaquim Luis on Windows when writing
GMT grids - the problem was a function call that caused GDAL to allocate a string
but then it allowing that pointer to be freed in GMT functions. The solution is
to copy the string and free the pointer using a GDAL call.
