### PR TITLE
Add openssh-server and RUN commands to allow ssh connections

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN yum -y groupinstall "Development Tools" && \
             netcdf-devel \
             openmotif \
             openmotif-devel \
+            openssh-server \
             perl \
             python3 \
             cmake3 \
@@ -71,6 +72,10 @@ WORKDIR  /opt/MBSWorkDir
 
 # due to programs failing to load libgmt
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/local/lib64
+
+# Permit executing MB-System commands via ssh from another container
+RUN echo "export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> /root/.bashrc
+RUN /usr/bin/ssh-keygen -A
 
 # No explicit cmd or entry_point. Launcher script will typically run `bash`
 # but also allow to run any other program in the container.


### PR DESCRIPTION
This adds 3 lines to Dockerfile that allows including the image in a [docker-compose.yml](https://github.com/mbari-org/SeafloorMappingDB/blob/main/debug.yml) like this:
```
  mb-system:
    image: mb-system
    container_name: mb-system
    volumes:
      # Edit source path to use directories from *your* host
      # Copy your public key to your ~/.ssh/authorized_keys file
      - /Users/mccann/.ssh:/root/.ssh:z
    command: /usr/sbin/sshd -D
```
Then we can run MB-System commands from our django container, e.g.:
```
(base) ➜  SeafloorMappingDB git:(main) ✗ docker-compose run --rm django /bin/bash
Creating seafloormappingdb_django_run ... done
PostgreSQL is available
root@5a22e05fa9b4:/app# ssh root@mb-system mbinfo -h

Program MBINFO
MB-system Version 5.7.9beta16

MBINFO reads a swath sonar data file and outputs
some basic statistics.  If pings are averaged (pings > 2)
MBINFO estimates the variance for each of the swath
beams by reading a set number of pings (>2) and then finding
the variance of the detrended values for each beam.
The results are dumped to stdout.

usage: mbinfo [-Byr/mo/da/hr/mn/sc -C -Eyr/mo/da/hr/mn/sc -Fformat -G -Ifile -Llonflip -Mnx/ny -N -O -Ppings -Rw/e/s/n -Sspeed -W -V -H -XinfFormat]
```
Applies to https://github.com/dwcaress/MB-System/issues/807