### PR TITLE
Put GMT_CUSTOM_LIBS in /root/gmt.conf for execution of MB-System gmt modules

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,6 +75,9 @@ ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/local/lib64
 
 # Permit executing MB-System commands via ssh from another container
 RUN echo "export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> /root/.bashrc
+# For execution of MB-System gmt modules, e.g.: gmt mbgrd2obj
+RUN echo "GMT_CUSTOM_LIBS = /usr/local/lib/mbsystem.so" >> /root/gmt.conf
+# Generate host keys
 RUN /usr/bin/ssh-keygen -A
 
 # No explicit cmd or entry_point. Launcher script will typically run `bash`


### PR DESCRIPTION
Without this setting in /root/gmt.conf:
```
GMT_CUSTOM_LIBS = /usr/local/lib/mbsystem.so
```
We get this error message:
```
[root@cc1c218cc7cd ~]# gmt mbgrd2obj

ERROR: No module named mbgrd2obj was found.  This could mean one of four cases:
  1. There actually is no such module; please check your spelling.
  2. You used a modern mode module name while running in GMT classic mode.
  3. Module exists in the GMT supplemental library, but the library could not be found.
  4. Module exists in a GMT custom library, but none was specified via GMT_CUSTOM_LIBS.
Shared libraries must be in standard system paths or set via environmental parameter LD_LIBRARY_PATH.
```