### PR TITLE
Fix documentation for format 59 - MBF_EM710MBA

### DIFF
--- a/src/html/mbsystem_formats.html
+++ b/src/html/mbsystem_formats.html
@@ -395,11 +395,11 @@ sonars are supported: </P>
 <UL>
 <LI>Format name:          MBF_EM710MBA</LI>
 
-<LI>Informal Description: Kongsberg current multibeam vendor format</LI>
+<LI>Informal Description: Kongsberg current multibeam processing format</LI>
 
 <LI>Attributes:           Kongsberg EM122, EM302, EM710,
                       bathymetry, amplitude, and sidescan,
-                      up to 400 beams, variable pixels, binary, Kongsberg.</LI>
+                      up to 400 beams, variable pixels, binary, MBARI.</LI>
 </UL>
 </UL>
 

--- a/src/htmlsrc/mbsystem_formats.html
+++ b/src/htmlsrc/mbsystem_formats.html
@@ -395,11 +395,11 @@ sonars are supported: </P>
 <UL>
 <LI>Format name:          MBF_EM710MBA</LI>
 
-<LI>Informal Description: Kongsberg current multibeam vendor format</LI>
+<LI>Informal Description: Kongsberg current multibeam processing format</LI>
 
 <LI>Attributes:           Kongsberg EM122, EM302, EM710,
                       bathymetry, amplitude, and sidescan,
-                      up to 400 beams, variable pixels, binary, Kongsberg.</LI>
+                      up to 400 beams, variable pixels, binary, MBARI.</LI>
 </UL>
 </UL>
 

--- a/src/man/man3/mbio.3
+++ b/src/man/man3/mbio.3
@@ -411,19 +411,19 @@ The following swath mapping sonar data formats are supported in this version of
 
     MBIO Data Format ID:  58
     Format name:          MBF_EM710RAW
-    Informal Description: Simrad current multibeam vendor format
-    Attributes:           Simrad EM710,
+    Informal Description: Kongsberg current multibeam vendor format
+    Attributes:           Kongsberg EM122, EM302, EM710,
                           bathymetry, amplitude, and sidescan,
                           up to 400 beams, variable pixels,
-    			  binary, Simrad.
+                          binary, Kongsberg.
 
     MBIO Data Format ID:  59
     Format name:          MBF_EM710MBA
-    Informal Description: Simrad current multibeam vendor format
-    Attributes:           Simrad EM710,
+    Informal Description: Kongsberg current multibeam processing format
+    Attributes:           Kongsberg EM122, EM302, EM710,
                           bathymetry, amplitude, and sidescan,
                           up to 400 beams, variable pixels,
-    			  binary, Simrad.
+                          binary, MBARI.
 
     MBIO Data Format ID:  61
     Format name:          MBF_MR1PRHIG

--- a/src/mbio/mbr_em710mba.c
+++ b/src/mbio/mbr_em710mba.c
@@ -90,9 +90,9 @@ int mbr_info_em710mba(int verbose, int *system, int *beams_bath_max, int *beams_
 	strncpy(format_name, "EM710MBA", MB_NAME_LENGTH);
 	strncpy(system_name, "SIMRAD3", MB_NAME_LENGTH);
 	strncpy(format_description,
-	        "Format name:          MBF_EM710MBA\nInformal Description: Kongsberg current multibeam vendor format\nAttributes:    "
+	        "Format name:          MBF_EM710MBA\nInformal Description: Kongsberg current multibeam processing format\nAttributes:    "
 	        "       Kongsberg EM122, EM302, EM710,\n                      bathymetry, amplitude, and sidescan,\n                 "
-	        "     up to 400 beams, variable pixels, binary, Kongsberg.\n",
+	        "     up to 400 beams, variable pixels, binary, MBARI.\n",
 	        MB_DESCRIPTION_LENGTH);
 	*numfile = 1;
 	*filetype = MB_FILETYPE_SINGLE;


### PR DESCRIPTION
Several places in the documentation, format 59 (EM710 processing format) was incorrectly described as the vendor format (same as format 58). This has been corrected, and "Simrad" has been updated to "Kongsberg" in the mbio man page for consistency with the rest of the code.