### PR TITLE
add missing include in mbprocess.cc

### DIFF
--- a/src/utilities/mbprocess.cc
+++ b/src/utilities/mbprocess.cc
@@ -45,6 +45,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <thread>
 
 #include "mb_aux.h"


### PR DESCRIPTION
This seems to be required to compile on some platforms. Maybe due to compiler version differences? I haven't checked too closely. 

Without this patch, on Fedora 36 with gcc 12.01, I get the following error:

```
mbprocess.cc:5429:37: error: ‘min’ is not a member of ‘std’; did you mean ‘sin’?
 5429 |               mask_bounds[2] = std::min(mask_bounds[2], sslat);
      |                                     ^~~
      |                                     sin
mbprocess.cc:5430:37: error: ‘max’ is not a member of ‘std’; did you mean ‘fmax’?
 5430 |               mask_bounds[3] = std::max(mask_bounds[3], sslat);
      |                                     ^~~
      |                                     fmax
make[3]: *** [Makefile:962: mbprocess.o] Error 1
```