### PR TITLE
Bug fix for formats 88 and 89

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -378,6 +378,9 @@ or beta, are equally accessible as tarballs through the Github interface.
 --
 #### 5.7.7beta07 (January 5, 2020)
 
+Formats 88 (MBF_RESON7KR) and 89 (MBF_RESON7K3): Fixed bug in handling of
+PingMotion data records (7012) that caused memory overruns and seg faults.
+
 Mbclean: Fixed two bugs. The first involved setting the left/right bounds of
 flagging by acrosstrack distance using the -Y option, and the other resulted in
 slope flagging being applied when not requested when the -Y option was used alone.

--- a/src/mbio/mbr_reson7k3.c
+++ b/src/mbio/mbr_reson7k3.c
@@ -4814,56 +4814,54 @@ int mbr_reson7k3_rd_PingMotion(int verbose, char *buffer, void *store_ptr, int *
 
   /* allocate memory for PingMotion if needed */
   if (status == MB_SUCCESS && PingMotion->nalloc < PingMotion->n) {
-    PingMotion->nalloc = sizeof(float) * PingMotion->n;
+    size_t size = sizeof(float) * PingMotion->n;
     if (status == MB_SUCCESS)
-      status = mb_reallocd(verbose, __FILE__, __LINE__, PingMotion->nalloc, (void **)&(PingMotion->roll), error);
-    if (status != MB_SUCCESS) {
-      PingMotion->nalloc = 0;
-    }
+      status = mb_reallocd(verbose, __FILE__, __LINE__, size, (void **)&(PingMotion->roll), error);
     if (status == MB_SUCCESS)
-      status = mb_reallocd(verbose, __FILE__, __LINE__, PingMotion->nalloc, (void **)&(PingMotion->heading), error);
-    if (status != MB_SUCCESS) {
-      PingMotion->nalloc = 0;
-    }
+      status = mb_reallocd(verbose, __FILE__, __LINE__, size, (void **)&(PingMotion->heading), error);
     if (status == MB_SUCCESS)
-      status = mb_reallocd(verbose, __FILE__, __LINE__, PingMotion->nalloc, (void **)&(PingMotion->heave), error);
-    if (status != MB_SUCCESS) {
-      PingMotion->nalloc = 0;
-    }
-  }
+      status = mb_reallocd(verbose, __FILE__, __LINE__, size, (void **)&(PingMotion->heave), error);
+    if (status == MB_SUCCESS) {
+      PingMotion->nalloc = PingMotion->n;
 
-  /* extract PingMotion data */
-  if (PingMotion->flags & 2) {
-    for (int i = 0; i < PingMotion->n; i++) {
-      mb_get_binary_float(true, &buffer[index], &(PingMotion->roll[i]));
-      index += 4;
+      /* extract PingMotion data */
+      if (PingMotion->flags & 2) {
+        for (int i = 0; i < PingMotion->n; i++) {
+          mb_get_binary_float(true, &buffer[index], &(PingMotion->roll[i]));
+          index += 4;
+        }
+      }
+      else {
+        for (int i = 0; i < PingMotion->n; i++) {
+          PingMotion->roll[i] = 0.0;
+        }
+      }
+      if (PingMotion->flags & 4) {
+        for (int i = 0; i < PingMotion->n; i++) {
+          mb_get_binary_float(true, &buffer[index], &(PingMotion->heading[i]));
+          index += 4;
+        }
+      }
+      else {
+        for (int i = 0; i < PingMotion->n; i++) {
+          PingMotion->heading[i] = 0.0;
+        }
+      }
+      if (PingMotion->flags & 8) {
+        for (int i = 0; i < PingMotion->n; i++) {
+          mb_get_binary_float(true, &buffer[index], &(PingMotion->heave[i]));
+          index += 4;
+        }
+      }
+      else {
+        for (int i = 0; i < PingMotion->n; i++) {
+          PingMotion->heave[i] = 0.0;
+        }
+      }
+
     }
-  }
-  else {
-    for (int i = 0; i < PingMotion->n; i++) {
-      PingMotion->roll[i] = 0.0;
-    }
-  }
-  if (PingMotion->flags & 4) {
-    for (int i = 0; i < PingMotion->n; i++) {
-      mb_get_binary_float(true, &buffer[index], &(PingMotion->heading[i]));
-      index += 4;
-    }
-  }
-  else {
-    for (int i = 0; i < PingMotion->n; i++) {
-      PingMotion->heading[i] = 0.0;
-    }
-  }
-  if (PingMotion->flags & 8) {
-    for (int i = 0; i < PingMotion->n; i++) {
-      mb_get_binary_float(true, &buffer[index], &(PingMotion->heave[i]));
-      index += 4;
-    }
-  }
-  else {
-    for (int i = 0; i < PingMotion->n; i++) {
-      PingMotion->heave[i] = 0.0;
+    else {
+      PingMotion->nalloc = 0;
     }
   }
 

--- a/src/mbio/mbr_reson7kr.c
+++ b/src/mbio/mbr_reson7kr.c
@@ -5555,14 +5555,8 @@ int mbr_reson7kr_rd_v2pingmotion(int verbose, char *buffer, void *store_ptr, int
     size_t size = sizeof(float) * v2pingmotion->n;
     if (status == MB_SUCCESS)
       status = mb_reallocd(verbose, __FILE__, __LINE__, size, (void **)&(v2pingmotion->roll), error);
-    if (status != MB_SUCCESS) {
-      v2pingmotion->nalloc = 0;
-    }
     if (status == MB_SUCCESS)
       status = mb_reallocd(verbose, __FILE__, __LINE__, size, (void **)&(v2pingmotion->heading), error);
-    if (status != MB_SUCCESS) {
-      v2pingmotion->nalloc = 0;
-    }
     if (status == MB_SUCCESS)
       status = mb_reallocd(verbose, __FILE__, __LINE__, size, (void **)&(v2pingmotion->heave), error);
     if (status == MB_SUCCESS) {
@@ -5602,7 +5596,7 @@ int mbr_reson7kr_rd_v2pingmotion(int verbose, char *buffer, void *store_ptr, int
           v2pingmotion->heave[i] = 0.0;
         }
       }
-      
+
     } else {
       v2pingmotion->nalloc = 0;
     }

--- a/src/mbio/mbr_reson7kr.c
+++ b/src/mbio/mbr_reson7kr.c
@@ -5552,56 +5552,59 @@ int mbr_reson7kr_rd_v2pingmotion(int verbose, char *buffer, void *store_ptr, int
 
   /* allocate memory for v2pingmotion if needed */
   if (status == MB_SUCCESS && v2pingmotion->nalloc < v2pingmotion->n) {
-    v2pingmotion->nalloc = sizeof(float) * v2pingmotion->n;
+    size_t size = sizeof(float) * v2pingmotion->n;
     if (status == MB_SUCCESS)
-      status = mb_reallocd(verbose, __FILE__, __LINE__, v2pingmotion->nalloc, (void **)&(v2pingmotion->roll), error);
+      status = mb_reallocd(verbose, __FILE__, __LINE__, size, (void **)&(v2pingmotion->roll), error);
     if (status != MB_SUCCESS) {
       v2pingmotion->nalloc = 0;
     }
     if (status == MB_SUCCESS)
-      status = mb_reallocd(verbose, __FILE__, __LINE__, v2pingmotion->nalloc, (void **)&(v2pingmotion->heading), error);
+      status = mb_reallocd(verbose, __FILE__, __LINE__, size, (void **)&(v2pingmotion->heading), error);
     if (status != MB_SUCCESS) {
       v2pingmotion->nalloc = 0;
     }
     if (status == MB_SUCCESS)
-      status = mb_reallocd(verbose, __FILE__, __LINE__, v2pingmotion->nalloc, (void **)&(v2pingmotion->heave), error);
-    if (status != MB_SUCCESS) {
-      v2pingmotion->nalloc = 0;
-    }
-  }
+      status = mb_reallocd(verbose, __FILE__, __LINE__, size, (void **)&(v2pingmotion->heave), error);
+    if (status == MB_SUCCESS) {
+      v2pingmotion->nalloc = v2pingmotion->n;
 
-  /* extract v2pingmotion data */
-  if (v2pingmotion->flags & 2) {
-    for (int i = 0; i < v2pingmotion->n; i++) {
-      mb_get_binary_float(true, &buffer[index], &(v2pingmotion->roll[i]));
-      index += 4;
-    }
-  }
-  else {
-    for (int i = 0; i < v2pingmotion->n; i++) {
-      v2pingmotion->roll[i] = 0.0;
-    }
-  }
-  if (v2pingmotion->flags & 4) {
-    for (int i = 0; i < v2pingmotion->n; i++) {
-      mb_get_binary_float(true, &buffer[index], &(v2pingmotion->heading[i]));
-      index += 4;
-    }
-  }
-  else {
-    for (int i = 0; i < v2pingmotion->n; i++) {
-      v2pingmotion->heading[i] = 0.0;
-    }
-  }
-  if (v2pingmotion->flags & 8) {
-    for (int i = 0; i < v2pingmotion->n; i++) {
-      mb_get_binary_float(true, &buffer[index], &(v2pingmotion->heave[i]));
-      index += 4;
-    }
-  }
-  else {
-    for (int i = 0; i < v2pingmotion->n; i++) {
-      v2pingmotion->heave[i] = 0.0;
+      /* extract v2pingmotion data */
+      if (v2pingmotion->flags & 2) {
+        for (int i = 0; i < v2pingmotion->n; i++) {
+          mb_get_binary_float(true, &buffer[index], &(v2pingmotion->roll[i]));
+          index += 4;
+        }
+      }
+      else {
+        for (int i = 0; i < v2pingmotion->n; i++) {
+          v2pingmotion->roll[i] = 0.0;
+        }
+      }
+      if (v2pingmotion->flags & 4) {
+        for (int i = 0; i < v2pingmotion->n; i++) {
+          mb_get_binary_float(true, &buffer[index], &(v2pingmotion->heading[i]));
+          index += 4;
+        }
+      }
+      else {
+        for (int i = 0; i < v2pingmotion->n; i++) {
+          v2pingmotion->heading[i] = 0.0;
+        }
+      }
+      if (v2pingmotion->flags & 8) {
+        for (int i = 0; i < v2pingmotion->n; i++) {
+          mb_get_binary_float(true, &buffer[index], &(v2pingmotion->heave[i]));
+          index += 4;
+        }
+      }
+      else {
+        for (int i = 0; i < v2pingmotion->n; i++) {
+          v2pingmotion->heave[i] = 0.0;
+        }
+      }
+      
+    } else {
+      v2pingmotion->nalloc = 0;
     }
   }
 
@@ -5638,6 +5641,7 @@ int mbr_reson7kr_rd_v2pingmotion(int verbose, char *buffer, void *store_ptr, int
   if (verbose >= 2)
 #endif
     mbsys_reson7k_print_v2pingmotion(verbose, v2pingmotion, error);
+mbsys_reson7k_print_v2pingmotion(1, v2pingmotion, error);
 
   if (verbose >= 2) {
     fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);

--- a/src/mbio/mbsys_reson7k.c
+++ b/src/mbio/mbsys_reson7k.c
@@ -1279,14 +1279,14 @@ int mbsys_reson7k_deall(int verbose, void *mbio_ptr, void **store_ptr, int *erro
 
   /* Reson 7k ping motion (record 7012) */
   s7kr_v2pingmotion *v2pingmotion = &store->v2pingmotion;
+  if (v2pingmotion->nalloc > 0 && v2pingmotion->roll != NULL)
+    status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&(v2pingmotion->roll), error);
+  if (v2pingmotion->nalloc > 0 && v2pingmotion->heading != NULL)
+    status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&(v2pingmotion->heading), error);
+  if (v2pingmotion->nalloc > 0 && v2pingmotion->heave != NULL)
+    status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&(v2pingmotion->heave), error);
   v2pingmotion->n = 0;
   v2pingmotion->nalloc = 0;
-  if (v2pingmotion->roll != NULL)
-    status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&(v2pingmotion->roll), error);
-  if (v2pingmotion->heading != NULL)
-    status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&(v2pingmotion->heading), error);
-  if (v2pingmotion->heave != NULL)
-    status &= mb_freed(verbose, __FILE__, __LINE__, (void **)&(v2pingmotion->heave), error);
 
   /* Reson 7k beamformed magnitude and phase data (record 7018) */
   s7kr_v2beamformed *v2beamformed = &store->v2beamformed;

--- a/src/mbio/mbsys_reson7k3.c
+++ b/src/mbio/mbsys_reson7k3.c
@@ -256,14 +256,14 @@ int mbsys_reson7k3_deall(int verbose, void *mbio_ptr, void **store_ptr, int *err
 
   /* Reson 7k ping MotionOverGround (record 7012) */
   s7k3_PingMotion *PingMotion = &store->PingMotion;
+  if (PingMotion->n > 0 && PingMotion->roll != NULL)
+    status = mb_freed(verbose, __FILE__, __LINE__, (void **)&(PingMotion->roll), error);
+  if (PingMotion->n > 0 && PingMotion->heading != NULL)
+    status = mb_freed(verbose, __FILE__, __LINE__, (void **)&(PingMotion->heading), error);
+  if (PingMotion->n > 0 && PingMotion->heave != NULL)
+    status = mb_freed(verbose, __FILE__, __LINE__, (void **)&(PingMotion->heave), error);
   PingMotion->n = 0;
   PingMotion->nalloc = 0;
-  if (PingMotion->roll != NULL)
-    status = mb_freed(verbose, __FILE__, __LINE__, (void **)&(PingMotion->roll), error);
-  if (PingMotion->heading != NULL)
-    status = mb_freed(verbose, __FILE__, __LINE__, (void **)&(PingMotion->heading), error);
-  if (PingMotion->heave != NULL)
-    status = mb_freed(verbose, __FILE__, __LINE__, (void **)&(PingMotion->heave), error);
 
   /* Reson 7k Adaptive Gate (record 7014) */
 


### PR DESCRIPTION
Formats 88 (MBF_RESON7KR) and 89 (MBF_RESON7K3): Fixed bug in handling of
PingMotion data records (7012) that caused memory overruns and seg faults.
