### PR TITLE
Update mbgrd2obj.c

### DIFF
--- a/src/gmt/mbgrd2obj.c
+++ b/src/gmt/mbgrd2obj.c
@@ -249,7 +249,7 @@ int GMT_mbgrd2obj (void *V_API, int mode, void *args) {
 #elif GMT_MAJOR_VERSION >= 6
 	if ((GMT = gmt_init_module (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_KEYS, THIS_MODULE_NEEDS, &options, &GMT_cpy)) == NULL) bailout (API->error); /* Save current state */
 #else
-	GMT = gmt_begin_module(API, THIS_MODULE_LIB, THIS_MODULE_NAME, &GMT_cpy); /* Save current state */
+	GMT = gmt_begin_module(API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, &GMT_cpy); /* Save current state */
 #endif
 
 	if (GMT_Parse_Common (API, THIS_MODULE_OPTIONS, options)) Return (API->error);


### PR DESCRIPTION
Fix undefined variable when building with GMT 5.