### PR TITLE
Fixes to mbnavlist, mbpreprocess, mbsslayout, mbnavlist

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ include "beta" in the tag name are preliminary and generally not announced.
 Distributions that do not include "beta" in the tag name correspond to the major,
 announced releases. The source distributions associated with all releases, major or beta, are equally accessible as tarballs through the Github interface.
 
+- **Version 5.7.6        October 4, 2020
 - Version 5.7.6beta56    September 28, 2020
 - Version 5.7.6beta55    September 16, 2020
 - Version 5.7.6beta54    September 14, 2020
@@ -366,7 +367,20 @@ announced releases. The source distributions associated with all releases, major
 ### MB-System Version 5.7 Release Notes:
 --
 
-#### 5.7.6 (September 29, 2020)
+#### 5.7.6 (October 4, 2020)
+
+Mbnavlist: Fixed bug in parsing -O option that sometimes resulting in the output
+of undesired values.
+
+Mbm_makeimagelist: New macro that constructs imagelist files of stereo photograph
+pairs as collected by MBARI's low altitude survey system. This is the first
+Python3 macro in MB-System.
+
+Format 88 (MBF_RESON7KR): Fixed calculation of speed when using the mb_extract_nav()
+function for navigation records.
+
+Mbpreprocess: Fixed problems with the --kluge-time-jumps option for fixing
+jumps in timestamps.
 
 Mbsslayout: Add blanking interval to option --altitude-bottompick-threshold=threshold[/blank]
 so that when picking the bottom return in the sidescan time series, nearfield backscatter

--- a/configure
+++ b/configure
@@ -2728,7 +2728,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
-$as_echo "#define VERSION_DATE \"29 September 2020\"" >>confdefs.h
+$as_echo "#define VERSION_DATE \"4 October 2020\"" >>confdefs.h
 
 
 $as_echo " "

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ dnl--------------------------------------------------------------------
 
 dnl Initialize and set version and version date
 AC_INIT([mbsystem],[5.7.6],[http://listserver.mbari.org/sympa/arc/mbsystem],[mbsystem],[http://www.mbari.org/data/mbsystem/])
-AC_DEFINE(VERSION_DATE, ["29 September 2020"], [Set VERSION_DATE define in mb_config.h])
+AC_DEFINE(VERSION_DATE, ["4 October 2020"], [Set VERSION_DATE define in mb_config.h])
 
 AS_ECHO([" "])
 AS_ECHO(["------------------------------------------------------------------------------"])

--- a/libtool
+++ b/libtool
@@ -1,6 +1,6 @@
 #! /bin/sh
 # Generated automatically by config.status (mbsystem) 5.7.6
-# Libtool was configured on host tharp.local:
+# Libtool was configured on host mbari1797.shore.mbari.org:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.

--- a/src/html/mbsystem_version.txt
+++ b/src/html/mbsystem_version.txt
@@ -1,2 +1,2 @@
 MB-System Version:  "5.7.6"
-MB-System Release Date:  "29 September 2020"
+MB-System Release Date:  "4 October 2020"

--- a/src/htmlsrc/mbsystem_version.txt
+++ b/src/htmlsrc/mbsystem_version.txt
@@ -1,2 +1,2 @@
 MB-System Version:  "5.7.6"
-MB-System Release Date:  "29 September 2020"
+MB-System Release Date:  "4 October 2020"

--- a/src/mbio/mb_config.h
+++ b/src/mbio/mb_config.h
@@ -128,7 +128,7 @@
 #define VERSION "5.7.6"
 
 /* Set VERSION_DATE define in mb_config.h */
-#define VERSION_DATE "29 September 2020"
+#define VERSION_DATE "4 October 2020"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/src/mbio/mbsys_reson7k3.c
+++ b/src/mbio/mbsys_reson7k3.c
@@ -7510,6 +7510,9 @@ int mbsys_reson7k3_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int
     *time_d = store->time_d;
 
     /* get Navigation */
+    *speed = 0.0;
+    if (mb_io_ptr->nfix > 0)
+      mb_navint_interp(verbose, mbio_ptr, store->time_d, *heading, *speed, navlon, navlat, speed, error);
     *navlon = RTD * Navigation->longitude;
     *navlat = RTD * Navigation->latitude;
 
@@ -7544,6 +7547,8 @@ int mbsys_reson7k3_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int
 
     /* get navigation */
     *speed = 0.0;
+    if (mb_io_ptr->nfix > 0)
+      mb_navint_interp(verbose, mbio_ptr, store->time_d, *heading, *speed, navlon, navlat, speed, error);
     *navlon = RTD * Position->longitude_easting;
     *navlat = RTD * Position->latitude_northing;
 

--- a/src/photo/Makefile.am
+++ b/src/photo/Makefile.am
@@ -1,4 +1,5 @@
 bin_PROGRAMS = mbphotomosaic mbgetphotocorrection mbphotogrammetry
+bin_SCRIPTS = mbm_makeimagelist
 
 include_HEADERS =
 

--- a/src/photo/Makefile.in
+++ b/src/photo/Makefile.in
@@ -15,6 +15,7 @@
 @SET_MAKE@
 
 
+
 VPATH = @srcdir@
 am__is_gnu_make = { \
   if test -z '$(MAKELEVEL)'; then \
@@ -108,7 +109,8 @@ mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/src/mbio/mb_config.h
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
-am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(includedir)"
+am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(bindir)" \
+	"$(DESTDIR)$(includedir)"
 PROGRAMS = $(bin_PROGRAMS)
 am_mbgetphotocorrection_OBJECTS = mbgetphotocorrection.$(OBJEXT)
 mbgetphotocorrection_OBJECTS = $(am_mbgetphotocorrection_OBJECTS)
@@ -123,6 +125,34 @@ mbphotogrammetry_LDADD = $(LDADD)
 am_mbphotomosaic_OBJECTS = mbphotomosaic.$(OBJEXT)
 mbphotomosaic_OBJECTS = $(am_mbphotomosaic_OBJECTS)
 mbphotomosaic_LDADD = $(LDADD)
+am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
+am__vpath_adj = case $$p in \
+    $(srcdir)/*) f=`echo "$$p" | sed "s|^$$srcdirstrip/||"`;; \
+    *) f=$$p;; \
+  esac;
+am__strip_dir = f=`echo $$p | sed -e 's|^.*/||'`;
+am__install_max = 40
+am__nobase_strip_setup = \
+  srcdirstrip=`echo "$(srcdir)" | sed 's/[].[^$$\\*|]/\\\\&/g'`
+am__nobase_strip = \
+  for p in $$list; do echo "$$p"; done | sed -e "s|$$srcdirstrip/||"
+am__nobase_list = $(am__nobase_strip_setup); \
+  for p in $$list; do echo "$$p $$p"; done | \
+  sed "s| $$srcdirstrip/| |;"' / .*\//!s/ .*/ ./; s,\( .*\)/[^/]*$$,\1,' | \
+  $(AWK) 'BEGIN { files["."] = "" } { files[$$2] = files[$$2] " " $$1; \
+    if (++n[$$2] == $(am__install_max)) \
+      { print $$2, files[$$2]; n[$$2] = 0; files[$$2] = "" } } \
+    END { for (dir in files) print dir, files[dir] }'
+am__base_list = \
+  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\n/ /g' | \
+  sed '$$!N;$$!N;$$!N;$$!N;s/\n/ /g'
+am__uninstall_files_from_dir = { \
+  test -z "$$files" \
+    || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
+    || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
+         $(am__cd) "$$dir" && rm -f $$files; }; \
+  }
+SCRIPTS = $(bin_SCRIPTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -166,33 +196,6 @@ am__can_run_installinfo = \
     n|no|NO) false;; \
     *) (install-info --version) >/dev/null 2>&1;; \
   esac
-am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
-am__vpath_adj = case $$p in \
-    $(srcdir)/*) f=`echo "$$p" | sed "s|^$$srcdirstrip/||"`;; \
-    *) f=$$p;; \
-  esac;
-am__strip_dir = f=`echo $$p | sed -e 's|^.*/||'`;
-am__install_max = 40
-am__nobase_strip_setup = \
-  srcdirstrip=`echo "$(srcdir)" | sed 's/[].[^$$\\*|]/\\\\&/g'`
-am__nobase_strip = \
-  for p in $$list; do echo "$$p"; done | sed -e "s|$$srcdirstrip/||"
-am__nobase_list = $(am__nobase_strip_setup); \
-  for p in $$list; do echo "$$p $$p"; done | \
-  sed "s| $$srcdirstrip/| |;"' / .*\//!s/ .*/ ./; s,\( .*\)/[^/]*$$,\1,' | \
-  $(AWK) 'BEGIN { files["."] = "" } { files[$$2] = files[$$2] " " $$1; \
-    if (++n[$$2] == $(am__install_max)) \
-      { print $$2, files[$$2]; n[$$2] = 0; files[$$2] = "" } } \
-    END { for (dir in files) print dir, files[dir] }'
-am__base_list = \
-  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\n/ /g' | \
-  sed '$$!N;$$!N;$$!N;$$!N;s/\n/ /g'
-am__uninstall_files_from_dir = { \
-  test -z "$$files" \
-    || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
-    || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
-         $(am__cd) "$$dir" && rm -f $$files; }; \
-  }
 HEADERS = $(include_HEADERS)
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 # Read a list of newline-separated strings from the standard input,
@@ -415,6 +418,7 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+bin_SCRIPTS = mbm_makeimagelist
 include_HEADERS = 
 AM_CPPFLAGS = -I${top_srcdir}/src/mbio -I${top_srcdir}/src/mbaux \
 	${opencv4_CPPFLAGS}
@@ -516,6 +520,41 @@ mbphotogrammetry$(EXEEXT): $(mbphotogrammetry_OBJECTS) $(mbphotogrammetry_DEPEND
 mbphotomosaic$(EXEEXT): $(mbphotomosaic_OBJECTS) $(mbphotomosaic_DEPENDENCIES) $(EXTRA_mbphotomosaic_DEPENDENCIES) 
 	@rm -f mbphotomosaic$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(mbphotomosaic_OBJECTS) $(mbphotomosaic_LDADD) $(LIBS)
+install-binSCRIPTS: $(bin_SCRIPTS)
+	@$(NORMAL_INSTALL)
+	@list='$(bin_SCRIPTS)'; test -n "$(bindir)" || list=; \
+	if test -n "$$list"; then \
+	  echo " $(MKDIR_P) '$(DESTDIR)$(bindir)'"; \
+	  $(MKDIR_P) "$(DESTDIR)$(bindir)" || exit 1; \
+	fi; \
+	for p in $$list; do \
+	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
+	  if test -f "$$d$$p"; then echo "$$d$$p"; echo "$$p"; else :; fi; \
+	done | \
+	sed -e 'p;s,.*/,,;n' \
+	    -e 'h;s|.*|.|' \
+	    -e 'p;x;s,.*/,,;$(transform)' | sed 'N;N;N;s,\n, ,g' | \
+	$(AWK) 'BEGIN { files["."] = ""; dirs["."] = 1; } \
+	  { d=$$3; if (dirs[d] != 1) { print "d", d; dirs[d] = 1 } \
+	    if ($$2 == $$4) { files[d] = files[d] " " $$1; \
+	      if (++n[d] == $(am__install_max)) { \
+		print "f", d, files[d]; n[d] = 0; files[d] = "" } } \
+	    else { print "f", d "/" $$4, $$1 } } \
+	  END { for (d in files) print "f", d, files[d] }' | \
+	while read type dir files; do \
+	     if test "$$dir" = .; then dir=; else dir=/$$dir; fi; \
+	     test -z "$$files" || { \
+	       echo " $(INSTALL_SCRIPT) $$files '$(DESTDIR)$(bindir)$$dir'"; \
+	       $(INSTALL_SCRIPT) $$files "$(DESTDIR)$(bindir)$$dir" || exit $$?; \
+	     } \
+	; done
+
+uninstall-binSCRIPTS:
+	@$(NORMAL_UNINSTALL)
+	@list='$(bin_SCRIPTS)'; test -n "$(bindir)" || exit 0; \
+	files=`for p in $$list; do echo "$$p"; done | \
+	       sed -e 's,.*/,,;$(transform)'`; \
+	dir='$(DESTDIR)$(bindir)'; $(am__uninstall_files_from_dir)
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
@@ -637,9 +676,9 @@ distclean-tags:
 	-rm -f TAGS ID GTAGS GRTAGS GSYMS GPATH tags
 check-am: all-am
 check: check-am
-all-am: Makefile $(PROGRAMS) $(HEADERS)
+all-am: Makefile $(PROGRAMS) $(SCRIPTS) $(HEADERS)
 installdirs:
-	for dir in "$(DESTDIR)$(bindir)" "$(DESTDIR)$(includedir)"; do \
+	for dir in "$(DESTDIR)$(bindir)" "$(DESTDIR)$(bindir)" "$(DESTDIR)$(includedir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-am
@@ -702,7 +741,7 @@ install-dvi: install-dvi-am
 
 install-dvi-am:
 
-install-exec-am: install-binPROGRAMS
+install-exec-am: install-binPROGRAMS install-binSCRIPTS
 
 install-html: install-html-am
 
@@ -744,7 +783,8 @@ ps: ps-am
 
 ps-am:
 
-uninstall-am: uninstall-binPROGRAMS uninstall-includeHEADERS
+uninstall-am: uninstall-binPROGRAMS uninstall-binSCRIPTS \
+	uninstall-includeHEADERS
 
 .MAKE: install-am install-strip
 
@@ -752,16 +792,17 @@ uninstall-am: uninstall-binPROGRAMS uninstall-includeHEADERS
 	clean-binPROGRAMS clean-generic clean-libtool cscopelist-am \
 	ctags ctags-am distclean distclean-compile distclean-generic \
 	distclean-libtool distclean-tags dvi dvi-am html html-am info \
-	info-am install install-am install-binPROGRAMS install-data \
-	install-data-am install-dvi install-dvi-am install-exec \
-	install-exec-am install-html install-html-am \
-	install-includeHEADERS install-info install-info-am \
-	install-man install-pdf install-pdf-am install-ps \
-	install-ps-am install-strip installcheck installcheck-am \
-	installdirs maintainer-clean maintainer-clean-generic \
-	mostlyclean mostlyclean-compile mostlyclean-generic \
-	mostlyclean-libtool pdf pdf-am ps ps-am tags tags-am uninstall \
-	uninstall-am uninstall-binPROGRAMS uninstall-includeHEADERS
+	info-am install install-am install-binPROGRAMS \
+	install-binSCRIPTS install-data install-data-am install-dvi \
+	install-dvi-am install-exec install-exec-am install-html \
+	install-html-am install-includeHEADERS install-info \
+	install-info-am install-man install-pdf install-pdf-am \
+	install-ps install-ps-am install-strip installcheck \
+	installcheck-am installdirs maintainer-clean \
+	maintainer-clean-generic mostlyclean mostlyclean-compile \
+	mostlyclean-generic mostlyclean-libtool pdf pdf-am ps ps-am \
+	tags tags-am uninstall uninstall-am uninstall-binPROGRAMS \
+	uninstall-binSCRIPTS uninstall-includeHEADERS
 
 .PRECIOUS: Makefile
 

--- a/src/photo/mbm_makeimagelist
+++ b/src/photo/mbm_makeimagelist
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+####
+# Simple Script to create imagelist.mb-2
+#
+# 09/22/18  GT   Created
+
+import sys, getopt, os
+import glob, csv
+from datetime import datetime
+from collections import namedtuple
+
+
+shortOpts = "hd:f:o:g:x"
+longOpts = ["help", "imdir=", "imformat=", "outfile=", "gpsfile=", "nogpsfile"]
+
+def usage():
+  pname, sname = os.path.split(sys.argv[0])
+  sys.stderr.write("usage: % s %s < path > \n" % (sname, str(longOpts)))
+  print( """
+  -h --help                  print this message
+  -d --imdir=path2images     Path to image files (default './')
+  -f --imformat=image_format Image format [image_format] [default 'tif']
+  -o --outfile=outfname      Output data to [ofname] [default 'imagelist']
+  -g --gpsfile=gpsfname      GPS time data from [gpsfname] [default './../logfile_gpstime_cam_sync.csv']
+  -x --nogpsfile             Avoid using GPS tigger times (just image time matching)
+  """ )
+  sys.exit()
+
+def utime_text(ts):
+  return datetime.utcfromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S')
+
+def StereoMatching(tleft, tright):
+  j,k = 0,0
+  matchStereo  = []
+  nomatch_left = []
+  nomatch_right = []
+  stereoItem = namedtuple('stereoItem', ['tleft','tright','tgps'])
+  MAX_DIFFERENCE_IMG_TIME = 1e5
+
+  while j < len(tleft) and k < len(tright):
+    # Left image without right
+    if tleft[j] <  tright[k] - MAX_DIFFERENCE_IMG_TIME:
+      nomatch_left.append(tleft[j])
+      j += 1
+    # Right image without left
+    elif tright[k] <  tleft[j] - MAX_DIFFERENCE_IMG_TIME:
+      nomatch_right.append(tright[k])
+      k += 1
+    # STEREO MATCH
+    else:
+      stereo = stereoItem(tleft = tleft[j], tright = tright[k], tgps = tleft[j])
+      matchStereo.append(stereo)
+      j+= 1;k+= 1
+
+  if j < len(tleft):
+    nomatch_left.extend(tleft[j:])
+
+  if k < len(tright):
+    nomatch_right.extend(tright[k:])
+
+  return matchStereo, nomatch_left, nomatch_right
+
+
+def StereoMatchingGPS(tgps, tleft, tright):
+  i,j,k = 0,0,0
+  matchStereo  = []
+  nomatch_left = []
+  nomatch_right = []
+  stereoItem = namedtuple('stereoItem', ['tleft','tright','tgps'])
+  MAX_DIFFERENCE_IMG_TIME = 1e5
+
+  while i < len(tgps) and j < len(tleft) and k < len(tright):
+    # Trigger without images
+    if tgps[i] < min(tleft[j],tright[k])-MAX_DIFFERENCE_IMG_TIME:
+      i += 1 # Dropping triger
+    # Left image without trigger
+    elif tleft[j] <  tgps[i] - MAX_DIFFERENCE_IMG_TIME:
+      nomatch_left.append(tleft[j])
+      j += 1
+    # Right image without trigger
+    elif tright[k] <  tgps[i] - MAX_DIFFERENCE_IMG_TIME:
+      nomatch_right.append(tright[k])
+      k += 1
+    # STEREO MATCH
+    elif (abs(tleft[j] - tgps[i])<MAX_DIFFERENCE_IMG_TIME) and (abs(tright[k] - tgps[i])<MAX_DIFFERENCE_IMG_TIME):
+      stereo = stereoItem(tleft = tleft[j], tright = tright[k], tgps = tgps[i])
+      matchStereo.append(stereo)
+      i+= 1;j+= 1;k+= 1
+    # Only left image match with trigger
+    elif abs(tleft[j] - tgps[i])<MAX_DIFFERENCE_IMG_TIME:
+      nomatch_left.append(tleft[j])
+      i += 1; j += 1
+    # Only right image match with trigger
+    elif abs(tright[k] - tgps[i])<MAX_DIFFERENCE_IMG_TIME:
+      nomatch_right.append(tright[k])
+      i += 1; k += 1
+    else:
+      print("StereoMatchingGPS: Condition not expected")
+
+  if j < len(tleft):
+    nomatch_left.extend(tleft[j:])
+
+  if k < len(tright):
+    nomatch_right.extend(tright[k:])
+
+  return matchStereo, nomatch_left, nomatch_right
+
+
+def saveFiles(outdir, outFname, imformat, matchStereo, nomatch_left, nomatch_right, tleft, tright):
+  # 0. Stereo Matches NO GPS
+  imfile = open(outdir+'/'+outFname+"-stereo.mb-2", "w")
+  imfile.write("#STEREOCAMERA\n#\n# Date range of files:\n")
+  imfile.write("# "+utime_text(matchStereo[0].tgps/1e6)+"  to  "+utime_text(matchStereo[-1].tgps/1e6)+"\n#\n")
+  for st in matchStereo:
+    imfile.write('PROSILICA_L/'+str(st.tleft)+'.'+imformat+'\t\t')
+    imfile.write('PROSILICA_R/'+str(st.tright)+'.'+imformat+'\t\t')
+    imfile.write("%.6f"%(st.tgps/1e6)+'\t'+'0 \n');
+  imfile.close()
+  # 1. Left imagelist
+  imfile = open(outdir+'/'+outFname+"-left.mb-2", "w")
+  imfile.write("#LEFTCAMERA\n#\n# Date range of files:\n")
+  imfile.write("# "+utime_text(matchStereo[0].tgps/1e6)+"  to  "+utime_text(matchStereo[-1].tgps/1e6)+"\n#\n")
+  for lt in tleft:
+    imfile.write('PROSILICA_L/'+str(lt)+'.'+imformat+'\t\t')
+    imfile.write("%.6f"%(lt/1e6)+'\n');
+  imfile.close()
+  # 2. Right imagelist
+  imfile = open(outdir+'/'+outFname+"-right.mb-2", "w")
+  imfile.write("#RIGHTCAMERA\n#\n# Date range of files:\n")
+  imfile.write("# "+utime_text(matchStereo[0].tgps/1e6)+"  to  "+utime_text(matchStereo[-1].tgps/1e6)+"\n#\n")
+  for rt in tright:
+    imfile.write('PROSILICA_R/'+str(rt)+'.'+imformat+'\t\t')
+    imfile.write("%.6f"%(rt/1e6)+'\n');
+  imfile.close()
+  # 3. NO MATCHES
+  imfile = open(outdir+'/'+"no_match.txt", "w")
+  imfile.write("#\n# Date range of files:\n")
+  imfile.write("# "+utime_text(matchStereo[0].tgps/1e6)+"  to  "+utime_text(matchStereo[-1].tgps/1e6)+"\n#\n")
+  imfile.write("# No matched LEFT images:\n")
+  for lt in nomatch_left:
+    imfile.write('PROSILICA_L/'+str(lt)+'.'+imformat+'\n')
+  imfile.write("# No matched RIGHT images:\n")
+  for rt in nomatch_right:
+    imfile.write('PROSILICA_R/'+str(rt)+'.'+imformat+'\n')
+  imfile.close()
+
+def main (args, opts={}):
+  imdir    = "./"
+  outdir   = "./"
+  imformat = "tif"
+  outFname = "imagelist"
+  gpsFname = "/../logfile_gpstime_cam_sync.csv"
+  fGPStimes = True
+  for o, a in opts:
+      if o in ("-h", "--help"):
+        usage()
+      elif o in ("-d", "--imdir"):
+        imdir = a
+      elif o in ("-f", "--imformat"):
+        imdir = a
+      elif o in ("-o", "--outfile"):
+        outFname = a
+      elif o in ("-g", "--gpsfile"):
+        gpsFname = a
+      elif o in ("-x", "--nogpsfile"):
+        fGPStimes = False
+      else:
+        assert False, "unhandled option: "+o+" "+a
+
+  if os.path.dirname(outFname) == '':
+    outdir   = imdir
+    outFname = os.path.basename(outFname)
+  else:
+    outdir   = os.path.dirname(outFname)
+    outFname = os.path.basename(outFname)
+
+  # Getting image list
+  imlist_left  = [os.path.basename(f) for f in sorted(glob.glob(imdir+"/PROSILICA_L/*."+imformat))]
+  imlist_right = [os.path.basename(f) for f in sorted(glob.glob(imdir+"/PROSILICA_R/*."+imformat))]
+
+  tlist_left   = [int(os.path.splitext(f)[0]) for f in imlist_left]
+  tlist_right  = [int(os.path.splitext(f)[0]) for f in imlist_right]
+
+  #  Use GPS Triggers?
+  if fGPStimes:
+    # Getting GPS times
+    with open(imdir+gpsFname, "r") as f:
+      reader = csv.reader(f)
+      tlist_gps_raw = list(reader)
+    tlist_gps = [int(row[0]) for row in tlist_gps_raw]
+
+    # Matching Stereo Images with GPS tiggers
+    matchStereo, nomatch_left, nomatch_right  = StereoMatchingGPS(tlist_gps,tlist_left,tlist_right)
+    print(str(len(matchStereo))+"\t stereo images matched with GPS triggers")
+    print(str(len(nomatch_left))+"\t left images not matched with GPS triggers")
+    print(str(len(nomatch_right))+"\t right images not matched with GPS triggers")
+
+  else:
+    # Matching Stereo Images between them (no GPS)
+    matchStereo, nomatch_left, nomatch_right  = StereoMatching(tlist_left,tlist_right)
+    print(str(len(matchStereo))+"\t stereo images matched")
+    print(str(len(nomatch_left))+"\t left images not matched")
+    print(str(len(nomatch_right))+"\t right images not matched")
+
+  # Save Outputs
+  saveFiles(outdir, outFname, imformat, matchStereo, nomatch_left, nomatch_right, tlist_left, tlist_right)
+
+
+if __name__ == "__main__":
+  # Parse command line arguments
+  try:
+      opts, args = getopt.gnu_getopt(sys.argv[1:], shortOpts, longOpts)
+  except getopt.GetoptError as err:
+      # print help information and exit:
+      print (str(err)) # will print something like "option -a not recognized"
+      usage()
+
+  # Run main script
+  main (args,opts)

--- a/src/ps/mb7k2jstar.ps
+++ b/src/ps/mb7k2jstar.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:18 2020
+%%CreationDate: Sat Oct  3 23:44:02 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mb7k2ss.ps
+++ b/src/ps/mb7k2ss.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:18 2020
+%%CreationDate: Sat Oct  3 23:44:03 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mb7kpreprocess.ps
+++ b/src/ps/mb7kpreprocess.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:03 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbabsorption.ps
+++ b/src/ps/mbabsorption.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:03 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbareaclean.ps
+++ b/src/ps/mbareaclean.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:03 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbauvloglist.ps
+++ b/src/ps/mbauvloglist.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:03 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbauvnavusbl.ps
+++ b/src/ps/mbauvnavusbl.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:03 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbbackangle.ps
+++ b/src/ps/mbbackangle.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:03 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbclean.ps
+++ b/src/ps/mbclean.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:03 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbconfig.ps
+++ b/src/ps/mbconfig.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:03 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%DocumentSuppliedResources: procset grops 1.19 2

--- a/src/ps/mbcontour.ps
+++ b/src/ps/mbcontour.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:04 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbcopy.ps
+++ b/src/ps/mbcopy.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:04 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbctdlist.ps
+++ b/src/ps/mbctdlist.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:04 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbdatalist.ps
+++ b/src/ps/mbdatalist.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:04 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbdefaults.ps
+++ b/src/ps/mbdefaults.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:04 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbdumpesf.ps
+++ b/src/ps/mbdumpesf.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:04 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbedit.ps
+++ b/src/ps/mbedit.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:04 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbeditviz.ps
+++ b/src/ps/mbeditviz.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:04 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbextractsegy.ps
+++ b/src/ps/mbextractsegy.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:19 2020
+%%CreationDate: Sat Oct  3 23:44:04 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbfilter.ps
+++ b/src/ps/mbfilter.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:04 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbformat.ps
+++ b/src/ps/mbformat.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:04 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbgetesf.ps
+++ b/src/ps/mbgetesf.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:05 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbgpstide.ps
+++ b/src/ps/mbgpstide.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:05 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbgrd2obj.ps
+++ b/src/ps/mbgrd2obj.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:05 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbgrdtiff.ps
+++ b/src/ps/mbgrdtiff.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:05 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbgrdviz.ps
+++ b/src/ps/mbgrdviz.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:05 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbgrid.ps
+++ b/src/ps/mbgrid.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:05 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbhistogram.ps
+++ b/src/ps/mbhistogram.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:05 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbhsdump.ps
+++ b/src/ps/mbhsdump.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:05 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbhysweeppreprocess.ps
+++ b/src/ps/mbhysweeppreprocess.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:05 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbinfo.ps
+++ b/src/ps/mbinfo.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:06 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbio.ps
+++ b/src/ps/mbio.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:11 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbkongsbergpreprocess.ps
+++ b/src/ps/mbkongsbergpreprocess.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:20 2020
+%%CreationDate: Sat Oct  3 23:44:06 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mblevitus.ps
+++ b/src/ps/mblevitus.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:06 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mblist.ps
+++ b/src/ps/mblist.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:06 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_arc2grd.ps
+++ b/src/ps/mbm_arc2grd.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:06 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_bpr.ps
+++ b/src/ps/mbm_bpr.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:06 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_copy.ps
+++ b/src/ps/mbm_copy.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:06 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_fmtvel.ps
+++ b/src/ps/mbm_fmtvel.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:06 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_grd2arc.ps
+++ b/src/ps/mbm_grd2arc.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_grd2geovrml.ps
+++ b/src/ps/mbm_grd2geovrml.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_grd3dplot.ps
+++ b/src/ps/mbm_grd3dplot.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_grdcut.ps
+++ b/src/ps/mbm_grdcut.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_grdinfo.ps
+++ b/src/ps/mbm_grdinfo.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_grdplot.ps
+++ b/src/ps/mbm_grdplot.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:21 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_grdtiff.ps
+++ b/src/ps/mbm_grdtiff.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_grid.ps
+++ b/src/ps/mbm_grid.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_histplot.ps
+++ b/src/ps/mbm_histplot.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_makedatalist.ps
+++ b/src/ps/mbm_makedatalist.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_makesvp.ps
+++ b/src/ps/mbm_makesvp.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_multicopy.ps
+++ b/src/ps/mbm_multicopy.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:07 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_multidatalist.ps
+++ b/src/ps/mbm_multidatalist.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:08 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_multiprocess.ps
+++ b/src/ps/mbm_multiprocess.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:08 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_plot.ps
+++ b/src/ps/mbm_plot.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:08 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_route2mission.ps
+++ b/src/ps/mbm_route2mission.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:08 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_stat.ps
+++ b/src/ps/mbm_stat.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:08 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_utm.ps
+++ b/src/ps/mbm_utm.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:08 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_xbt.ps
+++ b/src/ps/mbm_xbt.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:08 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbm_xyplot.ps
+++ b/src/ps/mbm_xyplot.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:08 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbmakeplatform.ps
+++ b/src/ps/mbmakeplatform.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:08 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbminirovnav.ps
+++ b/src/ps/mbminirovnav.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:22 2020
+%%CreationDate: Sat Oct  3 23:44:08 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbmosaic.ps
+++ b/src/ps/mbmosaic.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:09 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbnavadjust.ps
+++ b/src/ps/mbnavadjust.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:09 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbnavadjustmerge.ps
+++ b/src/ps/mbnavadjustmerge.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:09 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbnavedit.ps
+++ b/src/ps/mbnavedit.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:09 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbnavlist.ps
+++ b/src/ps/mbnavlist.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:09 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbneptune2esf.ps
+++ b/src/ps/mbneptune2esf.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:09 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbotps.ps
+++ b/src/ps/mbotps.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:09 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbpreprocess.ps
+++ b/src/ps/mbpreprocess.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:09 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbprocess.ps
+++ b/src/ps/mbprocess.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:09 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbps.ps
+++ b/src/ps/mbps.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:09 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbrollbias.ps
+++ b/src/ps/mbrollbias.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:09 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbrolltimelag.ps
+++ b/src/ps/mbrolltimelag.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbroutetime.ps
+++ b/src/ps/mbroutetime.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbsegygrid.ps
+++ b/src/ps/mbsegygrid.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbsegyinfo.ps
+++ b/src/ps/mbsegyinfo.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:23 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbsegylist.ps
+++ b/src/ps/mbsegylist.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbsegypsd.ps
+++ b/src/ps/mbsegypsd.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbset.ps
+++ b/src/ps/mbset.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbsslayout.ps
+++ b/src/ps/mbsslayout.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbstripnan.ps
+++ b/src/ps/mbstripnan.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%DocumentSuppliedResources: procset grops 1.19 2

--- a/src/ps/mbsvplist.ps
+++ b/src/ps/mbsvplist.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbsvpselect.ps
+++ b/src/ps/mbsvpselect.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbswath.ps
+++ b/src/ps/mbswath.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbswplspreprocess.ps
+++ b/src/ps/mbswplspreprocess.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:10 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbsystem.ps
+++ b/src/ps/mbsystem.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:11 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbtime.ps
+++ b/src/ps/mbtime.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:11 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbvelocitytool.ps
+++ b/src/ps/mbvelocitytool.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:11 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/ps/mbvoxelclean.ps
+++ b/src/ps/mbvoxelclean.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Creator: groff version 1.19.2
-%%CreationDate: Tue Sep 29 00:59:24 2020
+%%CreationDate: Sat Oct  3 23:44:11 2020
 %%DocumentNeededResources: font Times-Roman
 %%+ font Times-Bold
 %%+ font Times-Italic

--- a/src/utilities/mbnavlist.cc
+++ b/src/utilities/mbnavlist.cc
@@ -205,12 +205,16 @@ int main(int argc, char **argv) {
 				break;
 			case 'O':
 			case 'o':
-				for (int j = 0, n_list = 0; j < (int)strlen(optarg); j++, n_list++)
-					if (n_list < MAX_OPTIONS) {
-						list[n_list] = optarg[j];
-						if (list[n_list] == '^')
-							use_projection = true;
-					}
+        if (strlen(optarg) > 0) {
+          n_list = MIN(strlen(optarg), MAX_OPTIONS);
+          for (int j = 0; j < n_list; j++){
+            if (j < MAX_OPTIONS) {
+              list[j] = optarg[j];
+              if (list[j] == '^')
+                use_projection = true;
+            }
+          }
+        }
 				break;
 			case 'R':
 			case 'r':


### PR DESCRIPTION
Mbnavlist: Fixed bug in parsing -O option that sometimes resulting in the output
of undesired values.

Mbm_makeimagelist: New macro that constructs imagelist files of stereo photograph
pairs as collected by MBARI's low altitude survey system. This is the first
Python3 macro in MB-System.

Format 88 (MBF_RESON7KR): Fixed calculation of speed when using the mb_extract_nav()
function for navigation records.

Mbpreprocess: Fixed problems with the --kluge-time-jumps option for fixing
jumps in timestamps.

Mbsslayout: Add blanking interval to option --altitude-bottompick-threshold=threshold[/blank]
so that when picking the bottom return in the sidescan time series, nearfield backscatter
can be ignored out to the time interval in seconds given by the value blank.