### PR TITLE
Thread safety and buffer overflow fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,7 +23,7 @@ Distributions that do not include "beta" in the tag name correspond to the major
 announced releases. The source distributions associated with all releases, major
 or beta, are equally accessible as tarballs through the Github interface.
 
-- Version 5.7.9beta03    February 3, 2021
+- Version 5.7.9beta03    February 7, 2021
 - Version 5.7.9beta02    January 27, 2021
 - Version 5.7.9beta01    January 18, 2021
 - **Version 5.7.8        January 17, 2021
@@ -383,7 +383,38 @@ or beta, are equally accessible as tarballs through the Github interface.
 ### MB-System Version 5.7 Release Notes:
 --
 
-#### 5.7.9beta02 (January 27, 2020)
+#### 5.7.9beta03 (February 7, 2021)
+
+General changes: Replacing use of strtok() function with strtok_r(). Strtok() is
+intrinsically not thread safe or reentrant and is considered poor use under all
+circumstances. Source files with this change include:
+  src/mbio/mbr_edgjstar.c src/mbio/mbr_hypc8101.c src/mbio/mbr_hysweep1.c
+  src/mbio/mb_format.c src/mbio/mb_get_value.c src/bsio/mbbs_tm.c
+  src/utilities/mblevitus.cc src/mbvelocitytool/mbvelocity_callbacks.c
+  src/mbnavedit/mbnavedit_callbacks.c src/mbnavadjust/mbnavadjust_callbacks.c
+
+General changes: Replace atof() with strtod() for thread safety. Source files
+with this change include:
+  src/gmt/mbgrdtifforg.c src/bsio/mbbs_tm.c src/mbio/mb_navint.c
+  src/mbio/mbr_edgjstar.c src/mbnavadjust/mbnavadjust_fine.c
+
+General changes: Replace atoi() with strtol() for thread safety. Source files
+with this change include:
+  src/gmt/mbcontour.c src/gmt/mbgrdtifforg.c src/gmt/mbswath.c
+  src/gsf/gsf.c src/utilities/mbgrid.cc src/utilities/mbprocess.cc
+
+General changes: Protect against overflows copying comments in all of the
+mbsys_XXX_extract() and mbsys_XXX_insert() functions the in the source files
+mbsys_XXX.c
+
+MBnavadjust: Fixed bug that failed to save new navigation ties if the program was
+closed without solving for a new model. Now closing the program will always save
+any unsaved ties.
+
+MBeditviz and MBview: Removed unneeded functions from mbview/mb3dsoundings_callbacks.c
+that were breaking test Cmake builds.
+
+#### 5.7.9beta02 (January 27, 2021)
 
 Fixed bug in format 58 and 59 support for bathymetry recalculation. The per beam heave values were being calculated incorrectly when bathymetry was recalculated by raytracing.
 

--- a/configure
+++ b/configure
@@ -2734,7 +2734,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
-$as_echo "#define VERSION_DATE \"3 February 2021\"" >>confdefs.h
+$as_echo "#define VERSION_DATE \"7 February 2021\"" >>confdefs.h
 
 
 $as_echo " "

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ dnl--------------------------------------------------------------------
 
 dnl Initialize and set version and version date
 AC_INIT([mbsystem],[5.7.9beta03],[http://listserver.mbari.org/sympa/arc/mbsystem],[mbsystem],[http://www.mbari.org/data/mbsystem/])
-AC_DEFINE(VERSION_DATE, ["3 February 2021"], [Set VERSION_DATE define in mb_config.h])
+AC_DEFINE(VERSION_DATE, ["7 February 2021"], [Set VERSION_DATE define in mb_config.h])
 
 AS_ECHO([" "])
 AS_ECHO(["------------------------------------------------------------------------------"])

--- a/src/bsio/mbbs_tm.c
+++ b/src/bsio/mbbs_tm.c
@@ -117,7 +117,8 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 	ts.tm_isdst = 0;
 
 	char *token;
-	if ((token = strtok(tmstrcp, ":/- ")) == (char *)0)
+  char *saveptr;
+	if ((token = strtok_r(tmstrcp, ":/- ", &saveptr)) == (char *)0)
 		return mbbs_rsttz(BS_BADARG);
 	char *cp;
 	ts.tm_year = (int)strtol(token, &cp, 10);
@@ -135,7 +136,7 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 	}
 	ts.tm_year -= 1900;
 
-	if ((token = strtok((char *)0, ":/- ")) == (char *)0) {
+	if ((token = strtok_r((char *)0, ":/- ", &saveptr)) == (char *)0) {
 		const time_t tmt = mktime(&ts);
 		if (tmt == (time_t)-1)
 			return mbbs_rsttz(BS_FAILURE);
@@ -161,7 +162,7 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 			return mbbs_rsttz(BS_BADARG);
 		ts.tm_mon -= 1;
 
-		if ((token = strtok((char *)0, ":/- ")) == (char *)0) {
+		if ((token = strtok_r((char *)0, ":/- ", &saveptr)) == (char *)0) {
 			mbbs_cal2jul(&ts);
 			const time_t tmt = mktime(&ts);
 			if (tmt == (time_t)-1)
@@ -178,7 +179,7 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 		break;
 	}
 
-	if ((token = strtok((char *)0, ":/- ")) == (char *)0) {
+	if ((token = strtok_r((char *)0, ":/- ", &saveptr)) == (char *)0) {
 		const time_t tmt = mktime(&ts);
 		if (tmt == (time_t)-1)
 			return mbbs_rsttz(BS_FAILURE);
@@ -191,7 +192,7 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 	if ((ts.tm_hour < 0) || (ts.tm_hour > 23))
 		return mbbs_rsttz(BS_BADARG);
 
-	if ((token = strtok((char *)0, ":/- ")) == (char *)0) {
+	if ((token = strtok_r((char *)0, ":/- ", &saveptr)) == (char *)0) {
 		const time_t tmt = mktime(&ts);
 		if (tmt == (time_t)-1)
 			return mbbs_rsttz(BS_FAILURE);
@@ -204,7 +205,7 @@ int mbbs_tmparse(char *str, int tmmode, double *dtm) {
 	if ((ts.tm_min < 0) || (ts.tm_min > 59))
 		return mbbs_rsttz(BS_BADARG);
 
-	if ((token = strtok((char *)0, ":/- ")) == (char *)0) {
+	if ((token = strtok_r((char *)0, ":/- ", &saveptr)) == (char *)0) {
 		const time_t tmt = mktime(&ts);
 		if (tmt == (time_t)-1)
 			return mbbs_rsttz(BS_FAILURE);

--- a/src/gmt/mbcontour.c
+++ b/src/gmt/mbcontour.c
@@ -492,7 +492,7 @@ int GMT_mbcontour_parse(struct GMT_CTRL *GMT, struct MBCONTOUR_CTRL *Ctrl, struc
 			break;
 		case 'p': /* Sets the ping averaging */
 			Ctrl->p.active = true;
-			Ctrl->p.pings = atoi(opt->arg);
+			Ctrl->p.pings = (int)strtol(opt->arg, NULL, 10);
 			if (Ctrl->p.pings < 0) {
 				GMT_Report(API, GMT_MSG_NORMAL, "Error -p option: Don't invent, number of pings must be >= 0\n");
 				Ctrl->p.pings = 1;

--- a/src/gmt/mbgrdtifforg.c
+++ b/src/gmt/mbgrdtifforg.c
@@ -561,7 +561,7 @@ int GMT_mbgrdtiff_parse(struct GMT_CTRL *GMT, struct MBGRDTIFF_CTRL *Ctrl, struc
 			else if (opt->arg[0] == '\0')
 				Ctrl->E.dpi = 100; /* Default grid dpi */
 			else
-				Ctrl->E.dpi = atoi(opt->arg);
+				Ctrl->E.dpi = (int)strtol(opt->arg, NULL, 10);
 			break;
 		case 'G': /* 1-bit fore or background color for transparent masks */
 			Ctrl->G.active = true;
@@ -607,7 +607,7 @@ int GMT_mbgrdtiff_parse(struct GMT_CTRL *GMT, struct MBGRDTIFF_CTRL *Ctrl, struc
 				if (!gmt_access(GMT, opt->arg, R_OK)) /* Got a file */
 					Ctrl->Intensity.file = strdup(opt->arg);
 				else if (opt->arg[0] && !gmt_not_numeric(GMT, opt->arg)) { /* Looks like a constant value */
-					Ctrl->Intensity.value = atof(opt->arg);
+					Ctrl->Intensity.value = strtod(opt->arg, NULL);
 					Ctrl->Intensity.constant = true;
 				}
 				else {

--- a/src/gmt/mbswath.c
+++ b/src/gmt/mbswath.c
@@ -585,7 +585,7 @@ int GMT_mbswath_parse(struct GMT_CTRL *GMT, struct MBSWATH_CTRL *Ctrl, struct GM
 			break;
 		case 'p': /* Sets the ping averaging */
 			Ctrl->p.active = true;
-			Ctrl->p.pings = atoi(opt->arg);
+			Ctrl->p.pings = (int)strtol(opt->arg, NULL, 10);
 			if (Ctrl->p.pings < 0) {
 				GMT_Report(API, GMT_MSG_NORMAL, "Error -p option: Don't invent, number of pings must be >= 0\n");
 				Ctrl->p.pings = 1;

--- a/src/gsf/gsf.c
+++ b/src/gsf/gsf.c
@@ -7371,9 +7371,9 @@ gsfGetMBParams(const gsfRecords *rec, gsfMBParams *p, int *numArrays)
         else if (strncmp(rec->process_parameters.param[i], "NUMBER_OF_TRANSMITTERS", strlen("NUMBER_OF_TRANSMITTERS")) == 0)
         {
             sscanf (rec->process_parameters.param[i], "NUMBER_OF_TRANSMITTERS=%3s", str);
-            if ((atoi(str) >= 1) && (atoi(str) <= GSF_MAX_OFFSETS))
+            if (((int)strtol(str, NULL, 10) >= 1) && ((int)strtol(str, NULL, 10) <= GSF_MAX_OFFSETS))
             {
-                p->number_of_transmitters = atoi(str);
+                p->number_of_transmitters = (int)strtol(str, NULL, 10);
                 num_tx = p->number_of_transmitters;
             }
             else
@@ -7384,9 +7384,9 @@ gsfGetMBParams(const gsfRecords *rec, gsfMBParams *p, int *numArrays)
         else if (strncmp(rec->process_parameters.param[i], "NUMBER_OF_RECEIVERS", strlen("NUMBER_OF_RECEIVERS")) == 0)
         {
             sscanf (rec->process_parameters.param[i], "NUMBER_OF_RECEIVERS=%3s", str);
-            if ((atoi(str) >= 1) && (atoi(str) <= GSF_MAX_OFFSETS))
+            if (((int)strtol(str, NULL, 10) >= 1) && ((int)strtol(str, NULL, 10) <= GSF_MAX_OFFSETS))
             {
-                p->number_of_receivers = atoi(str);
+                p->number_of_receivers = (int)strtol(str, NULL, 10);
                 num_rx = p->number_of_receivers;
             }
             else
@@ -7453,9 +7453,9 @@ gsfGetMBParams(const gsfRecords *rec, gsfMBParams *p, int *numArrays)
         else if (strncmp(rec->process_parameters.param[i], "UTC_OFFSET", strlen("UTC_OFFSET")) == 0)
         {
             sscanf (rec->process_parameters.param[i], "UTC_OFFSET=%3s", str);
-            if ((abs(atoi(str)) >= 0) && (abs(atoi(str)) <= 12))
+            if ((abs((int)strtol(str, NULL, 10)) >= 0) && (abs((int)strtol(str, NULL, 10)) <= 12))
             {
-                p->utc_offset = atoi(str);
+                p->utc_offset = (int)strtol(str, NULL, 10);
             }
             else
             {

--- a/src/mbio/mb_config.h
+++ b/src/mbio/mb_config.h
@@ -131,7 +131,7 @@
 #define VERSION "5.7.9beta03"
 
 /* Set VERSION_DATE define in mb_config.h */
-#define VERSION_DATE "3 February 2021"
+#define VERSION_DATE "7 February 2021"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/src/mbio/mb_format.c
+++ b/src/mbio/mb_format.c
@@ -4079,9 +4079,10 @@ int mb_get_shortest_path(int verbose, char *path, int *error) {
 
     /* step through path */
     path[0] = '\0';
+    char *saveptr;
     if (tmppath[0] == '/')
       strcpy(path, "/");
-    char *result = strtok(tmppath, "/");
+    char *result = strtok_r(tmppath, "/", &saveptr);
     bool lasttokenordinary = false;
     while (result != NULL) {
       if (strcmp("..", result) == 0) {
@@ -4103,7 +4104,7 @@ int mb_get_shortest_path(int verbose, char *path, int *error) {
         lasttokenordinary = true;
         strcpy(lasttoken, result);
       }
-      result = strtok(NULL, "/");
+      result = strtok_r(NULL, "/", &saveptr);
     }
     if (lasttokenordinary)
       strcat(path, lasttoken);

--- a/src/mbio/mb_get_value.c
+++ b/src/mbio/mb_get_value.c
@@ -41,7 +41,7 @@ static char tmp[MB_GET_VALUE_MAXLINE];
 int mb_get_double(double *value, char *str, int nchar) {
 	memset(tmp, 0, MB_GET_VALUE_MAXLINE);
 	*value = 0.0;
-	*value = atof(strncpy(tmp, str, nchar));
+	*value = strtod(strncpy(tmp, str, nchar), NULL);
 	return (0);
 }
 /*--------------------------------------------------------------------*/
@@ -49,7 +49,7 @@ int mb_get_double(double *value, char *str, int nchar) {
  */
 int mb_get_int(int *value, char *str, int nchar) {
 	memset(tmp, 0, MB_GET_VALUE_MAXLINE);
-	*value = atoi(strncpy(tmp, str, nchar));
+	*value = strtol(strncpy(tmp, str, nchar), NULL, 10);
 	return (0);
 }
 /*--------------------------------------------------------------------*/
@@ -213,12 +213,13 @@ int mb_put_binary_long(bool swapped, mb_s_long value, void *buffer) {
  *	form. This code derives from code in GMT (gmt_init.c).
  */
 int mb_get_bounds(char *text, double *bounds) {
-	char *result = strtok(text, "/");
+  char *saveptr;
+	char *result = strtok_r(text, "/", &saveptr);
 	int i = 0;
 	while (result && i < 4) {
 		bounds[i] = mb_ddmmss_to_degree(result);
 		i++;
-		result = strtok(NULL, "/");
+		result = strtok_r(NULL, "/", &saveptr);
 	}
 	int status = MB_SUCCESS;
 	if (i == 4)
@@ -257,7 +258,7 @@ double mb_ddmmss_to_degree(const char *text) {
 		degfrac = degree + copysign(minute / 60.0, degree);
 	}
 	else
-		degfrac = atof(text);
+		degfrac = strtod(text, NULL);
 
 	if (suffix == 'W' || suffix == 'w' || suffix == 'S' || suffix == 's')
 		degfrac = -degfrac; /* Sign was given implicitly */

--- a/src/mbio/mb_navint.c
+++ b/src/mbio/mb_navint.c
@@ -1301,25 +1301,25 @@ int mb_loadnavdata(int verbose, char *merge_nav_file, int merge_nav_format, int 
 				else if (merge_nav_format == 5) {
 					strncpy(dummy, "", 128);
 					if (buffer[2] == '+') {
-						time_j[0] = atoi(strncpy(dummy, buffer, 2));
+						time_j[0] = strtol(strncpy(dummy, buffer, 2), NULL, 10);
 						mb_fix_y2k(verbose, time_j[0], &time_j[0]);
 						ioff = 3;
 					}
 					else {
-						time_j[0] = atoi(strncpy(dummy, buffer, 4));
+						time_j[0] = strtol(strncpy(dummy, buffer, 4), NULL, 10);
 						ioff = 5;
 					}
 					strncpy(dummy, "", 128);
-					time_j[1] = atoi(strncpy(dummy, buffer + ioff, 3));
+					time_j[1] = strtol(strncpy(dummy, buffer + ioff, 3), NULL, 10);
 					strncpy(dummy, "", 128);
 					ioff += 4;
-					hr = atoi(strncpy(dummy, buffer + ioff, 2));
+					hr = strtol(strncpy(dummy, buffer + ioff, 2), NULL, 10);
 					strncpy(dummy, "", 128);
 					ioff += 3;
-					time_j[2] = atoi(strncpy(dummy, buffer + ioff, 2)) + 60 * hr;
+					time_j[2] = strtol(strncpy(dummy, buffer + ioff, 2), NULL, 10) + 60 * hr;
 					strncpy(dummy, "", 128);
 					ioff += 3;
-					time_j[3] = atoi(strncpy(dummy, buffer + ioff, 2));
+					time_j[3] = strtol(strncpy(dummy, buffer + ioff, 2), NULL, 10);
 					time_j[4] = 0;
 					mb_get_itime(verbose, time_j, time_i);
 					mb_get_time(verbose, time_i, &time_d);
@@ -1330,19 +1330,19 @@ int mb_loadnavdata(int verbose, char *merge_nav_file, int merge_nav_format, int 
 					NorS[0] = buffer[ioff];
 					ioff += 1;
 					strncpy(dummy, "", 128);
-					mlat = atof(strncpy(dummy, buffer + ioff, 3));
+					mlat = strtod(strncpy(dummy, buffer + ioff, 3), NULL);
 					strncpy(dummy, "", 128);
 					ioff += 3;
-					llat = atof(strncpy(dummy, buffer + ioff, 8));
+					llat = strtod(strncpy(dummy, buffer + ioff, 8), NULL);
 					strncpy(EorW, "", sizeof(EorW));
 					ioff += 9;
 					EorW[0] = buffer[ioff];
 					strncpy(dummy, "", 128);
 					ioff += 1;
-					mlon = atof(strncpy(dummy, buffer + ioff, 4));
+					mlon = strtod(strncpy(dummy, buffer + ioff, 4), NULL);
 					strncpy(dummy, "", 128);
 					ioff += 4;
-					llon = atof(strncpy(dummy, buffer + ioff, 8));
+					llon = strtod(strncpy(dummy, buffer + ioff, 8), NULL);
 					n_lon[nrecord] = mlon + llon / 60.;
 					if (strncmp(EorW, "W", 1) == 0)
 						n_lon[nrecord] = -n_lon[nrecord];
@@ -1361,34 +1361,34 @@ int mb_loadnavdata(int verbose, char *merge_nav_file, int merge_nav_format, int 
 						if (strncmp(&buffer[3], "DAT", 3) == 0 && len > 15) {
 							time_set = false;
 							strncpy(dummy, "", 128);
-							time_i[0] = atoi(strncpy(dummy, buffer + 7, 4));
-							time_i[1] = atoi(strncpy(dummy, buffer + 11, 2));
-							time_i[2] = atoi(strncpy(dummy, buffer + 13, 2));
+							time_i[0] = strtol(strncpy(dummy, buffer + 7, 4), NULL, 10);
+							time_i[1] = strtol(strncpy(dummy, buffer + 11, 2), NULL, 10);
+							time_i[2] = strtol(strncpy(dummy, buffer + 13, 2), NULL, 10);
 						}
 						else if ((strncmp(&buffer[3], "ZDA", 3) == 0 || strncmp(&buffer[3], "UNX", 3) == 0) && len > 14) {
 							time_set = false;
 							/* find start of ",hhmmss.ss" */
 							if ((bufftmp = strchr(buffer, ',')) != NULL) {
 								strncpy(dummy, "", 128);
-								time_i[3] = atoi(strncpy(dummy, bufftmp + 1, 2));
+								time_i[3] = strtol(strncpy(dummy, bufftmp + 1, 2), NULL, 10);
 								strncpy(dummy, "", 128);
-								time_i[4] = atoi(strncpy(dummy, bufftmp + 3, 2));
+								time_i[4] = strtol(strncpy(dummy, bufftmp + 3, 2), NULL, 10);
 								strncpy(dummy, "", 128);
-								time_i[5] = atoi(strncpy(dummy, bufftmp + 5, 2));
+								time_i[5] = strtol(strncpy(dummy, bufftmp + 5, 2), NULL, 10);
 								if (bufftmp[7] == '.') {
 									strncpy(dummy, "", 128);
-									time_i[6] = 10000 * atoi(strncpy(dummy, bufftmp + 8, 2));
+									time_i[6] = 10000 * strtol(strncpy(dummy, bufftmp + 8, 2), NULL, 10);
 								}
 								else
 									time_i[6] = 0;
 								/* find start of ",dd,mm,yyyy" */
 								if ((bufftmp = strchr(&bufftmp[1], ',')) != NULL) {
 									strncpy(dummy, "", 128);
-									time_i[2] = atoi(strncpy(dummy, bufftmp + 1, 2));
+									time_i[2] = strtol(strncpy(dummy, bufftmp + 1, 2), NULL, 10);
 									strncpy(dummy, "", 128);
-									time_i[1] = atoi(strncpy(dummy, bufftmp + 4, 2));
+									time_i[1] = strtol(strncpy(dummy, bufftmp + 4, 2), NULL, 10);
 									strncpy(dummy, "", 128);
-									time_i[0] = atoi(strncpy(dummy, bufftmp + 7, 4));
+									time_i[0] = strtol(strncpy(dummy, bufftmp + 7, 4), NULL, 10);
 									time_set = true;
 								}
 							}
@@ -1402,9 +1402,9 @@ int mb_loadnavdata(int verbose, char *merge_nav_file, int merge_nav_format, int 
 								if (merge_nav_format == 7)
 									bufftmp = strchr(&bufftmp[1], ',');
 								strncpy(dummy, "", 128);
-								degree = atoi(strncpy(dummy, bufftmp + 1, 2));
+								degree = strtol(strncpy(dummy, bufftmp + 1, 2), NULL, 10);
 								strncpy(dummy, "", 128);
-								dminute = atof(strncpy(dummy, bufftmp + 3, 5));
+								dminute = strtod(strncpy(dummy, bufftmp + 3, 5), NULL);
 								strncpy(NorS, "", sizeof(NorS));
 								bufftmp = strchr(&bufftmp[1], ',');
 								strncpy(NorS, bufftmp + 1, 1);
@@ -1413,9 +1413,9 @@ int mb_loadnavdata(int verbose, char *merge_nav_file, int merge_nav_format, int 
 									n_lat[nrecord] = -n_lat[nrecord];
 								bufftmp = strchr(&bufftmp[1], ',');
 								strncpy(dummy, "", 128);
-								degree = atoi(strncpy(dummy, bufftmp + 1, 3));
+								degree = strtol(strncpy(dummy, bufftmp + 1, 3), NULL, 10);
 								strncpy(dummy, "", 128);
-								dminute = atof(strncpy(dummy, bufftmp + 4, 5));
+								dminute = strtod(strncpy(dummy, bufftmp + 4, 5), NULL);
 								bufftmp = strchr(&bufftmp[1], ',');
 								strncpy(EorW, "", sizeof(EorW));
 								strncpy(EorW, bufftmp + 1, 1);

--- a/src/mbio/mbr_hypc8101.c
+++ b/src/mbio/mbr_hypc8101.c
@@ -328,7 +328,7 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 	double lever_x, lever_y, lever_z;
 	double rr, xx, zz;
 	double ddummy1, ddummy2;
-	char *token;
+	char *token, *saveptr;
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
@@ -581,8 +581,8 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 
 			/* deal with multibeam data */
 			else if (strncmp(line, "SB2", 3) == 0) {
-				/* start strtok and get sb2_clock */
-				if (status == MB_SUCCESS && (token = strtok(line + 6, " ")) != NULL)
+				/* start strtok_r and get sb2_clock */
+				if (status == MB_SUCCESS && (token = strtok_r(line + 6, " ", &saveptr)) != NULL)
 					nscan = sscanf(token, "%lf", &sb2_clock);
 				else {
 					status = MB_FAILURE;
@@ -590,7 +590,7 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 				}
 
 				/* get sb2_nbeams */
-				if (status == MB_SUCCESS && (token = strtok(NULL, " ")) != NULL)
+				if (status == MB_SUCCESS && (token = strtok_r(NULL, " ", &saveptr)) != NULL)
 					nscan = sscanf(token, "%d", &sb2_nvalues);
 				else {
 					status = MB_FAILURE;
@@ -598,7 +598,7 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 				}
 
 				/* get sb2_ssv */
-				if (status == MB_SUCCESS && (token = strtok(NULL, " ")) != NULL)
+				if (status == MB_SUCCESS && (token = strtok_r(NULL, " ", &saveptr)) != NULL)
 					nscan = sscanf(token, "%lf", &sb2_ssv);
 				else {
 					status = MB_FAILURE;
@@ -612,7 +612,7 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 					sb2_nbeams = floor(0.8 * (sb2_nvalues - 1));
 					sb2_nquality = sb2_nvalues - sb2_nbeams - 1;
 					for (int i = 0; i < sb2_nbeams; i++) {
-						if (status == MB_SUCCESS && (token = strtok(NULL, " ")) != NULL) {
+						if (status == MB_SUCCESS && (token = strtok_r(NULL, " ", &saveptr)) != NULL) {
 							if ((nscan = sscanf(token, "%lf", &sb2_range)) == 1) {
 								data->tt[sb2_nbeams_read] = 100 * sb2_range;
 								sb2_nbeams_read++;
@@ -629,7 +629,7 @@ int mbr_hypc8101_rd_data(int verbose, void *mbio_ptr, int *error) {
 				if (status == MB_SUCCESS) {
 					sb2_nquality_read = 0;
 					for (int i = 0; i < sb2_nquality; i++) {
-						if (status == MB_SUCCESS && (token = strtok(NULL, " ")) != NULL) {
+						if (status == MB_SUCCESS && (token = strtok_r(NULL, " ", &saveptr)) != NULL) {
 							if ((nscan = sscanf(token, "%lf", &sb2_quality)) == 1) {
 								iquality = sb2_quality;
 								data->quality[4 * sb2_nquality_read] = (iquality >> 6) & 3;

--- a/src/mbio/mbr_hysweep1.c
+++ b/src/mbio/mbr_hysweep1.c
@@ -397,13 +397,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->RMB_beam_ranges[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -418,13 +419,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->RMB_multi_ranges[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -439,13 +441,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->RMB_sounding_eastings[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -460,13 +463,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->RMB_sounding_northings[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -481,13 +485,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->RMB_sounding_depths[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -502,13 +507,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->RMB_sounding_along[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -523,13 +529,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->RMB_sounding_across[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -544,13 +551,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->RMB_sounding_pitchangles[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -565,13 +573,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->RMB_sounding_rollangles[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -586,13 +595,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->RMB_sounding_takeoffangles[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -607,13 +617,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->RMB_sounding_azimuthalangles[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -628,13 +639,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%d", &(store->RMB_sounding_timedelays[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -649,13 +661,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%d", &(store->RMB_sounding_intensities[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -670,13 +683,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%d", &(store->RMB_sounding_quality[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -691,13 +705,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RMB_num_beams && token != NULL; i++) {
 							nscan = sscanf(token, "%d", &(store->RMB_sounding_flags[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RMB_num_beams) {
 							status = MB_FAILURE;
@@ -855,13 +870,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RSS_port_num_samples && token != NULL; i++) {
 							nscan = sscanf(token, "%d", &(store->RSS_port[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RSS_port_num_samples) {
 							status = MB_FAILURE;
@@ -876,13 +892,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->RSS_starboard_num_samples && token != NULL; i++) {
 							nscan = sscanf(token, "%d", &(store->RSS_starboard[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->RSS_starboard_num_samples) {
 							status = MB_FAILURE;
@@ -966,13 +983,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->MSS_num_pixels && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->MSS_ss[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->MSS_num_pixels) {
 							status = MB_FAILURE;
@@ -987,13 +1005,14 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 					status = mbr_hysweep1_rd_line(verbose, mb_io_ptr->mbfp, line, error);
 
 					/* parse the line */
-					if (status == MB_SUCCESS && (token = strtok(line + 0, " ")) != NULL) {
+          char *saveptr;
+					if (status == MB_SUCCESS && (token = strtok_r(line + 0, " ", &saveptr)) != NULL) {
 						nread = 0;
 						for (int i = 0; i < store->MSS_num_pixels && token != NULL; i++) {
 							nscan = sscanf(token, "%lf", &(store->MSS_ss_along[i]));
 							if (nscan == 1)
 								nread++;
-							token = strtok(NULL, " ");
+							token = strtok_r(NULL, " ", &saveptr);
 						}
 						if (nread != store->MSS_num_pixels) {
 							status = MB_FAILURE;
@@ -1266,14 +1285,15 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 				store->type = MBSYS_HYSWEEP_RECORDTYPE_DEV;
 
 				/* parse the first line */
-				token = strtok(line + 4, " ");
+        char *saveptr;
+				token = strtok_r(line + 4, " ", &saveptr);
 				nscan = sscanf(token, "%d", &(DEV_device_number));
 				if (nscan == 1) {
-					token = strtok(NULL, " ");
+					token = strtok_r(NULL, " ", &saveptr);
 					nscan = sscanf(token, "%d", &(DEV_device_capability));
 				}
 				if (nscan == 1) {
-					token = strtok(NULL, "\"");
+					token = strtok_r(NULL, "\"", &saveptr);
 					strcpy(DEV_device_name, token);
 					nscan = 3;
 				}
@@ -1302,6 +1322,7 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 				store->type = MBSYS_HYSWEEP_RECORDTYPE_DV2;
 
 				/* parse the first line */
+        char *saveptr;
 				nscan = sscanf(line + 4, "%d %x %d %d", &(DV2_device_number), &(DV2_device_capability), &(DV2_towfish),
 				               &(DV2_enabled));
 				if (nscan == 4) {
@@ -1513,35 +1534,36 @@ int mbr_hysweep1_rd_data(int verbose, void *mbio_ptr, void *store_ptr, int *erro
 						store->INF_tide_correction = 0.0;
 				}
 				else {
-					if ((token = strtok(line + 3, "\"")) != NULL) {
-						token = strtok(NULL, "\"");
+          char *saveptr;
+					if ((token = strtok_r(line + 3, "\"", &saveptr)) != NULL) {
+						token = strtok_r(NULL, "\"", &saveptr);
 						if (token != NULL && token[0] != ' ') {
 							strcpy(store->INF_surveyor, token);
-							token = strtok(NULL, "\"");
+							token = strtok_r(NULL, "\"", &saveptr);
 						}
 						else
 							store->INF_surveyor[0] = '\0';
 
-						token = strtok(NULL, "\"");
+						token = strtok_r(NULL, "\"", &saveptr);
 						if (token != NULL && token[0] != ' ') {
 							strcpy(store->INF_boat, token);
-							token = strtok(NULL, "\"");
+							token = strtok_r(NULL, "\"", &saveptr);
 						}
 						else
 							store->INF_boat[0] = '\0';
 
-						token = strtok(NULL, "\"");
+						token = strtok_r(NULL, "\"", &saveptr);
 						if (token != NULL && token[0] != ' ') {
 							strcpy(store->INF_project, token);
-							token = strtok(NULL, "\"");
+							token = strtok_r(NULL, "\"", &saveptr);
 						}
 						else
 							store->INF_project[0] = '\0';
 
-						token = strtok(NULL, "\"");
+						token = strtok_r(NULL, "\"", &saveptr);
 						if (token != NULL && token[0] != ' ') {
 							strcpy(store->INF_area, token);
-							token = strtok(NULL, "\"");
+							token = strtok_r(NULL, "\"", &saveptr);
 						}
 						else
 							store->INF_area[0] = '\0';

--- a/src/mbio/mbsys_3datdepthlidar.c
+++ b/src/mbio/mbsys_3datdepthlidar.c
@@ -769,8 +769,10 @@ int mbsys_3datdepthlidar_extract(int verbose,     /* in: verbosity level set on 
 		status = MB_SUCCESS;
 	}
 
-	else if (*kind == MB_DATA_COMMENT)
-		strncpy(comment, store->comment, MB_COMMENT_MAXLINE);
+	else if (*kind == MB_DATA_COMMENT) {
+    memset((void *)comment, 0, sizeof(comment));
+		strncpy(comment, store->comment, MIN(sizeof(comment), sizeof(store->comment)) - 1);
+  }
 
 	if (verbose >= 2) {
 		fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);
@@ -887,7 +889,8 @@ int mbsys_3datdepthlidar_insert(int verbose,     /* in: verbosity level set on c
 	else if (store->kind == MB_DATA_COMMENT) {
 		store->time_d = time_d;
 		store->comment_len = strlen(comment) + 1;
-		strncpy(store->comment, comment, MB_COMMENT_MAXLINE);
+    memset((void *)store->comment, 0, sizeof(store->comment));
+		strncpy(store->comment, comment, MIN(sizeof(store->comment), sizeof(comment)) - 1);
 	}
 
 	/* deal with other records types  */

--- a/src/mbio/mbsys_3ddwissl.c
+++ b/src/mbio/mbsys_3ddwissl.c
@@ -1238,7 +1238,8 @@ int mbsys_3ddwissl_extract
 
   else if (*kind == MB_DATA_COMMENT)
     {
-    strncpy(comment, store->comment, MB_COMMENT_MAXLINE);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		strncpy(comment, store->comment, MB_COMMENT_MAXLINE - 1);
     }
 
   if (verbose >= 2)
@@ -1393,7 +1394,8 @@ int mbsys_3ddwissl_insert
     {
     store->time_d = time_d;
     store->comment_len = MIN(strlen(comment), MB_COMMENT_MAXLINE-1);
-    strncpy(store->comment, comment, MB_COMMENT_MAXLINE);
+    memset((void *)store->comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(store->comment, comment, MB_COMMENT_MAXLINE - 1);
     }
 
   /* deal with other records types  */

--- a/src/mbio/mbsys_atlas.c
+++ b/src/mbio/mbsys_atlas.c
@@ -475,7 +475,8 @@ int mbsys_atlas_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strncpy(comment, store->comment, MBSYS_ATLAS_COMMENT_LENGTH);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_ATLAS_COMMENT_LENGTH) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -639,7 +640,8 @@ int mbsys_atlas_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, i
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, MBSYS_ATLAS_COMMENT_LENGTH);
+    memset((void *)store->comment, 0, MBSYS_ATLAS_COMMENT_LENGTH);
+    strncpy(store->comment, comment, MIN(MBSYS_ATLAS_COMMENT_LENGTH, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_benthos.c
+++ b/src/mbio/mbsys_benthos.c
@@ -353,7 +353,8 @@ int mbsys_benthos_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_BENTHOS_COMMENT_LENGTH) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);

--- a/src/mbio/mbsys_dsl.c
+++ b/src/mbio/mbsys_dsl.c
@@ -327,7 +327,8 @@ int mbsys_dsl_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_DSL_COMMENT_LENGTH) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -475,7 +476,8 @@ int mbsys_dsl_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, 79);
+    memset((void *)store->comment, 0, MBSYS_DSL_COMMENT_LENGTH);
+    strncpy(store->comment, comment, MIN(MBSYS_DSL_COMMENT_LENGTH, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	int status = MB_SUCCESS;

--- a/src/mbio/mbsys_elac.c
+++ b/src/mbio/mbsys_elac.c
@@ -357,7 +357,8 @@ int mbsys_elac_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_ELAC_COMMENT_LENGTH) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -519,7 +520,8 @@ int mbsys_elac_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, in
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, 199);
+    memset((void *)store->comment, 0, MBSYS_ELAC_COMMENT_LENGTH);
+    strncpy(store->comment, comment, MIN(MBSYS_ELAC_COMMENT_LENGTH, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_elacmk2.c
+++ b/src/mbio/mbsys_elacmk2.c
@@ -405,7 +405,8 @@ int mbsys_elacmk2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_ELACMK2_COMMENT_LENGTH) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -587,7 +588,8 @@ int mbsys_elacmk2_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, 199);
+    memset((void *)store->comment, 0, MBSYS_ELACMK2_COMMENT_LENGTH);
+    strncpy(store->comment, comment, MIN(MBSYS_ELACMK2_COMMENT_LENGTH, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_gsf.c
+++ b/src/mbio/mbsys_gsf.c
@@ -558,8 +558,10 @@ int mbsys_gsf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		if (records->comment.comment_length > 0 && records->comment.comment != NULL)
-			strcpy(comment, records->comment.comment);
+		if (records->comment.comment_length > 0 && records->comment.comment != NULL) {
+      memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		  strncpy(comment, records->comment.comment, MIN(MB_COMMENT_MAXLINE, records->comment.comment_length) - 1);
+    }
 		else
 			comment[0] = '\0';
 
@@ -802,11 +804,13 @@ int mbsys_gsf_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int
 				status = MB_FAILURE;
 				*error = MB_ERROR_MEMORY_FAIL;
 				records->comment.comment_length = 0;
-			}
+			} else {
+        records->comment.comment_length = strlen(comment) + 1;
+      }
 		}
 		if (status == MB_SUCCESS && records->comment.comment != NULL) {
-			strcpy(records->comment.comment, comment);
-			records->comment.comment_length = strlen(comment) + 1;
+      memset((void *)records->comment.comment, 0, records->comment.comment_length);
+      strncpy(records->comment.comment, comment, MIN(records->comment.comment_length, MB_COMMENT_MAXLINE) - 1);
 			records->comment.comment_time.tv_sec = (int)time_d;
 			records->comment.comment_time.tv_nsec = (int)(1000000000 * (time_d - records->comment.comment_time.tv_sec));
 		}

--- a/src/mbio/mbsys_hdcs.c
+++ b/src/mbio/mbsys_hdcs.c
@@ -604,7 +604,8 @@ int mbsys_hdcs_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strncpy(comment, store->comment, MBSYS_HDCS_MAX_COMMENT);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_HDCS_MAX_COMMENT) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -772,7 +773,8 @@ int mbsys_hdcs_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, in
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, MBSYS_HDCS_MAX_COMMENT);
+    memset((void *)store->comment, 0, MBSYS_HDCS_MAX_COMMENT);
+		strncpy(store->comment, comment, MIN(MBSYS_HDCS_MAX_COMMENT, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	if (verbose >= 2) {

--- a/src/mbio/mbsys_hs10.c
+++ b/src/mbio/mbsys_hs10.c
@@ -245,7 +245,8 @@ int mbsys_hs10_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strncpy(comment, store->comment, MBSYS_HS10_COMMENT);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_HS10_COMMENT) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -409,7 +410,8 @@ int mbsys_hs10_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, in
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, MBSYS_HS10_COMMENT);
+    memset((void *)store->comment, 0, MBSYS_HS10_COMMENT);
+    strncpy(store->comment, comment, MIN(MBSYS_HS10_COMMENT, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_hsds.c
+++ b/src/mbio/mbsys_hsds.c
@@ -250,7 +250,8 @@ int mbsys_hsds_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_HSDS_MAXLINE) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -417,7 +418,8 @@ int mbsys_hsds_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, in
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strcpy(store->comment, comment);
+    memset((void *)store->comment, 0, MBSYS_HSDS_MAXLINE);
+    strncpy(store->comment, comment, MIN(MBSYS_HSDS_MAXLINE, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	if (verbose >= 2) {

--- a/src/mbio/mbsys_hsmd.c
+++ b/src/mbio/mbsys_hsmd.c
@@ -296,7 +296,8 @@ int mbsys_hsmd_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_HSMD_COMMENT) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -487,7 +488,8 @@ int mbsys_hsmd_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, in
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strcpy(store->comment, comment);
+    memset((void *)store->comment, 0, MBSYS_HSMD_COMMENT);
+    strncpy(store->comment, comment, MIN(MBSYS_HSMD_COMMENT, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_hysweep.c
+++ b/src/mbio/mbsys_hysweep.c
@@ -1445,10 +1445,10 @@ int mbsys_hysweep_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 		*time_d = store->time_d;
 
 		/* copy comment */
-		if (strlen(store->COM_comment) > 0)
-			strncpy(comment, store->COM_comment, MB_COMMENT_MAXLINE);
-		else
-			comment[0] = '\0';
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    if (strlen(store->COM_comment) > 0) {
+      strncpy(comment, store->COM_comment, MB_COMMENT_MAXLINE - 1);
+    }
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
@@ -1684,7 +1684,8 @@ int mbsys_hysweep_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->COM_comment, comment, MB_COMMENT_MAXLINE);
+    memset((void *)store->COM_comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(store->COM_comment, comment, MB_COMMENT_MAXLINE - 1);
 	}
 
 	if (verbose >= 2) {

--- a/src/mbio/mbsys_image83p.c
+++ b/src/mbio/mbsys_image83p.c
@@ -226,7 +226,8 @@ int mbsys_image83p_extract(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strncpy(comment, store->comment, MBSYS_IMAGE83P_COMMENTLEN);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_IMAGE83P_COMMENTLEN) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -365,7 +366,8 @@ int mbsys_image83p_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind
 
 	/* insert data in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, MBSYS_IMAGE83P_COMMENTLEN);
+    memset((void *)store->comment, 0, MBSYS_IMAGE83P_COMMENTLEN);
+		strncpy(store->comment, comment, MIN(MBSYS_IMAGE83P_COMMENTLEN, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_jstar.c
+++ b/src/mbio/mbsys_jstar.c
@@ -797,8 +797,9 @@ int mbsys_jstar_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
-		/* copy comment */
-		strcpy(comment, store->comment.comment);
+    /* copy comment */
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment.comment, MB_COMMENT_MAXLINE - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -1134,7 +1135,8 @@ int mbsys_jstar_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, i
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strcpy(store->comment.comment, comment);
+    memset((void *)store->comment.comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(store->comment.comment, comment, MB_COMMENT_MAXLINE - 1);
 	}
 
 	if (verbose >= 2) {

--- a/src/mbio/mbsys_kmbes.c
+++ b/src/mbio/mbsys_kmbes.c
@@ -1156,8 +1156,10 @@ int mbsys_kmbes_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
     *time_d = store->time_d;
 
     /* copy comment */
-    if (strlen(xmc->comment) > 0)
-      strncpy(comment, xmc->comment, MB_COMMENT_MAXLINE);
+    if (strlen(xmc->comment) > 0) {
+      memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		  strncpy(comment, xmc->comment, MB_COMMENT_MAXLINE - 1);
+    }
     else
       comment[0] = '\0';
 
@@ -1447,8 +1449,8 @@ int mbsys_kmbes_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, i
   /* insert comment in structure */
   else if (store->kind == MB_DATA_COMMENT) {
     /* copy comment */
-    strncpy(xmc->comment, comment, MB_COMMENT_MAXLINE-1);
-    xmc->comment[MB_COMMENT_MAXLINE-1] = '\0';
+    memset((void *)xmc->comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(xmc->comment, comment, MB_COMMENT_MAXLINE - 1);
 
     /* have to construct this record now */
     const int numBytesComment = strlen(xmc->comment) + (strlen(xmc->comment) % 2);

--- a/src/mbio/mbsys_ldeoih.c
+++ b/src/mbio/mbsys_ldeoih.c
@@ -411,7 +411,8 @@ int mbsys_ldeoih_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
   /* extract comment from structure */
   else if (*kind == MB_DATA_COMMENT) {
     /* copy comment */
-    strcpy(comment, store->comment);
+    memset((void *)comment, 0, sizeof(comment));
+    strncpy(comment, store->comment, MIN(sizeof(comment), sizeof(store->comment)) - 1);
 
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);

--- a/src/mbio/mbsys_mr1.c
+++ b/src/mbio/mbsys_mr1.c
@@ -310,7 +310,8 @@ int mbsys_mr1_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_MR1_MAXLINE) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -502,7 +503,8 @@ int mbsys_mr1_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strcpy(store->comment, comment);
+    memset((void *)store->comment, 0, MBSYS_MR1_MAXLINE);
+    strncpy(store->comment, comment, MIN(MBSYS_MR1_MAXLINE, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_mr1b.c
+++ b/src/mbio/mbsys_mr1b.c
@@ -311,7 +311,8 @@ int mbsys_mr1b_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_MR1B_MAXLINE) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -503,7 +504,8 @@ int mbsys_mr1b_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, in
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strcpy(store->comment, comment);
+    memset((void *)store->comment, 0, MBSYS_MR1B_MAXLINE);
+    strncpy(store->comment, comment, MIN(MBSYS_MR1B_MAXLINE, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_mr1v2001.c
+++ b/src/mbio/mbsys_mr1v2001.c
@@ -370,7 +370,8 @@ int mbsys_mr1v2001_extract(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_MR1V2001_MAXLINE) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -616,7 +617,8 @@ int mbsys_mr1v2001_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strcpy(store->comment, comment);
+    memset((void *)store->comment, 0, MBSYS_MR1V2001_MAXLINE);
+    strncpy(store->comment, comment, MIN(MBSYS_MR1V2001_MAXLINE, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_navnetcdf.c
+++ b/src/mbio/mbsys_navnetcdf.c
@@ -535,7 +535,8 @@ int mbsys_navnetcdf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *k
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, sizeof(comment));
+    strncpy(comment, store->comment, MIN(sizeof(comment), sizeof(store->comment)) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -651,7 +652,8 @@ int mbsys_navnetcdf_insert(int verbose, void *mbio_ptr, void *store_ptr, int kin
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
 		/* copy in comment */
-		strcpy(store->comment, comment);
+    memset((void *)store->comment, 0, sizeof(store->comment));
+    strncpy(store->comment, comment, MIN(sizeof(store->comment), MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_netcdf.c
+++ b/src/mbio/mbsys_netcdf.c
@@ -1348,7 +1348,8 @@ int mbsys_netcdf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_NETCDF_COMMENTLEN) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -1796,7 +1797,8 @@ int mbsys_netcdf_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
 		/* copy in comment */
-		strcpy(store->comment, comment);
+    memset((void *)store->comment, 0, MBSYS_NETCDF_COMMENTLEN);
+    strncpy(store->comment, comment, MIN(MBSYS_NETCDF_COMMENTLEN, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	int status = MB_SUCCESS;

--- a/src/mbio/mbsys_oic.c
+++ b/src/mbio/mbsys_oic.c
@@ -337,7 +337,8 @@ int mbsys_oic_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strncpy(comment, store->client, MBSYS_OIC_MAX_COMMENT);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->client, MIN(MB_COMMENT_MAXLINE, MBSYS_OIC_MAX_COMMENT) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -547,9 +548,10 @@ int mbsys_oic_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->client, comment, MBSYS_OIC_MAX_COMMENT);
-		store->client_size = strlen(comment) + 1;
 		store->type = OIC_ID_COMMENT;
+    memset((void *)store->client, 0, MBSYS_OIC_MAX_COMMENT);
+    strncpy(store->client, comment, MIN(MBSYS_OIC_MAX_COMMENT, MB_COMMENT_MAXLINE) - 1);
+    store->client_size = strlen(store->client) + 1;
 	}
 
 	if (verbose >= 2) {

--- a/src/mbio/mbsys_reson.c
+++ b/src/mbio/mbsys_reson.c
@@ -398,7 +398,8 @@ int mbsys_reson_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_RESON_COMMENT_LENGTH) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -571,7 +572,8 @@ int mbsys_reson_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, i
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, 199);
+    memset((void *)store->comment, 0, MBSYS_RESON_COMMENT_LENGTH);
+    strncpy(store->comment, comment, MIN(MBSYS_RESON_COMMENT_LENGTH, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_reson7k.c
+++ b/src/mbio/mbsys_reson7k.c
@@ -6298,10 +6298,10 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
     *time_d = store->time_d;
 
     /* copy comment */
-    if (systemeventmessage->message_length > 0)
-      strncpy(comment, systemeventmessage->message, MB_COMMENT_MAXLINE);
-    else
-      comment[0] = '\0';
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    if (systemeventmessage->message_length > 0) {
+      strncpy(comment, systemeventmessage->message, MIN(MB_COMMENT_MAXLINE - 1, systemeventmessage->message_length));
+    }
 
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
@@ -6650,6 +6650,7 @@ int mbsys_reson7k_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
       systemeventmessage->event_id = 1;
       systemeventmessage->message_length = msglen;
       systemeventmessage->event_identifier = 0;
+      memset((void *)systemeventmessage->message, 0, systemeventmessage->message_alloc);
       strncpy(systemeventmessage->message, comment, msglen);
       systemeventmessage->header.Size =
           MBSYS_RESON7K_RECORDHEADER_SIZE + R7KHDRSIZE_7kSystemEventMessage + msglen + MBSYS_RESON7K_RECORDTAIL_SIZE;

--- a/src/mbio/mbsys_reson7k3.c
+++ b/src/mbio/mbsys_reson7k3.c
@@ -6510,10 +6510,10 @@ int mbsys_reson7k3_extract(int verbose, void *mbio_ptr, void *store_ptr, int *ki
     *time_d = store->time_d;
 
     /* copy comment */
-    if (SystemEventMessage->message_length > 0)
-      strncpy(comment, SystemEventMessage->message, MB_COMMENT_MAXLINE);
-    else
-      comment[0] = '\0';
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    if (SystemEventMessage->message_length > 0) {
+      strncpy(comment, SystemEventMessage->message, MIN(MB_COMMENT_MAXLINE - 1, SystemEventMessage->message_length));
+    }
 
     if (verbose >= 4) {
       fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
@@ -6868,6 +6868,7 @@ int mbsys_reson7k3_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind
       SystemEventMessage->event_id = 1;
       SystemEventMessage->message_length = msglen;
       SystemEventMessage->event_identifier = 0;
+      memset((void *)SystemEventMessage->message, 0, SystemEventMessage->message_alloc);
       strncpy(SystemEventMessage->message, comment, msglen);
       SystemEventMessage->header.Version = 5;
       SystemEventMessage->header.Offset = 60;

--- a/src/mbio/mbsys_reson8k.c
+++ b/src/mbio/mbsys_reson8k.c
@@ -416,7 +416,8 @@ int mbsys_reson8k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_RESON8K_COMMENT_LENGTH) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -570,7 +571,8 @@ int mbsys_reson8k_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, 199);
+    memset((void *)store->comment, 0, MBSYS_RESON8K_COMMENT_LENGTH);
+    strncpy(store->comment, comment, MIN(MBSYS_RESON8K_COMMENT_LENGTH, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_sb.c
+++ b/src/mbio/mbsys_sb.c
@@ -242,7 +242,8 @@ int mbsys_sb_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, in
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_SB_MAXLINE) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -385,7 +386,8 @@ int mbsys_sb_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int 
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strcpy(store->comment, comment);
+    memset((void *)store->comment, 0, MBSYS_SB_MAXLINE);
+    strncpy(store->comment, comment, MIN(MBSYS_SB_MAXLINE, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	if (verbose >= 2 && (kind == MB_DATA_DATA || kind == MB_DATA_NAV)) {

--- a/src/mbio/mbsys_sb2000.c
+++ b/src/mbio/mbsys_sb2000.c
@@ -260,7 +260,8 @@ int mbsys_sb2000_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, sizeof(comment));
+    strncpy(comment, store->comment, MIN(sizeof(comment), sizeof(store->comment)) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -444,7 +445,8 @@ int mbsys_sb2000_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
 		store->data_type[1] = 'R';
 		store->sensor_size = 0;
 		store->data_size = strlen(comment) + 1;
-		strcpy(store->comment, comment);
+    memset((void *)store->comment, 0, sizeof(store->comment));
+    strncpy(store->comment, comment, MIN(sizeof(store->comment), MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_sb2100.c
+++ b/src/mbio/mbsys_sb2100.c
@@ -261,7 +261,8 @@ int mbsys_sb2100_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_SB2100_MAXLINE) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -445,7 +446,8 @@ int mbsys_sb2100_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strcpy(store->comment, comment);
+    memset((void *)store->comment, 0, MBSYS_SB2100_MAXLINE);
+    strncpy(store->comment, comment, MIN(MBSYS_SB2100_MAXLINE, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_simrad.c
+++ b/src/mbio/mbsys_simrad.c
@@ -901,7 +901,8 @@ int mbsys_simrad_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_SIMRAD_COMMENT_LENGTH) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -1168,7 +1169,8 @@ int mbsys_simrad_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, 
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, 79);
+    memset((void *)store->comment, 0, MBSYS_SIMRAD_COMMENT_LENGTH);
+    strncpy(store->comment, comment, MIN(MBSYS_SIMRAD_COMMENT_LENGTH, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	if (verbose >= 2) {

--- a/src/mbio/mbsys_simrad2.c
+++ b/src/mbio/mbsys_simrad2.c
@@ -2678,7 +2678,8 @@ int mbsys_simrad2_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strncpy(comment, store->par_com, MBSYS_SIMRAD2_COMMENT_LENGTH);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->par_com, MIN(MB_COMMENT_MAXLINE, MBSYS_SIMRAD2_COMMENT_LENGTH) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -3116,7 +3117,8 @@ int mbsys_simrad2_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->par_com, comment, MBSYS_SIMRAD2_COMMENT_LENGTH);
+    memset((void *)store->par_com, 0, MBSYS_SIMRAD2_COMMENT_LENGTH);
+    strncpy(store->par_com, comment, MIN(MBSYS_SIMRAD2_COMMENT_LENGTH, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	if (verbose >= 2) {

--- a/src/mbio/mbsys_simrad3.c
+++ b/src/mbio/mbsys_simrad3.c
@@ -2249,7 +2249,8 @@ int mbsys_simrad3_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strncpy(comment, store->par_com, MBSYS_SIMRAD3_COMMENT_LENGTH);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->par_com, MIN(MB_COMMENT_MAXLINE, MBSYS_SIMRAD3_COMMENT_LENGTH) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -2486,7 +2487,8 @@ int mbsys_simrad3_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind,
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->par_com, comment, MBSYS_SIMRAD3_COMMENT_LENGTH);
+    memset((void *)store->par_com, 0, MBSYS_SIMRAD3_COMMENT_LENGTH);
+    strncpy(store->par_com, comment, MIN(MBSYS_SIMRAD3_COMMENT_LENGTH, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	if (verbose >= 2) {

--- a/src/mbio/mbsys_singlebeam.c
+++ b/src/mbio/mbsys_singlebeam.c
@@ -345,7 +345,8 @@ int mbsys_singlebeam_extract(int verbose, void *mbio_ptr, void *store_ptr, int *
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MB_COMMENT_MAXLINE - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -474,7 +475,8 @@ int mbsys_singlebeam_insert(int verbose, void *mbio_ptr, void *store_ptr, int ki
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strcpy(store->comment, comment);
+    memset((void *)store->comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(store->comment, comment, MB_COMMENT_MAXLINE - 1);
 	}
 
 	int status = MB_SUCCESS;

--- a/src/mbio/mbsys_stereopair.c
+++ b/src/mbio/mbsys_stereopair.c
@@ -388,7 +388,8 @@ int mbsys_stereopair_extract(int verbose, void *mbio_ptr, void *store_ptr, int *
 		mb_get_date(verbose, *time_d, time_i);
 
 		/* copy comment */
-		strncpy(comment, store->comment, MIN(store->comment_len, MB_COMMENT_MAXLINE));
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, store->comment_len) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
@@ -577,9 +578,10 @@ int mbsys_stereopair_insert(int verbose, void *mbio_ptr, void *store_ptr, int ki
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, MB_COMMENT_MAXLINE);
-		store->comment_len = strlen(store->comment) + 1;
-		store->comment_len += 4 - (store->comment_len % 4);
+		store->comment_len = strlen(store->comment) + 4 - (strlen(store->comment) % 4);
+    store->comment_len = MIN(store->comment_len, MB_COMMENT_MAXLINE - 4);
+    memset((void *)store->comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(store->comment, comment, store->comment_len);
 	}
 
 	if (verbose >= 2) {

--- a/src/mbio/mbsys_surf.c
+++ b/src/mbio/mbsys_surf.c
@@ -374,8 +374,8 @@ int mbsys_surf_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, 
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		/*		strncpy(comment,store->comment,
-		            MBSYS_SURF_COMMENT_LENGTH);*/
+    // memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    // strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, sizeof(store->comment)) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);

--- a/src/mbio/mbsys_swathplus.c
+++ b/src/mbio/mbsys_swathplus.c
@@ -622,11 +622,9 @@ int mbsys_swathplus_extract(int verbose, void *mbio_ptr, void *store_ptr, int *k
 		*time_d = store->time_d;
 
 		/* copy comment */
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
 		if (store->comment.nchars > 0) {
-			strncpy(comment, store->comment.message, MB_COMMENT_MAXLINE);
-		}
-		else {
-			comment[0] = '\0';
+      strncpy(comment, store->comment.message, MIN(MB_COMMENT_MAXLINE, store->comment.nchars) - 1);
 		}
 
 		if (verbose >= 4) {
@@ -892,7 +890,8 @@ int mbsys_swathplus_insert(int verbose, void *mbio_ptr, void *store_ptr, int kin
 
 		if (status == MB_SUCCESS) {
 			ocomment->nchars = nchars;
-			strcpy(ocomment->message, comment);
+      memset((void *)ocomment->message, 0, ocomment->message_alloc);
+      strncpy(ocomment->message, comment, MIN(ocomment->message_alloc, MB_COMMENT_MAXLINE) - 1);
 		}
 		else {
 			kind = MB_DATA_NONE;

--- a/src/mbio/mbsys_templatesystem.c
+++ b/src/mbio/mbsys_templatesystem.c
@@ -397,8 +397,10 @@ int mbsys_templatesystem_extract(int verbose, void *mbio_ptr, void *store_ptr, i
 		*time_d = store->time_d;
 
 		/* copy comment */
-		if (store->comment > 0)
-			strncpy(comment, store->comment, MB_COMMENT_MAXLINE);
+		if (store->comment > 0) {
+      memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+      strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_TEMPLATESYSTEM_MAX_COMMENT) - 1);
+    }
 		else
 			comment[0] = '\0';
 
@@ -607,7 +609,8 @@ int mbsys_templatesystem_insert(int verbose, void *mbio_ptr, void *store_ptr, in
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, MB_COMMENT_MAXLINE);
+    memset((void *)store->comment, 0, MBSYS_TEMPLATESYSTEM_MAX_COMMENT);
+    strncpy(store->comment, comment, MIN(MBSYS_TEMPLATESYSTEM_MAX_COMMENT, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_templatesystem.h
+++ b/src/mbio/mbsys_templatesystem.h
@@ -63,37 +63,42 @@
 #define MBSYS_TEMPLATESYSTEM_MAX_BEAMS 400
 #define MBSYS_TEMPLATESYSTEM_MAX_PIXELS 400
 
+/* Comment size definition */
+#define MBSYS_TEMPLATESYSTEM_MAX_COMMENT MB_COMMENT_MAXLINE
+
     /*---------------------------------------------------------------*/
 
     /* Structure size definitions (if needed because there are dynamically allocated substructures) */
 
     /* Internal data structure */
     struct mbsys_templatesystem_struct {
-	/* Type of most recently read data record */
-	int kind; /* MB-System record ID */
+      
+    /* Type of most recently read data record */
+    int kind; /* MB-System record ID */
 
-	/* MB-System time stamp of most recently read record */
-	double time_d;
-	int time_i[7];
+    /* MB-System time stamp of most recently read record */
+    double time_d;
+    int time_i[7];
 
-	/* Survey data
+    /* Survey data
 
-	/* Navigation and attitude associated with survey data */
+    /* Navigation and attitude associated with survey data */
 
-	/* Bathymetry and amplitude data */
+    /* Bathymetry and amplitude data */
 
-	/* Raw backscatter data */
+    /* Raw backscatter data */
 
-	/* Sidescan derived from raw backscatter */
+    /* Sidescan derived from raw backscatter */
 
-	/* Navigation data */
+    /* Navigation data */
 
-	/* Sensordepth */
+    /* Sensordepth */
 
-	/* Attitude data */
+    /* Attitude data */
 
-	/* Comment */
-};
+    /* Comment */
+    comment[MBSYS_TEMPLATESYSTEM_MAX_COMMENT];
+    };
 
 /*---------------------------------------------------------------*/
 

--- a/src/mbio/mbsys_wassp.c
+++ b/src/mbio/mbsys_wassp.c
@@ -442,10 +442,10 @@ int mbsys_wassp_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind,
 		*time_d = store->time_d;
 
 		/* copy comment */
-		if (mcomment->comment_length > 0)
-			strncpy(comment, mcomment->comment_message, MIN(mcomment->comment_length, MB_COMMENT_MAXLINE));
-		else
-			comment[0] = '\0';
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+		if (mcomment->comment_length > 0) {
+        strncpy(comment, mcomment->comment_message, MIN(mcomment->comment_length, MB_COMMENT_MAXLINE));
+    }
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  Comment extracted by MBIO function <%s>\n", __func__);
@@ -659,12 +659,12 @@ int mbsys_wassp_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, i
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(mcomment->comment_message, comment, MB_COMMENT_MAXLINE);
-		mcomment->comment_length = strlen(comment);
-		if (mcomment->comment_length % 2 == 1) {
-			mcomment->comment_length++;
-			mcomment->comment_message[mcomment->comment_length] = '\0';
-		}
+    mcomment->comment_length = MIN(strlen(comment) + 1, MB_COMMENT_MAXLINE);
+    if (mcomment->comment_length % 2 == 1) {
+      mcomment->comment_length = MIN(mcomment->comment_length + 1, MB_COMMENT_MAXLINE);
+    }
+    memset((void *)mcomment->comment_message, 0, MB_COMMENT_MAXLINE);
+    strncpy(mcomment->comment_message, comment, MB_COMMENT_MAXLINE - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbio/mbsys_xse.c
+++ b/src/mbio/mbsys_xse.c
@@ -687,7 +687,8 @@ int mbsys_xse_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kind, i
 	/* extract comment from structure */
 	else if (*kind == MB_DATA_COMMENT) {
 		/* copy comment */
-		strcpy(comment, store->comment);
+    memset((void *)comment, 0, MB_COMMENT_MAXLINE);
+    strncpy(comment, store->comment, MIN(MB_COMMENT_MAXLINE, MBSYS_XSE_COMMENT_LENGTH) - 1);
 
 		if (verbose >= 4) {
 			fprintf(stderr, "\ndbg4  New ping read by MBIO function <%s>\n", __func__);
@@ -916,7 +917,8 @@ int mbsys_xse_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind, int
 
 	/* insert comment in structure */
 	else if (store->kind == MB_DATA_COMMENT) {
-		strncpy(store->comment, comment, 199);
+    memset((void *)store->comment, 0, MBSYS_XSE_COMMENT_LENGTH);
+    strncpy(store->comment, comment, MIN(MBSYS_XSE_COMMENT_LENGTH, MB_COMMENT_MAXLINE) - 1);
 	}
 
 	const int status = MB_SUCCESS;

--- a/src/mbnavadjust/mbnavadjust_callbacks.c
+++ b/src/mbnavadjust/mbnavadjust_callbacks.c
@@ -199,9 +199,10 @@ void BxSetValuesCB(Widget w, XtPointer client, XtPointer call) {
 	int count = 0;
 
 	char *start = rscs;
-	for (; rscs && *rscs; rscs = strtok(NULL, "\n")) {
+  char *saveptr;
+	for (; rscs && *rscs; rscs = strtok_r(NULL, "\n", &saveptr)) {
 		if (first) {
-			rscs = strtok(rscs, "\n");
+			rscs = strtok_r(rscs, "\n", &saveptr);
 			first = false;
 		}
 		valueList[count] = XtNewString(rscs);

--- a/src/mbnavadjust/mbnavadjust_fine.cc
+++ b/src/mbnavadjust/mbnavadjust_fine.cc
@@ -404,7 +404,7 @@ int mbnavadjust_align_arguments(int argc, char** argv, mbnavadjust_align_params 
                         }
                         break;
             case 'd' :  if(optarg != nullptr && optarg[0] != '-') {
-                            params.icpSettings.maxDistance = atoi(optarg);
+                            params.icpSettings.maxDistance = strtol(optarg, nullptr, 10);
                         }
                         else {
                             std::cerr << argv[0] << ": option requires an argument -- 'o'\n";
@@ -413,7 +413,7 @@ int mbnavadjust_align_arguments(int argc, char** argv, mbnavadjust_align_params 
                         }
                         break;
             case 'r' :  if(optarg != nullptr && optarg[0] != '-') {
-                            params.icpSettings.epsilonT = atof(optarg);
+                            params.icpSettings.epsilonT = strtod(optarg, nullptr);
                         }
                         else {
                             std::cerr << argv[0] << ": option requires an argument -- 'o'\n";
@@ -422,7 +422,7 @@ int mbnavadjust_align_arguments(int argc, char** argv, mbnavadjust_align_params 
                         }
                         break;
             case 'f' :  if(optarg != nullptr && optarg[0] != '-') {
-                            params.icpSettings.epsilonFit = atof(optarg);
+                            params.icpSettings.epsilonFit = strtod(optarg, nullptr);
                         }
                         else {
                             std::cerr << argv[0] << ": option requires an argument -- 'o'\n";

--- a/src/mbnavedit/mbnavedit_callbacks.c
+++ b/src/mbnavedit/mbnavedit_callbacks.c
@@ -242,9 +242,10 @@ void BxSetValuesCB(Widget w, XtPointer client, XtPointer call) {
 	String *valueList = (String *)XtCalloc(CHUNK, sizeof(String));
 	int count = 0;
 
-	for (start = rscs; rscs && *rscs; rscs = strtok(NULL, "\n")) {
+  char *saveptr;
+	for (start = rscs; rscs && *rscs; rscs = strtok_r(NULL, "\n", &saveptr)) {
 		if (first) {
-			rscs = strtok(rscs, "\n");
+			rscs = strtok_r(rscs, "\n", &saveptr);
 			first = false;
 		}
 		valueList[count] = XtNewString(rscs);

--- a/src/mbtrnutils/mbtrnpp.c
+++ b/src/mbtrnutils/mbtrnpp.c
@@ -1555,8 +1555,9 @@ static int s_parse_opt_output(mbtrnpp_cfg_t *cfg, char *opt_str)
         // tokenize optarg
         char *ocopy = CHK_STRDUP(opt_str);
         char *tok[MBSYSOUT_OPT_N]={0};
+        char *saveptr;
         for(int i = 0; i < MBSYSOUT_OPT_N; i++){
-            tok[i] = (i==0  ? strtok(ocopy,",") : strtok(NULL,","));
+            tok[i] = (i==0  ? strtok_r(ocopy,",",&saveptr) : strtok_r(NULL,",",&saveptr));
             if(tok[i]==NULL)
                 break;
         }
@@ -1567,11 +1568,11 @@ static int s_parse_opt_output(mbtrnpp_cfg_t *cfg, char *opt_str)
             if (NULL!=strstr(tok[i], "socket:")) {
                 // enable mb1 socket (use specified IP)
                 char *acpy = strdup(tok[i]);
-                char *atok = strtok(acpy,":");
+                char *atok = strtok_r(acpy,":",&saveptr);
                 if(NULL!=atok){
                     // uses defaults if NULL
-                    char *shost = strtok(NULL,":");
-                    char *sport = strtok(NULL,":");
+                    char *shost = strtok_r(NULL,":",&saveptr);
+                    char *sport = strtok_r(NULL,":",&saveptr);
                     //                    fprintf(stderr,"shost[%s] sport[%s]\n",shost,sport);
 
                     if(NULL!=shost){
@@ -1595,7 +1596,7 @@ static int s_parse_opt_output(mbtrnpp_cfg_t *cfg, char *opt_str)
 
             if(NULL!=strstr(tok[i],"file:")){
                 char *acpy = strdup((tok[i]+strlen("file:")));
-                char *atok = strtok(acpy,":");
+                char *atok = strtok_r(acpy,":",&saveptr);
                 //                fprintf(stderr,"output_file[%s]\n",atok);
                 if(strlen(atok)>0){
                     strcpy(cfg->output_file,atok);
@@ -1623,8 +1624,9 @@ static int s_parse_opt_mbout(mbtrnpp_cfg_t *cfg, char *opt_str)
         // tokenize optarg
         char *ocopy = strdup(opt_str);
         char *tok[MBOUT_OPT_N] = {0};
+        char *saveptr;
         for(int i = 0; i < MBOUT_OPT_N; i++){
-            tok[i] = (i==0  ? strtok(ocopy,",") : strtok(NULL,","));
+            tok[i] = (i==0  ? strtok_r(ocopy,",",&saveptr) : strtok_r(NULL,",",&saveptr));
             if(tok[i]==NULL)
                 break;
         }
@@ -1635,11 +1637,11 @@ static int s_parse_opt_mbout(mbtrnpp_cfg_t *cfg, char *opt_str)
             if(strstr(tok[i], "mb1svr") != NULL) {
                 // enable mb1 socket output (optionally, specify host:port)
                 char *acpy = strdup(tok[i]);
-                char *atok = strtok(acpy, ":");
+                char *atok = strtok_r(acpy, ":",&saveptr);
                 if(NULL != atok){
                     // uses defaults if NULL
-                    char *shost = strtok(NULL,":");
-                    char *sport = strtok(NULL,":");
+                    char *shost = strtok_r(NULL,":",&saveptr);
+                    char *sport = strtok_r(NULL,":",&saveptr);
                     //                    fprintf(stderr,"shost[%s] sport[%s]\n",shost,sport);
 
                     if(NULL != shost){
@@ -1662,7 +1664,7 @@ static int s_parse_opt_mbout(mbtrnpp_cfg_t *cfg, char *opt_str)
             }
             if(NULL != strstr(tok[i], "file:")) {
                 char *acpy = strdup((tok[i] + strlen("file:")));
-                char *atok = strtok(acpy,":");
+                char *atok = strtok_r(acpy,":",&saveptr);
                 //                fprintf(stderr,"output_file[%s]\n",atok);
                 if(strlen(atok)>0){
                     strcpy(cfg->output_file,atok);
@@ -1710,8 +1712,9 @@ static int s_parse_opt_trnout(mbtrnpp_cfg_t *cfg, char *opt_str)
         // tokenize optarg
         char *ocopy = strdup(opt_str);
         char *tok[TRNOUT_OPT_N] = {0};
+        char *saveptr;
         for(int i = 0; i < TRNOUT_OPT_N; i++){
-            tok[i] = (i==0 ? strtok(ocopy,",") : strtok(NULL,","));
+            tok[i] = (i==0 ? strtok_r(ocopy,",",&saveptr) : strtok_r(NULL,",",&saveptr));
             //                fprintf(stderr,"tok[%d][%s]\n",i,tok[i]);
             if(tok[i] == NULL)
                 break;
@@ -1723,10 +1726,10 @@ static int s_parse_opt_trnout(mbtrnpp_cfg_t *cfg, char *opt_str)
             if(strstr(tok[i], "trnsvr")!=NULL) {
                 // enable trnsvr (mbsvr:host:port)
                 char *acpy = strdup(tok[i]);
-                char *atok = strtok(acpy,":");
+                char *atok = strtok_r(acpy,":",&saveptr);
                 if(NULL!=atok){
-                    char *shost = strtok(NULL,":");
-                    char *sport = strtok(NULL,":");
+                    char *shost = strtok_r(NULL,":",&saveptr);
+                    char *sport = strtok_r(NULL,":",&saveptr);
 
                     if(NULL!=shost){
                         MEM_CHKINVALIDATE(cfg->trnsvr_host);
@@ -1742,10 +1745,10 @@ static int s_parse_opt_trnout(mbtrnpp_cfg_t *cfg, char *opt_str)
             if(strstr(tok[i], "trnusvr")!=NULL){
                 // enable trnsvr (mbsvr:host:port)
                 char *acpy = strdup(tok[i]);
-                char *atok = strtok(acpy,":");
+                char *atok = strtok_r(acpy,":",&saveptr);
                 if(NULL != atok){
-                    char *shost = strtok(NULL,":");
-                    char *sport = strtok(NULL,":");
+                    char *shost = strtok_r(NULL,":",&saveptr);
+                    char *sport = strtok_r(NULL,":",&saveptr);
 
                     if(NULL != shost){
                         MEM_CHKINVALIDATE(cfg->trnusvr_host);
@@ -4851,7 +4854,7 @@ int mbtrnpp_trnu_pubempty_osocket(double time, double lat, double lon, double de
                 dzero,
                 dzero,
             };
-            
+
             if( (iobytes=netif_pub(trnusvr,(char *)&pub_data, sizeof(pub_data)))>0){
                 retval=iobytes;
                 MST_COUNTER_INC(app_stats->stats->events[MBTPP_EV_TRNU_PUBEMPTYN]);
@@ -5561,24 +5564,25 @@ int mbtrnpp_reson7kr_input_open(int verbose, void *mbio_ptr, char *definition, i
   // copy def (strtok is destructive)
   char *defcpy = strdup(definition);
   char *addr[2]={NULL,NULL};
+  char *saveptr;
   // separate hostname, numeric tokens
-  addr[0]=strtok(defcpy,":");
-  addr[1]=strtok(NULL,"");
+  addr[0]=strtok_r(defcpy,":",&saveptr);
+  addr[1]=strtok_r(NULL,"",&saveptr);
 
-    // parse hostname, port, size
-    if(NULL!=addr[0])
-    strcpy(hostname, addr[0]);
-    if(NULL!=addr[1])
-    sscanf(addr[1], "%d:%zu", &port, &size);
-    // release definition copy
-    free(defcpy);
+  // parse hostname, port, size
+  if(NULL!=addr[0])
+  strcpy(hostname, addr[0]);
+  if(NULL!=addr[1])
+  sscanf(addr[1], "%d:%zu", &port, &size);
+  // release definition copy
+  free(defcpy);
 
-    if (strlen(hostname) == 0)
-    strcpy(hostname, "localhost");
-    if (port == 0)
-    port = R7K_7KCENTER_PORT;
-    if (size == 0)
-    size = SONAR_READER_CAPACITY_DFL;
+  if (strlen(hostname) == 0)
+  strcpy(hostname, "localhost");
+  if (port == 0)
+  port = R7K_7KCENTER_PORT;
+  if (size == 0)
+  size = SONAR_READER_CAPACITY_DFL;
 
   PMPRINT(MOD_MBTRNPP, MM_DEBUG, (stderr, "configuring r7kr_reader using %s:%d\n", hostname, port));
   r7kr_reader_t *reader = r7kr_reader_new(hostname, port, size, reson_subs, reson_nsubs);
@@ -5822,13 +5826,14 @@ int mbtrnpp_kemkmall_input_open(int verbose, void *mbio_ptr, char *definition, i
   struct sockaddr_in localSock;
   struct ip_mreq group;
   char *token;
-  if ((token = strsep(&definition, ":")) != NULL) {
+  char *saveptr;
+  if ((token = strtok_r(definition, ":", &saveptr)) != NULL) {
     strncpy(hostInterface, token, sizeof(mb_path));
   }
-  if ((token = strsep(&definition, ":")) != NULL) {
+  if ((token = strtok_r(NULL, ":", &saveptr)) != NULL) {
     strncpy(bcastGrp, token, sizeof(mb_path));
   }
-  if ((token = strsep(&definition, ":")) != NULL) {
+  if ((token = strtok_r(NULL, ":", &saveptr)) != NULL) {
     sscanf(token, "%d", &port);
   }
 

--- a/src/mbvelocitytool/mbvelocity_callbacks.c
+++ b/src/mbvelocitytool/mbvelocity_callbacks.c
@@ -245,10 +245,11 @@ void BxSetValuesCB(Widget w, XtPointer client, XtPointer call) {
 	String rsc;
 	int i, count = 0;
 	Widget *current;
+  char *saveptr;
 
-	for (start = rscs; rscs && *rscs; rscs = strtok(NULL, "\n")) {
+	for (start = rscs; rscs && *rscs; rscs = strtok_r(NULL, "\n", &saveptr)) {
 		if (first) {
-			rscs = strtok(rscs, "\n");
+			rscs = strtok_r(rscs, "\n", &saveptr);
 			first = False;
 		}
 		valueList[count] = XtNewString(rscs);

--- a/src/utilities/mbgrid.cc
+++ b/src/utilities/mbgrid.cc
@@ -607,7 +607,7 @@ int main(int argc, char **argv) {
       case 'K':
       case 'k':
         sscanf(optarg, "%1023s", backgroundfile);
-        if ((grdrasterid = atoi(backgroundfile)) <= 0)
+        if ((grdrasterid = (int)strtol(backgroundfile, NULL, 10)) <= 0)
           grdrasterid = -1;
         break;
       case 'L':

--- a/src/utilities/mblevitus.cc
+++ b/src/utilities/mblevitus.cc
@@ -104,9 +104,7 @@ int main(int argc, char **argv) {
   double longitude = 0.0;
   double latitude = 0.0;
 
-  // TODO(schwehr): Why restrict the ofile size to be so small?
-  //   Why not mb_path?
-  char ofile[128];
+  mb_path ofile;
   strcpy(ofile, "velocity");
 
   /* process argument list */
@@ -127,8 +125,9 @@ int main(int argc, char **argv) {
       case 'R':
       case 'r':
       {
-        const char *lonptr = strtok(optarg, "/");
-        const char *latptr = strtok(nullptr, "/");
+        char *saveptr;
+        const char *lonptr = strtok_r(optarg, "/", &saveptr);
+        const char *latptr = strtok_r(nullptr, "/", &saveptr);
         if (lonptr != nullptr && latptr != nullptr) {
           longitude = mb_ddmmss_to_degree(lonptr);
           latitude = mb_ddmmss_to_degree(latptr);
@@ -137,7 +136,7 @@ int main(int argc, char **argv) {
       }
       case 'O':
       case 'o':
-        sscanf(optarg, "%127s", ofile);
+        sscanf(optarg, "%s", ofile);
         break;
       case '?':
         errflg = true;
@@ -255,11 +254,10 @@ int main(int argc, char **argv) {
   int last_good = -1;
   float velocity[NDEPTH_MAX];
   for (int i = 0; i < NDEPTH_MAX; i++) {
-    if (i < NLEVITUS_MAX)
-      if (salinity[i][ilat] > MBLEVITUS_NO_DATA) {
-        last_good = i;
-        nvelocity++;
-      }
+    if (i < NLEVITUS_MAX && salinity[i][ilat] > MBLEVITUS_NO_DATA) {
+      last_good = i;
+      nvelocity++;
+    }
     if (last_good >= 0) {
       /* set counter */
       nvelocity_tot++;
@@ -293,8 +291,6 @@ int main(int argc, char **argv) {
                         pressure * (0.00000485639620015 * salinity[last_good][ilat] - 0.000340597039004)));
       velocity[i] = c0 + dltact + dltacs + dltacp + dcstp;
     }
-    else
-      velocity[i] = salinity[i][ilat];
   }
 
   /* check for existence of water velocity profile */

--- a/src/utilities/mbprocess.cc
+++ b/src/utilities/mbprocess.cc
@@ -1314,25 +1314,25 @@ void process_file(int verbose, struct mb_process_struct *process,
       else if (process->mbp_nav_format == 5) {
         strncpy(dummy, "", 128);
         if (buffer[2] == '+') {
-          time_j[0] = atoi(strncpy(dummy, buffer, 2));
+          time_j[0] = (int)strtol(strncpy(dummy, buffer, 2), NULL, 10);
           mb_fix_y2k(verbose, time_j[0], &time_j[0]);
           ioff = 3;
         }
         else {
-          time_j[0] = atoi(strncpy(dummy, buffer, 4));
+          time_j[0] = (int)strtol(strncpy(dummy, buffer, 4), NULL, 10);
           ioff = 5;
         }
         strncpy(dummy, "", 128);
-        time_j[1] = atoi(strncpy(dummy, buffer + ioff, 3));
+        time_j[1] = (int)strtol(strncpy(dummy, buffer + ioff, 3), NULL, 10);
         strncpy(dummy, "", 128);
         ioff += 4;
-        hr = atoi(strncpy(dummy, buffer + ioff, 2));
+        hr = (int)strtol(strncpy(dummy, buffer + ioff, 2), NULL, 10);
         strncpy(dummy, "", 128);
         ioff += 3;
-        time_j[2] = atoi(strncpy(dummy, buffer + ioff, 2)) + 60 * hr;
+        time_j[2] = (int)strtol(strncpy(dummy, buffer + ioff, 2), NULL, 10) + 60 * hr;
         strncpy(dummy, "", 128);
         ioff += 3;
-        time_j[3] = atoi(strncpy(dummy, buffer + ioff, 2));
+        time_j[3] = (int)strtol(strncpy(dummy, buffer + ioff, 2), NULL, 10);
         time_j[4] = 0;
         mb_get_itime(verbose, time_j, time_i);
         mb_get_time(verbose, time_i, &time_d);
@@ -1373,34 +1373,34 @@ void process_file(int verbose, struct mb_process_struct *process,
           if (strncmp(&buffer[3], "DAT", 3) == 0 && len > 15) {
             time_set = false;
             strncpy(dummy, "", 128);
-            time_i[0] = atoi(strncpy(dummy, buffer + 7, 4));
-            time_i[1] = atoi(strncpy(dummy, buffer + 11, 2));
-            time_i[2] = atoi(strncpy(dummy, buffer + 13, 2));
+            time_i[0] = (int)strtol(strncpy(dummy, buffer + 7, 4), NULL, 10);
+            time_i[1] = (int)strtol(strncpy(dummy, buffer + 11, 2), NULL, 10);
+            time_i[2] = (int)strtol(strncpy(dummy, buffer + 13, 2), NULL, 10);
           }
           else if ((strncmp(&buffer[3], "ZDA", 3) == 0 || strncmp(&buffer[3], "UNX", 3) == 0) && len > 14) {
             time_set = false;
             /* find start of ",hhmmss.ss" */
             if ((bufftmp = strchr(buffer, ',')) != nullptr) {
               strncpy(dummy, "", 128);
-              time_i[3] = atoi(strncpy(dummy, bufftmp + 1, 2));
+              time_i[3] = (int)strtol(strncpy(dummy, bufftmp + 1, 2), NULL, 10);
               strncpy(dummy, "", 128);
-              time_i[4] = atoi(strncpy(dummy, bufftmp + 3, 2));
+              time_i[4] = (int)strtol(strncpy(dummy, bufftmp + 3, 2), NULL, 10);
               strncpy(dummy, "", 128);
-              time_i[5] = atoi(strncpy(dummy, bufftmp + 5, 2));
+              time_i[5] = (int)strtol(strncpy(dummy, bufftmp + 5, 2), NULL, 10);
               if (bufftmp[7] == '.') {
                 strncpy(dummy, "", 128);
-                time_i[6] = 10000 * atoi(strncpy(dummy, bufftmp + 8, 2));
+                time_i[6] = 10000 * (int)strtol(strncpy(dummy, bufftmp + 8, 2), NULL, 10);
               }
               else
                 time_i[6] = 0;
               /* find start of ",dd,mm,yyyy" */
               if ((bufftmp = strchr(&bufftmp[1], ',')) != nullptr) {
                 strncpy(dummy, "", 128);
-                time_i[2] = atoi(strncpy(dummy, bufftmp + 1, 2));
+                time_i[2] = (int)strtol(strncpy(dummy, bufftmp + 1, 2), NULL, 10);
                 strncpy(dummy, "", 128);
-                time_i[1] = atoi(strncpy(dummy, bufftmp + 4, 2));
+                time_i[1] = (int)strtol(strncpy(dummy, bufftmp + 4, 2), NULL, 10);
                 strncpy(dummy, "", 128);
-                time_i[0] = atoi(strncpy(dummy, bufftmp + 7, 4));
+                time_i[0] = (int)strtol(strncpy(dummy, bufftmp + 7, 4), NULL, 10);
                 time_set = true;
               }
             }
@@ -1414,7 +1414,7 @@ void process_file(int verbose, struct mb_process_struct *process,
               if (process->mbp_nav_format == 7)
                 bufftmp = strchr(&bufftmp[1], ',');
               strncpy(dummy, "", 128);
-              degree = atoi(strncpy(dummy, bufftmp + 1, 2));
+              degree = (int)strtol(strncpy(dummy, bufftmp + 1, 2), NULL, 10);
               strncpy(dummy, "", 128);
               dminute = atof(strncpy(dummy, bufftmp + 3, 5));
               strncpy(NorS, "", sizeof(NorS));
@@ -1425,7 +1425,7 @@ void process_file(int verbose, struct mb_process_struct *process,
                 nlat[nnav] = -nlat[nnav];
               bufftmp = strchr(&bufftmp[1], ',');
               strncpy(dummy, "", 128);
-              degree = atoi(strncpy(dummy, bufftmp + 1, 3));
+              degree = (int)strtol(strncpy(dummy, bufftmp + 1, 3), NULL, 10);
               strncpy(dummy, "", 128);
               dminute = atof(strncpy(dummy, bufftmp + 4, 5));
               bufftmp = strchr(&bufftmp[1], ',');


### PR DESCRIPTION
General changes: Replacing use of strtok() function with strtok_r(). Strtok() is
intrinsically not thread safe or reentrant and is considered poor use under all
circumstances. Source files with this change include:
  src/mbio/mbr_edgjstar.c src/mbio/mbr_hypc8101.c src/mbio/mbr_hysweep1.c
  src/mbio/mb_format.c src/mbio/mb_get_value.c src/bsio/mbbs_tm.c
  src/utilities/mblevitus.cc src/mbvelocitytool/mbvelocity_callbacks.c
  src/mbnavedit/mbnavedit_callbacks.c src/mbnavadjust/mbnavadjust_callbacks.c

General changes: Replace atof() with strtod() for thread safety. Source files
with this change include:
  src/gmt/mbgrdtifforg.c src/bsio/mbbs_tm.c src/mbio/mb_navint.c
  src/mbio/mbr_edgjstar.c src/mbnavadjust/mbnavadjust_fine.c

General changes: Replace atoi() with strtol() for thread safety. Source files
with this change include:
  src/gmt/mbcontour.c src/gmt/mbgrdtifforg.c src/gmt/mbswath.c
  src/gsf/gsf.c src/utilities/mbgrid.cc src/utilities/mbprocess.cc

General changes: Protect against overflows copying comments in all of the
mbsys_XXX_extract() and mbsys_XXX_insert() functions the in the source files
mbsys_XXX.c