### PR TITLE
Update mb_readwritegrd.c

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ include "beta" in the tag name are preliminary and generally not announced.
 Distributions that do not include "beta" in the tag name correspond to the major,
 announced releases. The source distributions associated with all releases, major or beta, are equally accessible as tarballs through the Github interface.
 
+- Version 5.7.6beta37    May 23, 2020
 - Version 5.7.6beta36    May 17, 2020
 - Version 5.7.6beta34    May 14, 2020
 - Version 5.7.6beta33    May 5, 2020
@@ -347,13 +348,17 @@ announced releases. The source distributions associated with all releases, major
 ### MB-System Version 5.7 Release Notes:
 --
 
+#### 5.7.6beta37 (May 23, 2020)
+
 Mbnavadjust: Fixed crash on Linux when executing the Auto Set Vertical Offset
 function (didn't dimension arrays large enough).
 
 Writing GMT grids: Fixed crash reported by Joaquim Luis on Windows when writing
 GMT grids - the problem was a function call that caused GDAL to allocate a string
 but then it allowing that pointer to be freed in GMT functions. The solution is
-to copy the string and free the pointer using a GDAL call.
+to copy the string and free the pointer using a GDAL call. I also had to alter
+the configure.ac to add a conditional HAVE_GDAL that mimics one used in the
+GMT build system so that GDAL related headers are included by gmt_dev.h.
 
 #### 5.7.6beta36 (May 17, 2020)
 

--- a/configure
+++ b/configure
@@ -698,6 +698,8 @@ libgmt_INCLUDEDIR
 libgmt_CPPFLAGS
 libgmt_LIBS
 GMT_CONF
+HAVE_GDAL_FALSE
+HAVE_GDAL_TRUE
 libgdal_CPPFLAGS
 libgdal_LIBS
 GDAL_CONF
@@ -20469,6 +20471,7 @@ $as_echo "$GDAL_LIB" >&6; }
     libgdal_CPPFLAGS="$GDAL_INC"
     libgdal_LIBS="-L$GDAL_LIB_PATH -R $GDAL_LIB_PATH -lgdal"
     libgdal_LDFLAGS="-L$GDAL_LIB_PATH"
+
 else
     $as_echo "Did not find gdal-config program, use --with-gdal-config to set the location"
     as_fn_error $? "\"Did not find gdal-config program, use --with-gdal-config to set the location\"" "$LINENO" 5
@@ -20478,6 +20481,13 @@ libgdal_LIBS=$libgdal_LIBS
 
 libgdal_CPPFLAGS=$libgdal_CPPFLAGS
 
+ if test -x "$GDAL_CONF"; then
+  HAVE_GDAL_TRUE=
+  HAVE_GDAL_FALSE='#'
+else
+  HAVE_GDAL_TRUE='#'
+  HAVE_GDAL_FALSE=
+fi
 
 
 
@@ -22892,6 +22902,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${BUILD_MBSVPSELECT_TRUE}" && test -z "${BUILD_MBSVPSELECT_FALSE}"; then
   as_fn_error $? "conditional \"BUILD_MBSVPSELECT\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${HAVE_GDAL_TRUE}" && test -z "${HAVE_GDAL_FALSE}"; then
+  as_fn_error $? "conditional \"HAVE_GDAL\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${GMT61PLUS_TRUE}" && test -z "${GMT61PLUS_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ define([AC_CACHE_LOAD], )
 define([AC_CACHE_SAVE], )
 
 dnl Initialize and set version and version date
-AC_INIT([mbsystem],[5.7.6beta36],[http://listserver.mbari.org/sympa/arc/mbsystem],[mbsystem],[http://www.mbari.org/data/mbsystem/])
+AC_INIT([mbsystem],[5.7.6beta37],[http://listserver.mbari.org/sympa/arc/mbsystem],[mbsystem],[http://www.mbari.org/data/mbsystem/])
 
 AC_CONFIG_MACRO_DIR(m4)
 AC_LANG(C)
@@ -27,7 +27,7 @@ AC_LANG(C)
 dnl Require c++11
 AX_CXX_COMPILE_STDCXX(11)
 
-AC_DEFINE(VERSION_DATE, "17 May 2020", [Set VERSION_DATE define in mb_config.h])
+AC_DEFINE(VERSION_DATE, "23 May 2020", [Set VERSION_DATE define in mb_config.h])
 
 dnl Check system arch
 AC_CANONICAL_HOST
@@ -540,6 +540,7 @@ if test -x "$GDAL_CONF" ; then
     libgdal_CPPFLAGS="$GDAL_INC"
     libgdal_LIBS="-L$GDAL_LIB_PATH -R $GDAL_LIB_PATH -lgdal"
     libgdal_LDFLAGS="-L$GDAL_LIB_PATH"
+
 else
     AS_ECHO(["Did not find gdal-config program, use --with-gdal-config to set the location"])
     AC_MSG_ERROR(["Did not find gdal-config program, use --with-gdal-config to set the location"])
@@ -548,7 +549,7 @@ fi
 dnl Substitute GDAL library and header arguments
 AC_SUBST([libgdal_LIBS], [$libgdal_LIBS])
 AC_SUBST([libgdal_CPPFLAGS], [$libgdal_CPPFLAGS])
-
+AM_CONDITIONAL([HAVE_GDAL], [test -x "$GDAL_CONF"])
 
 dnl--------------------------------------------------------------------
 dnl GMT Section

--- a/libtool
+++ b/libtool
@@ -1,6 +1,6 @@
 #! /bin/sh
 # Generated automatically by config.status (mbsystem) 5.7.6beta36
-# Libtool was configured on host mbari1900.shore.mbari.org:
+# Libtool was configured on host mbari1716.shore.mbari.org:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/src/mbaux/mb_readwritegrd.c
+++ b/src/mbaux/mb_readwritegrd.c
@@ -462,22 +462,28 @@ int mb_write_gmt_grd(int verbose, const char *grdfile, float *grid,
   }
 
   struct GMT_GRID_HEADER *header = G->header;
-  /* Rely on GDAL to tell us the Proj string of this EPSG code */
-  {
-    OGRErr eErr = OGRERR_NONE;
-    OGRSpatialReferenceH hSRS = OSRNewSpatialReference(NULL);
-    char *pszResult = NULL;
-    if ((eErr = OSRImportFromEPSG(hSRS, epsgid)) != OGRERR_NONE) {
-      fprintf(stderr, "Did not get the SRS from input EPSG  %d\n", epsgid);
-    }
-    if ((eErr = OSRExportToProj4(hSRS, &pszResult)) != OGRERR_NONE) {
-      fprintf(stderr, "Failed to convert the SRS to Proj syntax\n");
-    }
-    header->ProjRefPROJ4 = gmt_strdup_noquote(pszResult); // allocated within GMT because it will be freed within GMT
-    CPLFree(pszResult); // make sure this is freed within GDAL because it was allocated within GDAL
-    OSRDestroySpatialReference(hSRS);
+#ifdef HAVE_GDAL
+  /* If GDAL available use it to get the Proj string of this EPSG code */
+  OGRErr eErr = OGRERR_NONE;
+  OGRSpatialReferenceH hSRS = OSRNewSpatialReference(NULL);
+  char *pszResult = NULL;
+  if ((eErr = OSRImportFromEPSG(hSRS, epsgid)) != OGRERR_NONE) {
+    fprintf(stderr, "Did not get the SRS from input EPSG  %d\n", epsgid);
   }
-  fprintf(stderr,"header->ProjRefPROJ4:%s\n", header->ProjRefPROJ4);
+  if ((eErr = OSRExportToProj4(hSRS, &pszResult)) != OGRERR_NONE) {
+    fprintf(stderr, "Failed to convert the SRS to Proj syntax\n");
+  }
+#if (GMT_MAJOR_VERSION == 6 && GMT_MINOR_VERSION >= 1) || GMT_MAJOR_VERSION > 6
+  header->ProjRefPROJ4 = gmt_strdup_noquote(pszResult); // allocated within GMT because it will be freed within GMT
+#else
+  header->ProjRefPROJ4 = strdup(pszResult);
+#endif
+#if GMT_MAJOR_VERSION >= 6
+  header->ProjRefEPSG = epsgid;
+#endif
+  CPLFree(pszResult); // make sure this is freed within GDAL because it was allocated within GDAL
+  OSRDestroySpatialReference(hSRS);
+#endif
 
   mb_path program_name = "";
   if (argc > 0)


### PR DESCRIPTION
Another attempt to fix crash on Windows when writing GMT grids, this time without breaking building on all other systems.

Writing GMT grids: Fixed crash reported by Joaquim Luis on Windows when writing
GMT grids - the problem was a function call that caused GDAL to allocate a string
but then it allowing that pointer to be freed in GMT functions. The solution is
to ensure that memory allocated with GMT or GDAL libraries is freed from those
same libraries. I also had to alter the configure.ac to add a conditional
HAVE_GDAL that mimics one used in the GMT build system so that GDAL related
headers are included by gmt_dev.h. The relevant code is only used if GDAL is
available. If GMT version is >= 6.1.1 then the function gmt_strdup_noquote()
is called to allocate a PROJ4 string stored in the grid header; otherwise strdup()
is called. Building on Windows will now require GMT 6.1.1 or later.