### PR TITLE
Added travel time tracking to plotting arrays returned by raytracing …

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -390,6 +390,10 @@ or beta, are equally accessible as tarballs through the Github interface.
 --
 #### 5.7.9beta08 (June 7, 2021)
 
+Mb_rt raytracing functions: Added tracking of travel times in arrays returned by
+mb_rt() for plotting raypaths. This adds a parameter to the mb_rt() function call,
+which is used by utilities/mb_process.cc and mbvelocitytool/mbvelocity_prog.c.
+
 Mbm_grdplot: If \fB\-MGL\fP\fIF\fP is given in conjunction with \fB\-MGL\fP\fIscalebar\fP
 then the map scale will be surrounded by a white filled, black bounded box on
 top of the map.

--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -650,8 +650,9 @@ int mb_beaudoin_unrotate(int verbose, mb_3D_vector orig, mb_3D_orientation rotat
 int mb_rt_init(int verbose, int number_node, double *depth, double *velocity, void **modelptr, int *error);
 int mb_rt_deall(int verbose, void **modelptr, int *error);
 int mb_rt(int verbose, void *modelptr, double source_depth, double source_angle, double end_time, int ssv_mode,
-          double surface_vel, double null_angle, int nplot_max, int *nplot, double *xplot, double *zplot, double *x, double *z,
-          double *travel_time, int *ray_stat, int *error);
+          double surface_vel, double null_angle, int nplot_max,
+          int *nplot, double *xplot, double *zplot, double *tplot,
+          double *x, double *z, double *travel_time, int *ray_stat, int *error);
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/src/mbvelocitytool/mbvelocity_prog.c
+++ b/src/mbvelocitytool/mbvelocity_prog.c
@@ -148,6 +148,7 @@ int nraypathmax;
 int *nraypath = NULL;
 double **raypathx = NULL;
 double **raypathy = NULL;
+double **raypatht = NULL;
 double *depth = NULL;
 double *acrosstrack = NULL;
 double rayxmax;
@@ -2274,10 +2275,12 @@ int mbvt_open_swath_file(char *file, int form, int *numload) {
 	status = mb_mallocd(verbose, __FILE__, __LINE__, beams_bath * sizeof(int), (void **)&nraypath, &error);
 	status = mb_mallocd(verbose, __FILE__, __LINE__, beams_bath * sizeof(double *), (void **)&raypathx, &error);
 	status = mb_mallocd(verbose, __FILE__, __LINE__, beams_bath * sizeof(double *), (void **)&raypathy, &error);
+	status = mb_mallocd(verbose, __FILE__, __LINE__, beams_bath * sizeof(double *), (void **)&raypatht, &error);
 	nraypathmax = 100 * profile_edit.n;
 	for (i = 0; i < beams_bath; i++) {
 		status = mb_mallocd(verbose, __FILE__, __LINE__, nraypathmax * sizeof(double), (void **)&(raypathx[i]), &error);
 		status = mb_mallocd(verbose, __FILE__, __LINE__, nraypathmax * sizeof(double), (void **)&(raypathy[i]), &error);
+		status = mb_mallocd(verbose, __FILE__, __LINE__, nraypathmax * sizeof(double), (void **)&(raypatht[i]), &error);
 	}
 
 	/* if error initializing memory then quit */
@@ -2331,9 +2334,11 @@ int mbvt_deallocate_swath() {
 		for (i = 0; i < beams_bath; i++) {
 			mb_freed(verbose, __FILE__, __LINE__, (void **)&(raypathx[i]), &error);
 			mb_freed(verbose, __FILE__, __LINE__, (void **)&(raypathy[i]), &error);
+			mb_freed(verbose, __FILE__, __LINE__, (void **)&(raypatht[i]), &error);
 		}
 		mb_freed(verbose, __FILE__, __LINE__, (void **)&raypathx, &error);
 		mb_freed(verbose, __FILE__, __LINE__, (void **)&raypathy, &error);
+		mb_freed(verbose, __FILE__, __LINE__, (void **)&raypatht, &error);
 		mb_freed(verbose, __FILE__, __LINE__, (void **)&depth, &error);
 		mb_freed(verbose, __FILE__, __LINE__, (void **)&acrosstrack, &error);
 		mb_freed(verbose, __FILE__, __LINE__, (void **)&angle, &error);
@@ -2345,6 +2350,7 @@ int mbvt_deallocate_swath() {
 		nraypath = NULL;
 		raypathx = NULL;
 		raypathy = NULL;
+		raypatht = NULL;
 		depth = NULL;
 		acrosstrack = NULL;
 		angle = NULL;
@@ -2507,13 +2513,14 @@ int mbvt_process_multibeam() {
 					plotting list */
 					status =
 					    mb_rt(verbose, rt_svp, sonardepth, ping[k].angles[i], 0.5 * ping[k].ttimes[i], anglemode, ping[k].ssv,
-					          ping[k].angles_null[i], 0, NULL, NULL, NULL, &acrosstrack[i], &depth[i], &ttime, &ray_stat, &error);
+					          ping[k].angles_null[i], 0, NULL, NULL, NULL, NULL, &acrosstrack[i], &depth[i], &ttime, &ray_stat, &error);
 				}
 				else {
 					/* call raytracing keeping
 					plotting list */
-					status = mb_rt(verbose, rt_svp, sonardepth, ping[k].angles[i], 0.5 * ping[k].ttimes[i], anglemode,
-					               ping[k].ssv, ping[k].angles_null[i], nraypathmax, &nraypath[i], raypathx[i], raypathy[i],
+					status = mb_rt(verbose, rt_svp, sonardepth, ping[k].angles[i], 0.5 * ping[k].ttimes[i],
+                         anglemode, ping[k].ssv, ping[k].angles_null[i],
+                         nraypathmax, &nraypath[i], raypathx[i], raypathy[i], raypatht[i],
 					               &acrosstrack[i], &depth[i], &ttime, &ray_stat, &error);
 
 					/* reset acrosstrack distances */

--- a/src/utilities/mbprocess.cc
+++ b/src/utilities/mbprocess.cc
@@ -4583,7 +4583,7 @@ void process_file(int verbose, struct mb_process_struct *process,
 
             /* raytrace */
             *status = mb_rt(verbose, rt_svp, (depth_offset_use - static_shift), angles[i], 0.5 * ttimes[i],
-                           process->mbp_angle_mode, ssv, angles_null[i], 0, nullptr, nullptr, nullptr, &xx, &zz, &ttime,
+                           process->mbp_angle_mode, ssv, angles_null[i], 0, nullptr, nullptr, nullptr, nullptr, &xx, &zz, &ttime,
                            &ray_stat, error);
 
             /* apply static shift if any */


### PR DESCRIPTION
…function

Mb_rt raytracing functions: Added tracking of travel times in arrays returned by
mb_rt() for plotting raypaths. This adds a parameter to the mb_rt() function call,
which is used by utilities/mb_process.cc and mbvelocitytool/mbvelocity_prog.c.