### PR TITLE
Change configure.ac to fix problem with Homebrew installation

### DIFF
--- a/configure
+++ b/configure
@@ -2730,7 +2730,6 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 $as_echo "#define VERSION_DATE \"7 July 2020\"" >>confdefs.h
 
-prefix=$ac_default_prefix
 
 $as_echo " "
 $as_echo "------------------------------------------------------------------------------"

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ dnl--------------------------------------------------------------------
 dnl Initialize and set version and version date
 AC_INIT([mbsystem],[5.7.6beta40],[http://listserver.mbari.org/sympa/arc/mbsystem],[mbsystem],[http://www.mbari.org/data/mbsystem/])
 AC_DEFINE(VERSION_DATE, ["7 July 2020"], [Set VERSION_DATE define in mb_config.h])
-prefix=$ac_default_prefix
+dnl prefix=$ac_default_prefix
 
 AS_ECHO([" "])
 AS_ECHO(["------------------------------------------------------------------------------"])

--- a/libtool
+++ b/libtool
@@ -1,6 +1,6 @@
 #! /bin/sh
 # Generated automatically by config.status (mbsystem) 5.7.6beta40
-# Libtool was configured on host Haxby.local:
+# Libtool was configured on host bochica.shore.mbari.org:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.


### PR DESCRIPTION
I added the line
  prefix=$ac_default_prefix
near the top of configure.ac in order to insure the installation prefix is embedded into mbio/mb_config.h to be accessed by mbconfig. This appears to have the effect of overriding the default prefix for Homebrew installations, which makes the install phase fail because Homebrew installations go into /usr/local/Cellar/package/ not directly into /usr/local.