### PR TITLE
Update ld cache in docker images when install GMT or GDAL from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
 
   - os: linux
     name: Ubuntu Focal (20.04) Build-Deps Docker Image
-    if: repo = dwcaress/MB-System AND type = cron
+    if: repo = berkowski/MB-System AND type = cron
     services: docker
     env:
       - TRAVIS_CONFIG=docker_dep_image
@@ -51,7 +51,7 @@ matrix:
 
 
   - os: linux
-    if: repo = dwcaress/MB-System AND type = cron
+    if: repo = berkowski/MB-System AND type = cron
     name: Ubuntu Focal (20.04) GMT 6.0.0 PROJ 6.3 Build-Deps Docker Image
     services: docker
     env:
@@ -63,7 +63,7 @@ matrix:
       - DOCKER_IMAGE=zberkowitz/mbsystem-deps:ubuntu-focal-proj6.3-gmt6.0.0
 
   - os: linux
-    if: repo = dwcaress/MB-System AND type = cron
+    if: repo = berkowski/MB-System AND type = cron
     name: Ubuntu Bionic (18.04) Build-Deps Docker Image
     services: docker
     env:
@@ -73,7 +73,7 @@ matrix:
       - DOCKER_IMAGE=zberkowitz/mbsystem-deps:ubuntu-bionic
 
   - os: linux
-    if: repo = dwcaress/MB-System AND type = cron
+    if: repo = berkowski/MB-System AND type = cron
     name: Ubuntu Disco (19.04) Build-Deps Docker Image
     services: docker
     env:
@@ -83,7 +83,7 @@ matrix:
       - DOCKER_IMAGE=zberkowitz/mbsystem-deps:ubuntu-disco
 
   - os: linux
-    if: repo = dwcaress/MB-System AND type = cron
+    if: repo = berkowski/MB-System AND type = cron
     name: Ubuntu Xenial (16.04) Build-Deps Docker Image
     services: docker
     env:
@@ -94,7 +94,7 @@ matrix:
       - DOCKER_IMAGE=zberkowitz/mbsystem-deps:ubuntu-xenial
 
   - os: linux
-    if: repo = dwcaress/MB-System AND type = cron
+    if: repo = berkowski/MB-System AND type = cron
     name: CentOS 7 Build-Deps Docker Image
     services: docker
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
 
   - os: linux
     name: Ubuntu Focal (20.04) Build-Deps Docker Image
-    if: repo = berkowski/MB-System AND type = cron
+    if: repo = dwcaress/MB-System AND type = cron
     services: docker
     env:
       - TRAVIS_CONFIG=docker_dep_image
@@ -51,7 +51,7 @@ matrix:
 
 
   - os: linux
-    if: repo = berkowski/MB-System AND type = cron
+    if: repo = dwcaress/MB-System AND type = cron
     name: Ubuntu Focal (20.04) GMT 6.0.0 PROJ 6.3 Build-Deps Docker Image
     services: docker
     env:
@@ -63,7 +63,7 @@ matrix:
       - DOCKER_IMAGE=zberkowitz/mbsystem-deps:ubuntu-focal-proj6.3-gmt6.0.0
 
   - os: linux
-    if: repo = berkowski/MB-System AND type = cron
+    if: repo = dwcaress/MB-System AND type = cron
     name: Ubuntu Bionic (18.04) Build-Deps Docker Image
     services: docker
     env:
@@ -74,7 +74,7 @@ matrix:
 
   # Disco repos are no longer online
   # - os: linux
-  #   if: repo = berkowski/MB-System AND type = cron
+  #   if: repo = dwcaress/MB-System AND type = cron
   #   name: Ubuntu Disco (19.04) Build-Deps Docker Image
   #   services: docker
   #   env:
@@ -84,7 +84,7 @@ matrix:
   #     - DOCKER_IMAGE=zberkowitz/mbsystem-deps:ubuntu-disco
 
   - os: linux
-    if: repo = berkowski/MB-System AND type = cron
+    if: repo = dwcaress/MB-System AND type = cron
     name: Ubuntu Xenial (16.04) Build-Deps Docker Image
     services: docker
     env:
@@ -95,7 +95,7 @@ matrix:
       - DOCKER_IMAGE=zberkowitz/mbsystem-deps:ubuntu-xenial
 
   - os: linux
-    if: repo = berkowski/MB-System AND type = cron
+    if: repo = dwcaress/MB-System AND type = cron
     name: CentOS 7 Build-Deps Docker Image
     services: docker
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,15 +72,16 @@ matrix:
       - OS_TAG=bionic
       - DOCKER_IMAGE=zberkowitz/mbsystem-deps:ubuntu-bionic
 
-  - os: linux
-    if: repo = berkowski/MB-System AND type = cron
-    name: Ubuntu Disco (19.04) Build-Deps Docker Image
-    services: docker
-    env:
-      - TRAVIS_CONFIG=docker_dep_image
-      - OS=ubuntu
-      - OS_TAG=disco
-      - DOCKER_IMAGE=zberkowitz/mbsystem-deps:ubuntu-disco
+  # Disco repos are no longer online
+  # - os: linux
+  #   if: repo = berkowski/MB-System AND type = cron
+  #   name: Ubuntu Disco (19.04) Build-Deps Docker Image
+  #   services: docker
+  #   env:
+  #     - TRAVIS_CONFIG=docker_dep_image
+  #     - OS=ubuntu
+  #     - OS_TAG=disco
+  #     - DOCKER_IMAGE=zberkowitz/mbsystem-deps:ubuntu-disco
 
   - os: linux
     if: repo = berkowski/MB-System AND type = cron

--- a/docker/centos/scripts/install-gmt.sh
+++ b/docker/centos/scripts/install-gmt.sh
@@ -19,5 +19,8 @@ cmake3 -DGSHHG_ROOT=/usr/share/gshhg-gmt -DDCW_ROOT=/usr/share/dcw-gmt ..
 make
 make install
 
+# Update ldconfig
+ldconfig -v
+
 cd ../..
 rm -rf gmt

--- a/docker/centos/scripts/install-proj.sh
+++ b/docker/centos/scripts/install-proj.sh
@@ -46,6 +46,9 @@ autoreconf -fvi
 make -j3 
 make install
 
+# Update ldconfig
+ldconfig -v
+
 popd
 
 rm -rf PROJ gdal

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:${OS_TAG}
 
 ARG GMT_SOURCE_TAG
 ARG PROJ_SOURCE_TAG
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install all dependencies except for proj and gmt from default repos
 RUN apt-get update && \

--- a/docker/ubuntu/scripts/install-gmt.sh
+++ b/docker/ubuntu/scripts/install-gmt.sh
@@ -19,5 +19,8 @@ cmake -DGSHHG_ROOT=/usr/share/gmt-gshhg -DDCW_ROOT=/usr/share/gmt-dcw ..
 make
 make install
 
+# Update ldconfig
+ldconfig -v
+
 cd ../..
 rm -rf gmt

--- a/docker/ubuntu/scripts/install-proj.sh
+++ b/docker/ubuntu/scripts/install-proj.sh
@@ -47,6 +47,9 @@ autoreconf -fvi
 make -j3 
 make install
 
+# Update ldconfig
+ldconfig -v
+
 popd
 
 rm -rf PROJ gdal


### PR DESCRIPTION
Fixes an issue in Ubuntu Xenial where GMT libraries could not be found at run time which failed some unit tests.