### PR TITLE
Update for 5.7.9beta35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,4 @@ src/mbtrnav/mb1rs
 src/mbtrn/mb1r_test
 build/README.md
 src/mbtrn/mb1-cli
+src/mbtrnutils/mbgrdtilemaker

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,7 +23,7 @@ Distributions that do not include "beta" in the tag name correspond to the major
 announced releases. The source distributions associated with all releases, major
 or beta, are equally accessible as tarballs through the Github interface.
 
-- Version 5.7.9beta35    June 10, 2022
+- Version 5.7.9beta35    June 13, 2022
 - Version 5.7.9beta34    June 5, 2022
 - Version 5.7.9beta33    June 5, 2022
 - Version 5.7.9beta32    June 4, 2022
@@ -413,13 +413,21 @@ or beta, are equally accessible as tarballs through the Github interface.
 ### MB-System Version 5.7 Release Notes:
 --
 
-#### 5.7.9beta35 (June 10, 2022)
+#### 5.7.9beta35 (June 13, 2022)
 
 Mbtrnpp: Added options to set the TRN search area on the command line and in
 cfg files. Fixed wrapper script mbtrnpp.sh so that the number of cycles
 to be used is set correction.
 
 Mbm_trnplot: Fixed plotting macro to work with the current mbtrnpp output.
+
+Mbgrd2octree: Recast program that translates a topography grid in a projected
+coordinate system (like UTM) into a TRN octree model. This program now used
+MB-System-like arguments, e.g. mbgrd2octree --input=grid --output=octree
+
+Mbgrdtilemaker: Added new program to generate a tileset of octrees for TRN from a
+reference grid in a projected coordinate system (like UTM). This tileset can be
+used by mbtrnpp.
 
 #### 5.7.9beta34 (June 5, 2022)
 

--- a/configure
+++ b/configure
@@ -3293,7 +3293,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
-printf "%s\n" "#define VERSION_DATE \"10 June 2022\"" >>confdefs.h
+printf "%s\n" "#define VERSION_DATE \"13 June 2022\"" >>confdefs.h
 
 
 printf "%s\n" " "

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ dnl--------------------------------------------------------------------
 
 dnl Initialize and set version and version date
 AC_INIT([mbsystem],[5.7.9beta35],[http://listserver.mbari.org/sympa/arc/mbsystem],[mbsystem],[http://www.mbari.org/data/mbsystem/])
-AC_DEFINE(VERSION_DATE, ["10 June 2022"], [Set VERSION_DATE define in mb_config.h])
+AC_DEFINE(VERSION_DATE, ["13 June 2022"], [Set VERSION_DATE define in mb_config.h])
 
 AS_ECHO([" "])
 AS_ECHO(["------------------------------------------------------------------------------"])

--- a/src/mbio/mb_config.h
+++ b/src/mbio/mb_config.h
@@ -124,7 +124,7 @@
 #define VERSION "5.7.9beta35"
 
 /* Set VERSION_DATE define in mb_config.h */
-#define VERSION_DATE "10 June 2022"
+#define VERSION_DATE "13 June 2022"
 
 /* 0 */
 /* #undef WITH_DEBUG */

--- a/src/mbtrnutils/Makefile.am
+++ b/src/mbtrnutils/Makefile.am
@@ -39,7 +39,7 @@ AM_CPPFLAGS = -g -O0 $(MBTRN_INC) $(MBTNAV_INC) \
 	${FRAMES7K_VER} ${TRNC_VER} ${STREAM7K_VER} \
 	${TBIN_VER} ${EMU7K_VER} ${MBTNAV_OPT}
 
-bin_PROGRAMS =  mbtrnpp mbgrd2octree
+bin_PROGRAMS =  mbtrnpp mbgrd2octree mbgrdtilemaker
 
 mbtrnpp_SOURCES = mbtrnpp.c
 
@@ -54,6 +54,12 @@ mbgrd2octree_SOURCES = mbgrd2octree.cc
 mbgrd2octree_LDADD =  \
 	${libgmt_LIBS} ${libnetcdf_LIBS} ${libproj_LIBS} \
   $(TRNWLIBS) $(LIBM)
+
+mbgrdtilemaker_SOURCES = mbgrdtilemaker.cc
+mbgrdtilemaker_LDADD =  $(top_builddir)/src/mbio/libmbio.la \
+	$(top_builddir)/src/mbaux/libmbaux.la \
+	$(LIBMBXGR) \
+	${libgmt_LIBS} ${libnetcdf_LIBS} ${libproj_LIBS} $(LIBM)
 
 CLEANFILES =
 DISTCLEANFILES =

--- a/src/mbtrnutils/Makefile.in
+++ b/src/mbtrnutils/Makefile.in
@@ -88,7 +88,8 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
-bin_PROGRAMS = mbtrnpp$(EXEEXT) mbgrd2octree$(EXEEXT)
+bin_PROGRAMS = mbtrnpp$(EXEEXT) mbgrd2octree$(EXEEXT) \
+	mbgrdtilemaker$(EXEEXT)
 subdir = src/mbtrnutils
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_compile_flag.m4 \
@@ -119,6 +120,12 @@ AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
+am_mbgrdtilemaker_OBJECTS = mbgrdtilemaker.$(OBJEXT)
+mbgrdtilemaker_OBJECTS = $(am_mbgrdtilemaker_OBJECTS)
+mbgrdtilemaker_DEPENDENCIES = $(top_builddir)/src/mbio/libmbio.la \
+	$(top_builddir)/src/mbaux/libmbaux.la $(LIBMBXGR) \
+	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1) \
+	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1)
 am_mbtrnpp_OBJECTS = mbtrnpp.$(OBJEXT)
 mbtrnpp_OBJECTS = $(am_mbtrnpp_OBJECTS)
 mbtrnpp_DEPENDENCIES = $(top_builddir)/src/mbio/libmbio.la \
@@ -142,7 +149,7 @@ DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)/src/mbio
 depcomp = $(SHELL) $(top_srcdir)/depcomp
 am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = ./$(DEPDIR)/mbgrd2octree.Po \
-	./$(DEPDIR)/mbtrnpp.Po
+	./$(DEPDIR)/mbgrdtilemaker.Po ./$(DEPDIR)/mbtrnpp.Po
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
@@ -180,7 +187,8 @@ AM_V_CXXLD = $(am__v_CXXLD_@AM_V@)
 am__v_CXXLD_ = $(am__v_CXXLD_@AM_DEFAULT_V@)
 am__v_CXXLD_0 = @echo "  CXXLD   " $@;
 am__v_CXXLD_1 = 
-SOURCES = $(mbgrd2octree_SOURCES) $(mbtrnpp_SOURCES)
+SOURCES = $(mbgrd2octree_SOURCES) $(mbgrdtilemaker_SOURCES) \
+	$(mbtrnpp_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -457,6 +465,12 @@ mbgrd2octree_LDADD = \
 	${libgmt_LIBS} ${libnetcdf_LIBS} ${libproj_LIBS} \
   $(TRNWLIBS) $(LIBM)
 
+mbgrdtilemaker_SOURCES = mbgrdtilemaker.cc
+mbgrdtilemaker_LDADD = $(top_builddir)/src/mbio/libmbio.la \
+	$(top_builddir)/src/mbaux/libmbaux.la \
+	$(LIBMBXGR) \
+	${libgmt_LIBS} ${libnetcdf_LIBS} ${libproj_LIBS} $(LIBM)
+
 CLEANFILES = 
 DISTCLEANFILES = 
 all: all-am
@@ -546,6 +560,10 @@ mbgrd2octree$(EXEEXT): $(mbgrd2octree_OBJECTS) $(mbgrd2octree_DEPENDENCIES) $(EX
 	@rm -f mbgrd2octree$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(mbgrd2octree_OBJECTS) $(mbgrd2octree_LDADD) $(LIBS)
 
+mbgrdtilemaker$(EXEEXT): $(mbgrdtilemaker_OBJECTS) $(mbgrdtilemaker_DEPENDENCIES) $(EXTRA_mbgrdtilemaker_DEPENDENCIES) 
+	@rm -f mbgrdtilemaker$(EXEEXT)
+	$(AM_V_CXXLD)$(CXXLINK) $(mbgrdtilemaker_OBJECTS) $(mbgrdtilemaker_LDADD) $(LIBS)
+
 mbtrnpp$(EXEEXT): $(mbtrnpp_OBJECTS) $(mbtrnpp_DEPENDENCIES) $(EXTRA_mbtrnpp_DEPENDENCIES) 
 	@rm -f mbtrnpp$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(mbtrnpp_OBJECTS) $(mbtrnpp_LDADD) $(LIBS)
@@ -557,6 +575,7 @@ distclean-compile:
 	-rm -f *.tab.c
 
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mbgrd2octree.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mbgrdtilemaker.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mbtrnpp.Po@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
@@ -715,6 +734,7 @@ clean-am: clean-binPROGRAMS clean-generic clean-libtool mostlyclean-am
 
 distclean: distclean-am
 		-rm -f ./$(DEPDIR)/mbgrd2octree.Po
+	-rm -f ./$(DEPDIR)/mbgrdtilemaker.Po
 	-rm -f ./$(DEPDIR)/mbtrnpp.Po
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
@@ -762,6 +782,7 @@ installcheck-am:
 
 maintainer-clean: maintainer-clean-am
 		-rm -f ./$(DEPDIR)/mbgrd2octree.Po
+	-rm -f ./$(DEPDIR)/mbgrdtilemaker.Po
 	-rm -f ./$(DEPDIR)/mbtrnpp.Po
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic

--- a/src/mbtrnutils/mbgrd2octree.cc
+++ b/src/mbtrnutils/mbgrd2octree.cc
@@ -1,22 +1,53 @@
+/*--------------------------------------------------------------------
+ *    The MB-system:  mbgrd2octree.cc  5/2/94
+ *
+ *    Copyright (c) 2020-2022 by
+ *    David W. Caress (caress@mbari.org)
+ *      Monterey Bay Aquarium Research Institute
+ *      Moss Landing, CA 95039
+ *    and Dale N. Chayes (dale@ldeo.columbia.edu)
+ *      Lamont-Doherty Earth Observatory
+ *      Palisades, NY 10964
+ *
+ *    See README file for copying and redistribution conditions.
+ *--------------------------------------------------------------------*/
+/**
+  @file
+ * MBgrd2octree translates a topography grid to a TRN octree topography model
+ * for use with the MB-System TRN (terrain relative navigation) tools.
+ * The input grid is expected to be in a carteisan projected coordinate system
+ * such as UTM.
+ * This program derives from grdOctreeMaker, a TRN program contained within the
+ * terrain-nav codebase created by Steve Rock's Precision Navigation project
+ * team over many years. The original author(s) are unclear, but probably
+ * include multiple Steve Rock students at Stanford such as Debbie Meduna,
+ * Peter Kimball, etc.
+ *
+ * Author:  D. W. Caress
+ * Date:  August 13, 2020
+ */
+/*--------------------------------------------------------------------*/
+
+
 /*! grdOctreeMaker
-  This octree generator takes a utm grd file and generates an octree from it.  
+  This octree generator takes a utm grd file and generates an octree from it.
 
-  The input file is set with INFILE and the name to write to is OUTFILE.  
+  The input file is set with INFILE and the name to write to is OUTFILE.
 
-  For details on how octree works including the internals of how the octree generates from the inpot 
+  For details on how octree works including the internals of how the octree generates from the inpot
   points, go look at Octree.hpp.
 */
 
 /*! Coordinate Systems
-  Octrees used for TRN have historically been stored in the NED coordinate system.  This code can 
-  take a The define X_INDEX_FIRST sets the indexing order into the one dimensional array of z values.  
-  I have only ever worked with X_INDEX_FIRST = 1, but it should work to negate z and flip the x-y index 
-  ordering when set to 0. If things aren't working, look at the points or the north, east, and down 
+  Octrees used for TRN have historically been stored in the NED coordinate system.  This code can
+  take a The define X_INDEX_FIRST sets the indexing order into the one dimensional array of z values.
+  I have only ever worked with X_INDEX_FIRST = 1, but it should work to negate z and flip the x-y index
+  ordering when set to 0. If things aren't working, look at the points or the north, east, and down
   bounds on the points and make sure they are correct for a NED coordinate system point in Monterey
   Bay (X: 4E6, Y: 5E5, Z: >0).
 
   The Raytrace function of the octree requires a Euclidean coordinate system to give meaningful
-  results. Otherwise, the octree will work fine in any coordinate system (like LLA), and querying 
+  results. Otherwise, the octree will work fine in any coordinate system (like LLA), and querying
   the value at a location (with an LLA query point) will work fine.
 */
 
@@ -30,46 +61,17 @@
 
 /*! Reducing the area of the resulting octree:
   You can cut down the area of the octree with limits on the North and East coordinates. This is
-  set with NORTH_BOUND, EAST_BOUND, SOUTH_BOUND, and WEST_BOUND respectively. Set any of them to 
-  -1 to disable that bound and go to the edge of the input grd on that dimension. Similarly, 
-  MAX_ACCEPTED_DEPTH and MIN_ACCEPTED_DEPTH set the range of depths which are accepted. If you 
+  set with NORTH_BOUND, EAST_BOUND, SOUTH_BOUND, and WEST_BOUND respectively. Set any of them to
+  -1 to disable that bound and go to the edge of the input grd on that dimension. Similarly,
+  MAX_ACCEPTED_DEPTH and MIN_ACCEPTED_DEPTH set the range of depths which are accepted. If you
   wanted to be fancy, you could make these inputs rather than #defines.
 
-  To use the spacing between the zeroth and first elements in X and Y as the x-y resolution of 
+  To use the spacing between the zeroth and first elements in X and Y as the x-y resolution of
   the octree, set RESOLUTION to -1. Otherwise, set RESOLUTION to the desired resolution of the map.
 
-  FILL_NUMBER sets how many voxels to fill below each input point. This insures that steep hills 
+  FILL_NUMBER sets how many voxels to fill below each input point. This insures that steep hills
   will not have holes when looking sideways at them.
 */
-
-
-#include <netcdf.h>
-#include "mapio.h"
-#include "OctreeSupport.hpp"
-#include "Octree.hpp"
-#include <iostream>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-
-#define X_INDEX_FIRST 1
-//#define RESOLUTION -1
-#define RESOLUTION 1
-#define FILL_NUMBER 2
-
-#define NORTH_BOUND -1//5094336
-#define SOUTH_BOUND -1//5084336
-#define EAST_BOUND  -1//591526
-#define WEST_BOUND  -1//587430
-#define MIN_ACCEPTED_DEPTH  1//1000
-#define MAX_ACCEPTED_DEPTH  3500
-
-#define OUTFILE "temp.bo"
-//#define INFILE  "/home/david/ARL/SharedWithVM/mapsfromRock/Topo_UpperCanyonTesting_2m_Wall_UTM_STEVE2.grd"
-//#define INFILE  "/home/david/ARL/SharedWithVM/mapsfromRock/Topo_UpperCanyonTesting_2m_UTM.grd"
-//#define INFILE "/home/david/ARL/mbariMaps/PortugueseLedge/PortugueseLedge20080424TopoUTM_NoNan.grd"
-//#define INFILE "/media/sf_SharedWithVM/planer-fit/Map/AxialEM_post2015_AUV2015Bounds_TopoUTM5m.grd"
-#define INFILE "/media/sf_SharedWithVM/planer-fit/Map/IcebergTestWall/IcebergTestWall_Topo1mUTM.grd"
 
 //! zGrid could be moved to OctreeSupport (that's where I have it, but to simplify sending this, I copied it here)
 /*//header entry:
@@ -79,7 +81,7 @@
   zGrid(float* const z, unsigned int numX, unsigned int numY, bool xFirst): zValues(z), numXValues(numX), numYValues(numY), xIndexFirst(xFirst){}
   double getZ(unsigned int xIndex, unsigned int yIndex) const;
   void Print();
-	
+
   float* zValues;
   unsigned int numXValues, numYValues;
   bool xIndexFirst;
@@ -101,299 +103,338 @@ std::cout << "X: " << numXValues << "\tY: " << numYValues << "\tXfirst: " << xIn
 
 */
 
+/*--------------------------------------------------------------------*/
+#include <iostream>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <getopt.h>
+#include "mapio.h"
+#include <netcdf.h>
+#include "OctreeSupport.hpp"
+#include "Octree.hpp"
+
+#include "mb_define.h"
+#include "mb_status.h"
+
+/* output stream for basic stuff (stdout if verbose <= 1,
+    stderr if verbose > 1) */
+FILE *outfp = stdout;
+
+/* program identifiers */
+constexpr char program_name[] = "mbgrd2octree";
+constexpr char help_message[] =
+    "MBgrd2octree translates a topography grid to a TRN octree topography model"
+    "for use with the MB-System TRN (terrain relative navigation) tools."
+    "The input grid is expected to be in a carteisan projected coordinate system"
+    "such as UTM.";
+constexpr char usage_message[] =
+    "mbgrd2octree\n"
+    "\t--verbose\n"
+    "\t--help\n\n"
+    "\t--input=input_grid\n"
+    "\t--output=output_root\n\n"
+    "\t--tile-dimension=tile_dimension\n"
+    "\t--tile-mode=mode\n\n"
+    "\t--tile-spacing=tile_spacing\n\n";
+
+#define X_INDEX_FIRST 1
+
+#define RESOLUTION 1
+#define FILL_NUMBER 2
+
+#define NORTH_BOUND -1
+#define SOUTH_BOUND -1
+#define EAST_BOUND  -1
+#define WEST_BOUND  -1/
+#define MIN_ACCEPTED_DEPTH  1
+#define MAX_ACCEPTED_DEPTH  3500
+
 int setupXYZ(double** xValues, double** yValues, zGrid& zValues, char *inFile );
 
-int main( int argc, char **argv ) 
+int main( int argc, char **argv )
 {
-   zGrid zValues;
-   double *xValues = NULL, *yValues = NULL;
+  int verbose = 0;
+  int status = MB_SUCCESS;
+  mb_path inFile;
+  mb_path outFile;
+  double bounds[4];
+  bool bounds_set = false;
 
-   long north_bound = -1;
-   long south_bound = -1;
-   long  east_bound = -1;
-   long  west_bound = -1;
+  static struct option options[] = {{"verbose", no_argument, nullptr, 0},
+                                    {"help", no_argument, nullptr, 0},
+                                    {"bounds", required_argument, nullptr, 0},
+                                    {"input", required_argument, nullptr, 0},
+                                    {"output", required_argument, nullptr, 0}};
 
-   // Read input data
-
-   if( argc < 2 )
-   {
-      printf("Please supply a file name, without the suffix.\n");
-      return 1;
-   }
-	
-   char inFile[128], outFile[128];
-   sprintf(inFile, "%s.grd",argv[1]);
-   sprintf(outFile,"%s.bo",argv[1]);
-   
-   //struct stat buf;
-   //if( stat(inFile, &buf) == 0 )
-   if( open( inFile, O_EXCL) == 0 )
-   {
-      printf("File %s not found.\n", inFile);
-      return 1;
-   }
-
-   if( argc > 2 )
-   {
-      for (int i = 1; i < argc; i++)
+  int option_index;
+  bool errflg = false;
+  int c;
+  bool help = false;
+  while ((c = getopt_long(argc, argv, "HhI:i:O:o:R:r:Vv", options, &option_index)) != -1) {
+    switch (c) {
+    /*-------------------------------------------------------*/
+    /* long options all return c=0 */
+    case 0:
+      if (strcmp("verbose", options[option_index].name) == 0) {
+        verbose++;
+        if (verbose >= 2)
+          outfp = stderr;
+      }
+      else if (strcmp("help", options[option_index].name) == 0) {
+        help = true;
+      }
+      else if (strcmp("input", options[option_index].name) == 0) {
+        const int n = sscanf(optarg, "%1023s", inFile);
+        if (n != 1 || strlen(inFile) <= 0) {
+          fprintf(stderr, "Failed to parse argument: %s=%s\nProgram %s terminated\n",
+                  options[option_index].name, optarg, program_name);
+          exit(MB_ERROR_BAD_PARAMETER);
+        }
+        if (strlen(inFile) < 5 || strncmp(".grd", &inFile[strlen(inFile)-4], 4) != 0) {
+          if (strlen(inFile) < MB_PATH_MAXLINE - 5)
+            strcat(inFile, ".grd");
+        }
+      }
+      else if (strcmp("output", options[option_index].name) == 0) {
+        const int n = sscanf(optarg, "%1023s", outFile);
+        if (n != 1 || strlen(outFile) <= 0) {
+          fprintf(stderr, "Failed to parse argument: %s=%s\nProgram %s terminated\n",
+                  options[option_index].name, optarg, program_name);
+          exit(MB_ERROR_BAD_PARAMETER);
+        }
+        if (strlen(outFile) < 5 || strncmp(".bo", &outFile[strlen(outFile)-3], 3) != 0) {
+          if (strlen(outFile) < MB_PATH_MAXLINE - 4)
+            strcat(outFile, ".bo");
+        }
+      }
+      else if (strcmp("bounds", options[option_index].name) == 0) {
+        const int n = sscanf(optarg, "%lf/%lf/%lf/%lf",
+                              &bounds[0], &bounds[1], &bounds[2], &bounds[3]);
+        if (n != 4 || (bounds[0] >= bounds[1]) || (bounds[2] >= bounds[3])) {
+          fprintf(stderr, "Failed to parse argument: %s=%s\nProgram %s terminated\n",
+                  options[option_index].name, optarg, program_name);
+          exit(MB_ERROR_BAD_PARAMETER);
+        } else {
+          bounds_set = true;
+        }
+      }
+      break;
+    /*-------------------------------------------------------*/
+    /* short options */
+    case 'H':
+    case 'h':
+      help = true;
+      break;
+    case 'I':
+    case 'i':
+      sscanf(optarg, "%1023s", inFile);
+      break;
+    case 'O':
+    case 'o':
+      sscanf(optarg, "%1023s", outFile);
+      break;
+    case 'R':
+    case 'r':
       {
-	 if( !strcmp(argv[i], "-R") )
-	 {
-	    if( i < (argc - 4) )
-	    {
-	       east_bound  = atol(argv[i+1]);
-	       west_bound  = atol(argv[i+2]);
-	       south_bound = atol(argv[i+3]);
-	       north_bound = atol(argv[i+4]);
-	    }
-	    else
-	    {
-	       printf("Error:  You must supply four arguments after -R, with a space after -R.\n");
-	       return 1;
-	    }
-	 }
-	 else if( !strcmp(argv[i], "-G") )
-	 {
-	    if( i < (argc - 1) )
-	    {
-	       sprintf(outFile,"%s.bo",argv[i+1]);
-	    }
-	    else
-	    {
-	       printf("Error:  You must supply a file name after -G.\n");
-	       return 1;
-	    }
-	 }
+      int n = sscanf(optarg, "%lf/%lf/%lf/%lf",
+                            &bounds[0], &bounds[1], &bounds[2], &bounds[3]);
+      if (n != 4 || (bounds[0] >= bounds[1]) || (bounds[2] >= bounds[3])) {
+        fprintf(stderr, "Failed to parse argument: %s=%s\nProgram %s terminated\n",
+                options[option_index].name, optarg, program_name);
+        exit(MB_ERROR_BAD_PARAMETER);
       }
-   }
+      }
+      break;
+    case 'V':
+    case 'v':
+      verbose++;
+      if (verbose >= 2)
+        outfp = stderr;
+      break;
+    case '?':
+      errflg = true;
+    }
+  }
 
-   //Yes I mean '=' not '==' DO NOT CHANGE IT.	
-   if(int temp = setupXYZ(&xValues, &yValues, zValues, inFile)){return temp;}
-	
-   std::cout << "X[0]: " << xValues[0] << std::endl;
-   std::cout << "Y[0]: " << yValues[0] << std::endl;
-   std::cout << "Z dimensions and order:\n";
-   zValues.Print();
-	
-   //Auto detect X and Y resolution or use input
-	
-   Vector DesiredResolution(RESOLUTION,RESOLUTION,RESOLUTION);
-	
-   if(RESOLUTION == -1){
-      DesiredResolution.x = xValues[1] - xValues[0];
-      DesiredResolution.y = yValues[1] - yValues[0];
-      DesiredResolution.z = 1;
-   }
-	
-   std::cout << "Detecting point cloud size:\n";
-	
-   Vector Lowermost;
-   Vector Uppermost;
-   bool uninitialized = true;
-	
-   //autodetect size
-   Vector point;
-   for(unsigned int xIndex = 0; xIndex < zValues.numXValues; xIndex++){
-      for(unsigned int yIndex = 0; yIndex < zValues.numYValues; yIndex++){
-	 if(zValues.getZ(xIndex, yIndex) != 99999 && !isnan(zValues.getZ(xIndex, yIndex))){ 
-	    //test bounds
-	    if((north_bound != -1) && (xValues[xIndex] > north_bound)){continue;}
-	    if((south_bound != -1) && (xValues[xIndex] < south_bound)){continue;}
-	    if((east_bound != -1) && (yValues[yIndex] > east_bound)){continue;}
-	    if((west_bound != -1) && (yValues[yIndex] < west_bound)){continue;}
-	    if((MAX_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) > MAX_ACCEPTED_DEPTH)){continue;}
-	    if((MIN_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) < MIN_ACCEPTED_DEPTH)){continue;}
-				
-				
-	    if(uninitialized){
-	       Lowermost = Vector(xValues[xIndex], yValues[yIndex], zValues.getZ(xIndex, yIndex));
-	       Uppermost = Vector(xValues[xIndex], yValues[yIndex], zValues.getZ(xIndex, yIndex));
-	       uninitialized = false;
-	       Lowermost.Print();
-	    }
-				
-	    point = Vector( xValues[xIndex], yValues[yIndex], zValues.getZ(xIndex, yIndex));
-	    if(Lowermost.x > point.x){ Lowermost.x = point.x;}
-	    if(Lowermost.y > point.y){ Lowermost.y = point.y;}
-	    if(Lowermost.z > point.z){ Lowermost.z = point.z;}
-	    if(Uppermost.x < point.x){ Uppermost.x = point.x;}
-	    if(Uppermost.y < point.y){ Uppermost.y = point.y;}
-	    if(Uppermost.z < point.z){ Uppermost.z = point.z;}
-				
-				
-	 }
+  if (errflg) {
+    fprintf(outfp, "usage: %s\n", usage_message);
+    fprintf(outfp, "\nProgram <%s> Terminated\n", program_name);
+    exit(MB_ERROR_BAD_USAGE);
+  }
+
+  if (verbose == 1 || help) {
+    fprintf(outfp, "\nProgram %s\n", program_name);
+    fprintf(outfp, "MB-system Version %s\n", MB_VERSION);
+  }
+
+  if (verbose >= 2) {
+    fprintf(outfp, "\ndbg2  Program <%s>\n", program_name);
+    fprintf(outfp, "dbg2  MB-system Version %s\n", MB_VERSION);
+    fprintf(outfp, "dbg2  Control Parameters:\n");
+    fprintf(outfp, "dbg2       verbose:              %d\n", verbose);
+    fprintf(outfp, "dbg2       help:                 %d\n", help);
+    fprintf(outfp, "dbg2       inFile:               %s\n", inFile);
+    fprintf(outfp, "dbg2       outFile:              %s\n", outFile);
+    fprintf(outfp, "dbg2       bounds_set:           %d\n", bounds_set);
+    if (bounds_set) {
+      fprintf(outfp, "dbg2       bounds[0]:            %f\n", bounds[0]);
+      fprintf(outfp, "dbg2       bounds[1]:            %f\n", bounds[1]);
+      fprintf(outfp, "dbg2       bounds[2]:            %f\n", bounds[2]);
+      fprintf(outfp, "dbg2       bounds[3]:            %f\n", bounds[3]);
+    }
+  }
+
+  if (help) {
+    fprintf(outfp, "\n%s\n", help_message);
+    fprintf(outfp, "\nusage: %s\n", usage_message);
+    exit(MB_ERROR_NO_ERROR);
+  }
+
+  long north_bound = -1;
+  long south_bound = -1;
+  long  east_bound = -1;
+  long  west_bound = -1;
+  if(bounds_set) {
+    east_bound  = bounds[0];
+    west_bound  = bounds[1];
+    south_bound = bounds[2];
+    north_bound = bounds[3];
+  }
+
+  // Read input data
+  if( open( inFile, O_EXCL) == 0 ) {
+    printf("\nInput grid %s not opened.\n", inFile);
+    fprintf(outfp, "Program <%s> Terminated\n", program_name);
+    exit(MB_ERROR_BAD_USAGE);
+  }
+
+  //Yes I mean '=' not '==' DO NOT CHANGE IT.
+  zGrid zValues;
+  double *xValues = NULL, *yValues = NULL;
+  if(int temp = setupXYZ(&xValues, &yValues, zValues, inFile)){return temp;}
+
+  //Auto detect X and Y resolution or use input
+  Vector DesiredResolution(RESOLUTION,RESOLUTION,RESOLUTION);
+  if(RESOLUTION == -1){
+    DesiredResolution.x = xValues[1] - xValues[0];
+    DesiredResolution.y = yValues[1] - yValues[0];
+    DesiredResolution.z = 1;
+  }
+
+  Vector Lowermost;
+  Vector Uppermost;
+  bool uninitialized = true;
+
+  //autodetect size
+  Vector point;
+  for(unsigned int xIndex = 0; xIndex < zValues.numXValues; xIndex++){
+    for(unsigned int yIndex = 0; yIndex < zValues.numYValues; yIndex++){
+      if(zValues.getZ(xIndex, yIndex) != 99999 && !isnan(zValues.getZ(xIndex, yIndex))){
+        //test bounds
+        if((north_bound != -1) && (xValues[xIndex] > north_bound)){continue;}
+        if((south_bound != -1) && (xValues[xIndex] < south_bound)){continue;}
+        if((east_bound != -1) && (yValues[yIndex] > east_bound)){continue;}
+        if((west_bound != -1) && (yValues[yIndex] < west_bound)){continue;}
+        if((MAX_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) > MAX_ACCEPTED_DEPTH)){continue;}
+        if((MIN_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) < MIN_ACCEPTED_DEPTH)){continue;}
+
+
+        if(uninitialized){
+           Lowermost = Vector(xValues[xIndex], yValues[yIndex], zValues.getZ(xIndex, yIndex));
+           Uppermost = Vector(xValues[xIndex], yValues[yIndex], zValues.getZ(xIndex, yIndex));
+           uninitialized = false;
+           Lowermost.Print();
+        }
+
+        point = Vector( xValues[xIndex], yValues[yIndex], zValues.getZ(xIndex, yIndex));
+        if(Lowermost.x > point.x){ Lowermost.x = point.x;}
+        if(Lowermost.y > point.y){ Lowermost.y = point.y;}
+        if(Lowermost.z > point.z){ Lowermost.z = point.z;}
+        if(Uppermost.x < point.x){ Uppermost.x = point.x;}
+        if(Uppermost.y < point.y){ Uppermost.y = point.y;}
+        if(Uppermost.z < point.z){ Uppermost.z = point.z;}
+
+
       }
-   }
-   std::cout << uninitialized << "\n\n";
-   std::cout << "Lowermost: ";
-   Lowermost.Print();
-   std::cout << "Uppermost: ";
-   Uppermost.Print();
-	
-   Vector PointCloudSize = Uppermost - Lowermost + Vector(1.0, 1.0, 1.0);
-   Vector OctreeSize = DesiredResolution;
-   printf("PointCloudSize\t");
-   PointCloudSize.Print();
-   while(!OctreeSize.StrictlyGreaterOrEqualTo(PointCloudSize)){
-      OctreeSize *= 2.0;
-      printf("OctreeSize\t");
-      OctreeSize.Print();
-   }
-   Vector LowerBounds = Lowermost - DesiredResolution *0.5;
-   Vector UpperBounds = LowerBounds + OctreeSize;
-	
-   //initialize octree
-   printf("about to build Octree\n");
-   Octree<bool> newOctreeMap(DesiredResolution + Vector(0.001,0.001,0.001), LowerBounds, UpperBounds,
-			     OctreeType::BinaryOccupancy);
-	
-   newOctreeMap.Print();
-   Vector tempPoint;
-   // Add points
-   std::cout << "adding points\nrow\t# added\tLast Point Tested\n";
-   int countPointsAdded = 0;
-   for(unsigned int xIndex = 0; xIndex < zValues.numXValues; xIndex++){
-      for(unsigned int yIndex = 0; yIndex < zValues.numYValues; yIndex++){
-	 if(zValues.getZ(xIndex, yIndex) != 99999 && !isnan(zValues.getZ(xIndex, yIndex))){
-	    if(zValues.getZ(xIndex, yIndex) <= 4000){
-	       point = Vector( xValues[xIndex], yValues[yIndex], zValues.getZ(xIndex, yIndex));
-					
-	       //test bounds
-	       if((north_bound != -1) && (xValues[xIndex] > north_bound)){continue;}
-	       if((south_bound != -1) && (xValues[xIndex] < south_bound)){continue;}
-	       if((east_bound != -1) && (yValues[yIndex] > east_bound)){continue;}
-	       if((west_bound != -1) && (yValues[yIndex] < west_bound)){continue;}
-	       if((MAX_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) > MAX_ACCEPTED_DEPTH)){continue;}
-	       if((MIN_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) < MIN_ACCEPTED_DEPTH)){continue;}
-					
-	       countPointsAdded ++;
-	       newOctreeMap.AddPoint(point);
-					
-	       /*
-	       //if((4072252 > point.x) & (4072250 < point.x ) & (588730 < point.y) & (588732 > point.y)){
-	       //if((xIndex > 799.9) & (xIndex < 800.1) & (yIndex > 799.9) & (yIndex < 800.1)){
-	       if((xIndex == 800) & (yIndex == 800)){
-	       //if(countPointsAdded == 21744847){
-	       std::cout << "TEST POINT: \n";
-	       std::cout << "xindex: " << xIndex << "\tyIndex: " << yIndex << "\n";
-	       std::cout << "xInt: " << (int)point.x << "\n";
-	       point.Print();
-	       tempPoint = point;
-	       }
-	       */
-					
-	    }
-	 }
+    }
+  }
+
+  Vector PointCloudSize = Uppermost - Lowermost + Vector(1.0, 1.0, 1.0);
+  Vector OctreeSize = DesiredResolution;
+  while(!OctreeSize.StrictlyGreaterOrEqualTo(PointCloudSize)){
+    OctreeSize *= 2.0;
+  }
+  Vector LowerBounds = Lowermost - DesiredResolution * 0.5;
+  Vector UpperBounds = LowerBounds + OctreeSize;
+
+  //initialize octree
+  //printf("about to build Octree\n");
+  Octree<bool> newOctreeMap(DesiredResolution + Vector(0.001,0.001,0.001),
+                            LowerBounds, UpperBounds, OctreeType::BinaryOccupancy);
+
+  // Add points
+  int countPointsAdded = 0;
+  for(unsigned int xIndex = 0; xIndex < zValues.numXValues; xIndex++){
+    for(unsigned int yIndex = 0; yIndex < zValues.numYValues; yIndex++){
+      if(zValues.getZ(xIndex, yIndex) != 99999 && !isnan(zValues.getZ(xIndex, yIndex))){
+        if(zValues.getZ(xIndex, yIndex) <= 4000){
+          point = Vector( xValues[xIndex], yValues[yIndex], zValues.getZ(xIndex, yIndex));
+
+          //test bounds
+          if((north_bound != -1) && (xValues[xIndex] > north_bound)){continue;}
+          if((south_bound != -1) && (xValues[xIndex] < south_bound)){continue;}
+          if((east_bound != -1) && (yValues[yIndex] > east_bound)){continue;}
+          if((west_bound != -1) && (yValues[yIndex] < west_bound)){continue;}
+          if((MAX_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) > MAX_ACCEPTED_DEPTH)){continue;}
+          if((MIN_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) < MIN_ACCEPTED_DEPTH)){continue;}
+
+          countPointsAdded ++;
+          newOctreeMap.AddPoint(point);
+        }
       }
-      //report progress
-      if(xIndex %100 == 0){std::cout << xIndex << "\t" << countPointsAdded << "\t";point.Print();}
-   }
-   Vector TrueResolution = newOctreeMap.GetTrueResolution();
-	
-   //fill below input points
-   std::cout << "about to fill Octree\n";
-   int count = 0;//for progress reporting
-	
-   for(unsigned int xIndex = 0; xIndex < zValues.numXValues; xIndex++){
-      for(unsigned int yIndex = 0; yIndex < zValues.numYValues; yIndex++){
-	 if((zValues.getZ(xIndex, yIndex) != 99999) && (!isnan(zValues.getZ(xIndex, yIndex))) && (zValues.getZ(xIndex, yIndex) < 3000)) {
-	    //test bounds
-	    if((north_bound != -1) && (xValues[xIndex] > north_bound)){continue;}
-	    if((south_bound != -1) && (xValues[xIndex] < south_bound)){continue;}
-	    if((east_bound != -1) && (yValues[yIndex] > east_bound)){continue;}
-	    if((west_bound != -1) && (yValues[yIndex] < west_bound)){continue;}
-	    if((MAX_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) > MAX_ACCEPTED_DEPTH)){continue;}
-	    if((MIN_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) < MIN_ACCEPTED_DEPTH)){continue;}
-				
-	    point = Vector( xValues[xIndex], yValues[yIndex], zValues.getZ(xIndex, yIndex));
-		
-	    //report progress
-	    if(count %100000 == 0){
-	       std::cout << count << std::endl;
-	    }
-	    count ++;
-				
-	    //fill
-	    double zToFill = point.z + TrueResolution.z;
-	    for(int jj = 0; jj < FILL_NUMBER; jj++){
-	       newOctreeMap.FillSmallestResolutionLeafAtPointIfEmpty(Vector(point.x, point.y, zToFill),true);
-					
-	       zToFill += TrueResolution.z;
-	    }
-	 }
+    }
+  }
+  Vector TrueResolution = newOctreeMap.GetTrueResolution();
+
+  //fill below input points
+  for(unsigned int xIndex = 0; xIndex < zValues.numXValues; xIndex++){
+    for(unsigned int yIndex = 0; yIndex < zValues.numYValues; yIndex++){
+      if((zValues.getZ(xIndex, yIndex) != 99999) && (!isnan(zValues.getZ(xIndex, yIndex))) && (zValues.getZ(xIndex, yIndex) < 3000)) {
+        //test bounds
+        if((north_bound != -1) && (xValues[xIndex] > north_bound)){continue;}
+        if((south_bound != -1) && (xValues[xIndex] < south_bound)){continue;}
+        if((east_bound != -1) && (yValues[yIndex] > east_bound)){continue;}
+        if((west_bound != -1) && (yValues[yIndex] < west_bound)){continue;}
+        if((MAX_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) > MAX_ACCEPTED_DEPTH)){continue;}
+        if((MIN_ACCEPTED_DEPTH != -1) && (zValues.getZ(xIndex, yIndex) < MIN_ACCEPTED_DEPTH)){continue;}
+
+        point = Vector( xValues[xIndex], yValues[yIndex], zValues.getZ(xIndex, yIndex));
+
+        //fill
+        double zToFill = point.z + TrueResolution.z;
+        for(int jj = 0; jj < FILL_NUMBER; jj++){
+           newOctreeMap.FillSmallestResolutionLeafAtPointIfEmpty(Vector(point.x, point.y, zToFill),true);
+
+           zToFill += TrueResolution.z;
+        }
       }
-   }
-	
-   //compress
-   printf("about to collapse\n");
-   newOctreeMap.Collapse();
-	
-   //put any test ray traces you want here. 
-   std::cout << "\nTest Ray Traces\n";
-   std::cout << newOctreeMap.RayTrace(Vector(south_bound + 2, east_bound - 2,0), Vector(0,0,1)) << "\t";
-   std::cout << newOctreeMap.RayTrace(Vector(south_bound + 2, east_bound + 2,0), Vector(0,0,1)) << "\n";
-   std::cout << newOctreeMap.RayTrace(Vector(south_bound - 2, east_bound - 2,0), Vector(0,0,1)) << "\t";
-   std::cout << newOctreeMap.RayTrace(Vector(south_bound - 2, east_bound + 2,0), Vector(0,0,1)) << "\n";
-	
-	
-	
-   std::cout << "\nDone building octree\n";
-   //newOctreeMap.SaveToFile(OUTFILE);
-   newOctreeMap.SaveToFile(outFile);
-   std::cout << "Done\n\n";
-	
-   /*
-   //save corner to corner trace from octree to compare to DEM
-   FILE* f = fopen("tempTestTraceOfLatestOctree.txt", "w");
-   fprintf(f, "LowerX = %f\nLowerY = %f\nUpperX = %f\nUpperY = %f\n\nZ = [", Lowermost.x, Lowermost.y, Uppermost.x, Uppermost.y);
-   for(double i = 0.0; i< 1000.0; i++){
-   fprintf(f, "%f, ", newOctreeMap.RayTrace(Vector((Lowermost.x * i/1000.0) + (Uppermost.x * (1000.0 - i) / 1000.0),
-   (Lowermost.y * i/1000.0) + (Uppermost.y * (1000.0 - i) / 1000.0),
-   0.0),
-   Vector(0,0,1)));
-   }
-   fprintf(f, "];\n");
-   fclose(f);
-	
-   */
-	
-	
-	
-   double num = 1000.0;
-   FILE* f = fopen("tempTestTraceOfLatestOctree.txt", "w");
-   //fprintf(f, "LowerX = %f\nLowerY = %f\nUpperX = %f\nUpperY = %f\n\nZ = [", Lowermost.x, Lowermost.y, Uppermost.x, Uppermost.y);
-	
-   //Look Down
-   //Vector dir(0,0,1);
-   //double depth = 0.0;
-	
-	
-	
-   //for looking sideways
-   Lowermost = Vector(4070168, 589629, 860);
-   Uppermost = Vector(4070306, 588843, 860);
-   Vector dir(-1,0,0);
-   double depth = 890;
-	
-   for(double i = 0.0; i< num; i++){
-      fprintf(f, "%f, ", newOctreeMap.RayTrace(Vector((Lowermost.x * i/num) + (Uppermost.x * (num - i) / num),
-						      (Lowermost.y * i/num) + (Uppermost.y * (num - i) / num),
-						      depth),
-					       dir));
-   }
-   fprintf(f, "];\n");
-   fclose(f);
-	
-	
-   newOctreeMap.Print();
-	
-   delete[] xValues;
-   delete[] yValues;
-   delete[] zValues.zValues;
-	
-	
-	
-   return 0;
+    }
+  }
+
+  //compress
+  newOctreeMap.Collapse();
+
+  newOctreeMap.SaveToFile(outFile);
+
+  fprintf(outfp, "\nCompleted octree %s:\n", outFile);
+  newOctreeMap.Print();
+
+  delete[] xValues;
+  delete[] yValues;
+  delete[] zValues.zValues;
+
+  return 0;
 }
 
 /*! The following is mostly riped from the TRN code to load a DEM */
@@ -415,26 +456,25 @@ int status;         // Error status (see MAPIO_* values)
 int setupXYZ(double** xValues, double** yValues, zGrid& zValues, char *inFile )
 {
    mapsrc* src = mapsrc_init();
-	
+
    int err, i;
    double range[2];
    double delta;
-	
-   std::cout << "loading grd\n";
-	
+
+
    err = nc_open(inFile, NC_NOWRITE, &(src->ncid));
    if(NC_NOERR != err) {
-      std::cout << "failed load: " << err << "\n";
+      std::cout << "Failed to load input grid: " << err << "\n";
       std::cout << "check input filename\n";
       return 1;
    }
-	
+
    /* get x variable */
    err = nc_inq_dimid(src->ncid, "x", &(src->xdimid));
    if(NC_NOERR != err) {
       err = nc_inq_dimid(src->ncid,"lon", &(src->ydimid));
       if(NC_NOERR != err){
-	 return 2;
+   return 2;
       }
       std::cout << "Warning: Using \"lon\" for x\n";
    }
@@ -442,14 +482,14 @@ int setupXYZ(double** xValues, double** yValues, zGrid& zValues, char *inFile )
    if(NC_NOERR != err) {
       return 3;
    }
-	
+
    *xValues = new double[src->xdimlen];
 
    err = nc_inq_varid(src->ncid, "x", &(src->xid));
    if(NC_NOERR != err) {
       err = nc_inq_varid(src->ncid,"lon", &(src->xid));
       if(NC_NOERR != err){
-	 return 4;
+   return 4;
       }
       std::cout << "Warning: Using \"lon\" for x\n";
    }
@@ -457,19 +497,19 @@ int setupXYZ(double** xValues, double** yValues, zGrid& zValues, char *inFile )
    if(NC_NOERR != err) {
       return 5;
    }
-	
+
    //fill in xvec based on range boundaries.
    delta = (range[1] - range[0]) / (src->xdimlen - 1);
    for(i = 0; i < int(src->xdimlen); i++) {
       (*xValues)[i] = range[0] + delta * i;
    }
-	
+
    /* get y variable */
    err = nc_inq_dimid(src->ncid, "y", &(src->ydimid));
    if(NC_NOERR != err) {
       err = nc_inq_dimid(src->ncid,"lat", &(src->ydimid));
       if(NC_NOERR != err){
-	 return 6;
+   return 6;
       }
       std::cout << "Warning: Using \"lat\" for y\n";
    }
@@ -477,18 +517,18 @@ int setupXYZ(double** xValues, double** yValues, zGrid& zValues, char *inFile )
    if(NC_NOERR != err) {
       return 7;
    }
-	
+
    *yValues = new double[src->ydimlen];
-	
+
    err = nc_inq_varid(src->ncid, "y", &(src->yid));
    if(NC_NOERR != err) {
       err = nc_inq_varid(src->ncid,"lat", &(src->yid));
       if(NC_NOERR != err){
-	 return 8;
+   return 8;
       }
       std::cout << "Warning: Using \"lat\" for y\n";
    }
-	
+
    err = nc_get_att_double(src->ncid, src->yid, "actual_range", range);
    if(NC_NOERR != err) {
       return 9;
@@ -498,48 +538,45 @@ int setupXYZ(double** xValues, double** yValues, zGrid& zValues, char *inFile )
    for(i = 0; i < int(src->ydimlen); i++) {
       (*yValues)[i] = range[0] + delta * i;
    }
-	
+
    /* get z variable */
    err = nc_inq_varid(src->ncid, "z", &(src->zid));
    if(NC_NOERR != err) {
       return 10;
    }
-	
+
    // start = { x0, y0}, count = {xdimlen, ydimlen}
    size_t start[2];        // For NetCDF access -> {x0, y0}
    size_t count[2];        // For NetCDF access -> {xdimlen, ydimlen}
-	
+
    int XI = 1, YI = 0;
    float* array;
-	
+
    // Get the indices into the map array for the corners of our submap
    start[XI] = 0;//nearest(xmin, src->x, src->xdimlen);
    start[YI] = 0;
    count[XI] = src->xdimlen;//nearest(xmax, src->x, src->xdimlen) - start[XI] + 1;
    count[YI] = src->ydimlen;
    std::cout << start[XI] << "\t" << start[YI] << "\t" << count[XI] << "\t" << count[YI] << "\n";
-	
+
    // Allocate memory for the arrays
    array = new float[count[YI] * count[XI]];
    if(array == NULL) {
       exit(19);
    }
-	
+
    // Extract the data from the netcdf source file.
    err = nc_get_vara_float(src->ncid, src->zid, start, count, array);
-	
-	
+
+
    if(X_INDEX_FIRST){
       zValues = zGrid(array, src->ydimlen, src->xdimlen, true);
-      //std::cout << *xValues << "\t" << *yValues << "\t" << (*xValues)[0] << "\n";
       double* temp = *xValues;
       (*xValues) = *yValues;
       (*yValues) = temp;
-      //std::cout << *xValues << "\t" << *yValues << "\t" << (*xValues)[0] << "\n";
    }else{
       zValues = zGrid(array, src->xdimlen, src->ydimlen, false);
    }
-	
+
    return 0;
 }
-	

--- a/src/mbtrnutils/mbgrdtilemaker.cc
+++ b/src/mbtrnutils/mbgrdtilemaker.cc
@@ -1,0 +1,429 @@
+/*--------------------------------------------------------------------
+ *    The MB-system:  mbgrdtilemaker.cc  5/2/94
+ *
+ *    Copyright (c) 2022-2022 by
+ *    David W. Caress (caress@mbari.org)
+ *      Monterey Bay Aquarium Research Institute
+ *      Moss Landing, CA 95039
+ *    and Dale N. Chayes (dale@ldeo.columbia.edu)
+ *      Lamont-Doherty Earth Observatory
+ *      Palisades, NY 10964
+ *
+ *    See README file for copying and redistribution conditions.
+ *--------------------------------------------------------------------*/
+/**
+  @file
+ * MBgrdtilemaker creates a set of overlapping square grids from an original
+ * topography grid. The grid tiles will have 50% overlap in all directions with
+ * neighboring grids.
+ *
+ * Author:  D. W. Caress
+ * Date:  June 11, 2022
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <getopt.h>
+#include <limits>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
+
+#include "mb_aux.h"
+#include "mb_define.h"
+#include "mb_status.h"
+
+/* output stream for basic stuff (stdout if verbose <= 1,
+    stderr if verbose > 1) */
+FILE *outfp = stdout;
+
+/* program identifiers */
+constexpr char program_name[] = "mbgrdtilemaker";
+constexpr char help_message[] =
+    "MBgrdtilemaker creates a set of overlapping square grids from an original "
+    "topography grid. The grid tiles will have 50% overlap in all directions with "
+    "neighboring grids.";
+constexpr char usage_message[] =
+    "mbgrdtilemaker\n"
+    "\t--verbose\n"
+    "\t--help\n\n"
+    "\t--input=input_grid\n"
+    "\t--output=output_root\n\n"
+    "\t--tile-dimension=tile_dimension\n"
+    "\t--tile-mode=mode\n\n"
+    "\t--tile-spacing=tile_spacing\n\n";
+
+/*--------------------------------------------------------------------*/
+
+int main( int argc, char **argv )
+{
+  int verbose = 0;
+  int status = MB_SUCCESS;
+  mb_path input_grid = "";
+  mb_path output_root = "";
+  int tile_dimension = 2001;
+  int tile_dimension_spacing = ((tile_dimension - 1) / 2) + 1;
+  double tile_width = 0.0;
+  double tile_spacing = 0.0;
+  int tile_mode = 0;
+
+  static struct option options[] = {{"verbose", no_argument, nullptr, 0},
+                                    {"help", no_argument, nullptr, 0},
+                                    {"input", required_argument, nullptr, 0},
+                                    {"mode", required_argument, nullptr, 0},
+                                    {"output", required_argument, nullptr, 0},
+                                    {"tile-dimension", required_argument, nullptr, 0},
+                                    {"tile-spacing", required_argument, nullptr, 0}};
+
+  int option_index;
+  bool errflg = false;
+  int c;
+  bool help = false;
+  while ((c = getopt_long(argc, argv, "D:d:HhI:i:M:m:O:o:S:s:Vv", options, &option_index)) != -1) {
+    switch (c) {
+    /*-------------------------------------------------------*/
+    /* long options all return c=0 */
+    case 0:
+      if (strcmp("verbose", options[option_index].name) == 0) {
+        verbose++;
+        if (verbose >= 2)
+          outfp = stderr;
+      }
+      else if (strcmp("help", options[option_index].name) == 0) {
+        help = true;
+      }
+      else if (strcmp("input", options[option_index].name) == 0) {
+        const int n = sscanf(optarg, "%1023s", input_grid);
+        if (n != 1 || strlen(input_grid) <= 0) {
+          fprintf(stderr, "Failed to parse argument: %s=%s\nProgram %s terminated\n",
+                  options[option_index].name, optarg, program_name);
+          exit(MB_ERROR_BAD_PARAMETER);
+        }
+      }
+      else if (strcmp("output", options[option_index].name) == 0) {
+        const int n = sscanf(optarg, "%1023s", output_root);
+        if (n != 1 || strlen(input_grid) <= 0) {
+          fprintf(stderr, "Failed to parse argument: %s=%s\nProgram %s terminated\n",
+                  options[option_index].name, optarg, program_name);
+          exit(MB_ERROR_BAD_PARAMETER);
+        }
+      }
+      else if (strcmp("tile-dimension", options[option_index].name) == 0) {
+        const int n = sscanf(optarg, "%d", &tile_dimension);
+        if (n != 1 || tile_dimension <= 0) {
+          fprintf(stderr, "Failed to parse argument: %s=%s\nProgram %s terminated\n",
+                  options[option_index].name, optarg, program_name);
+          exit(MB_ERROR_BAD_PARAMETER);
+        }
+      }
+      else if (strcmp("tile-mode", options[option_index].name) == 0) {
+        const int n = sscanf(optarg, "%d", &tile_mode);
+        if (n != 1 || tile_mode < 0) {
+          fprintf(stderr, "Failed to parse argument: %s=%s\nProgram %s terminated\n",
+                  options[option_index].name, optarg, program_name);
+          exit(MB_ERROR_BAD_PARAMETER);
+        }
+      }
+      else if (strcmp("tile-spacing", options[option_index].name) == 0) {
+        const int n = sscanf(optarg, "%lf", &tile_spacing);
+        if (n != 1 || tile_spacing <= 0.0) {
+          fprintf(stderr, "Failed to parse argument: %s=%s\nProgram %s terminated\n",
+                  options[option_index].name, optarg, program_name);
+          exit(MB_ERROR_BAD_PARAMETER);
+        }
+      }
+      break;
+    /*-------------------------------------------------------*/
+    /* short options */
+    case 'D':
+    case 'd':
+      sscanf(optarg, "%d", &tile_dimension);
+      break;
+    case 'H':
+    case 'h':
+      help = true;
+      break;
+    case 'I':
+    case 'i':
+      sscanf(optarg, "%1023s", input_grid);
+      break;
+    case 'M':
+    case 'm':
+      sscanf(optarg, "%d", &tile_mode);
+      break;
+    case 'O':
+    case 'o':
+      sscanf(optarg, "%1023s", output_root);
+      break;
+    case 'S':
+    case 's':
+      sscanf(optarg, "%lf", &tile_spacing);
+      break;
+    case 'V':
+    case 'f':
+      verbose++;
+      if (verbose >= 2)
+        outfp = stderr;
+      break;
+    case '?':
+      errflg = true;
+    }
+  }
+
+  if (errflg) {
+    fprintf(outfp, "usage: %s\n", usage_message);
+    fprintf(outfp, "\nProgram <%s> Terminated\n", program_name);
+    exit(MB_ERROR_BAD_USAGE);
+  }
+
+  if (verbose == 1 || help) {
+    fprintf(outfp, "\nProgram %s\n", program_name);
+    fprintf(outfp, "MB-system Version %s\n", MB_VERSION);
+  }
+
+  if (verbose >= 2) {
+    fprintf(outfp, "\ndbg2  Program <%s>\n", program_name);
+    fprintf(outfp, "dbg2  MB-system Version %s\n", MB_VERSION);
+    fprintf(outfp, "dbg2  Control Parameters:\n");
+    fprintf(outfp, "dbg2       verbose:              %d\n", verbose);
+    fprintf(outfp, "dbg2       help:                 %d\n", help);
+    fprintf(outfp, "dbg2       input_grid:           %s\n", input_grid);
+    fprintf(outfp, "dbg2       output_root:          %s\n", output_root);
+    fprintf(outfp, "dbg2       tile_mode:            %d\n", tile_mode);
+    fprintf(outfp, "dbg2       tile_dimension:       %d\n", tile_dimension);
+    fprintf(outfp, "dbg2       tile_spacing:         %f\n", tile_spacing);
+  }
+
+  if (help) {
+    fprintf(outfp, "\n%s\n", help_message);
+    fprintf(outfp, "\nusage: %s\n", usage_message);
+    exit(MB_ERROR_NO_ERROR);
+  }
+
+  // Set tile_dimension if neither spacing nor dimension has been set
+  if (tile_dimension <= 0 && tile_spacing <= 0.0)
+    tile_dimension = 2001;
+
+  int error = MB_ERROR_NO_ERROR;
+  int memclear_error = MB_ERROR_NO_ERROR;
+
+  int grid_projection_mode;
+  mb_path grid_projection_id;
+  float grid_nodatavalue;
+  int grid_nxy;
+  int grid_n_columns;
+  int grid_n_rows;
+  double grid_min;
+  double grid_max;
+  double grid_xmin;
+  double grid_xmax;
+  double grid_ymin;
+  double grid_ymax;
+  double grid_dx;
+  double grid_dy;
+  float *grid_data;
+
+  // Read the input grid file
+  status = mb_read_gmt_grd(verbose, input_grid, &grid_projection_mode, grid_projection_id,
+                           &grid_nodatavalue, &grid_nxy, &grid_n_columns, &grid_n_rows,
+                           &grid_min, &grid_max, &grid_xmin, &grid_xmax, &grid_ymin,
+                           &grid_ymax, &grid_dx, &grid_dy, &grid_data, NULL, NULL, &error);
+  if (status == MB_FAILURE) {
+    fprintf(stderr, "Unable to read input grid %s\n", input_grid);
+    fprintf(stderr, "Program %s terminated\n", program_name);
+    exit(error);
+  }
+
+  fprintf(stdout, "\nInput grid:           %s\n", input_grid);
+  fprintf(stdout, "  Projection mode:    %d\n", grid_projection_mode);
+  fprintf(stdout, "  Projection id:      %s\n", grid_projection_id);
+  fprintf(stdout, "  No data value:      %f\n", grid_nodatavalue);
+  fprintf(stdout, "  grid_nxy:           %d\n", grid_nxy);
+  fprintf(stdout, "  grid_n_columns:     %d\n", grid_n_columns);
+  fprintf(stdout, "  grid_n_rows:        %d\n", grid_n_rows);
+  fprintf(stdout, "  grid_min:           %f\n", grid_min);
+  fprintf(stdout, "  grid_max:           %f\n", grid_max);
+  fprintf(stdout, "  grid_xmin:          %f\n", grid_xmin);
+  fprintf(stdout, "  grid_xmax:          %f\n", grid_xmax);
+  fprintf(stdout, "  grid_ymin:          %f\n", grid_ymin);
+  fprintf(stdout, "  grid_ymax:          %f\n", grid_ymax);
+  fprintf(stdout, "  grid_dx:            %f\n", grid_dx);
+  fprintf(stdout, "  grid_dy:            %f\n", grid_dy);
+
+  // Set up output tile scheme
+  // Each grid tile will have 50% overlap with surrounding tiles
+  // Tiles are either defined in terms of the desired dimensions of the grids
+  // or the tile spacing in meters. The tileset will be constructed with the
+  // using the southwest corner of the input grid as the origin.
+  double tile_width_x;
+  double tile_width_y;
+  double tile_spacing_x;
+  double tile_spacing_y;
+  double tileset_origin_x = grid_xmin;
+  double tileset_origin_y = grid_ymin;
+  if (tile_spacing > 0.0) {
+    tile_dimension = 2.0 * tile_spacing / grid_dx + 1;
+    tile_width_x = (tile_dimension - 1) * grid_dx;
+    tile_width_y = (tile_dimension - 1) * grid_dy;
+    tile_spacing_x = tile_width_x / 2.0;
+    tile_spacing_y = tile_width_x / 2.0;
+  } else if (tile_dimension > 0) {
+    tile_width_x = (tile_dimension - 1) * grid_dx;
+    tile_width_y = (tile_dimension - 1) * grid_dy;
+    tile_spacing_x = tile_width_x / 2.0;
+    tile_spacing_y = tile_width_x / 2.0;
+  } else {
+    fprintf(stderr, "Neither tile dimension nor spacing have been defined "
+            "(--tile-dimension=dimension or --tile-spacing=spacing)\n"
+            "Program %s terminated\n", program_name);
+    exit(MB_ERROR_BAD_PARAMETER);
+  }
+  int num_tiles_x = (int)ceil((grid_xmax - tileset_origin_x) / tile_spacing_x);
+  int num_tiles_y = (int)ceil((grid_ymax - tileset_origin_y) / tile_spacing_y);
+  int num_tiles = num_tiles_x * num_tiles_y;
+  double tileset_max_x = tileset_origin_x + num_tiles_x * tile_spacing_x;
+  double tileset_max_y = tileset_origin_y + num_tiles_y * tile_spacing_y;
+  mb_path tile_xlabel;
+  mb_path tile_ylabel;
+  mb_path tile_zlabel;
+  mb_path tile_title;
+  strcpy(tile_xlabel, "Easting (meters)");
+  strcpy(tile_ylabel, "Northing (meters)");
+  strcpy(tile_zlabel, "Topography (meters)");
+
+  fprintf(stdout, "\nOutput tileset:       %s\n", output_root);
+  fprintf(stdout, "  tile_width_x:       %f\n", tile_width_x);
+  fprintf(stdout, "  tile_width_y:       %f\n", tile_width_y);
+  fprintf(stdout, "  tileset_origin_x:   %f\n", tileset_origin_x);
+  fprintf(stdout, "  tileset_origin_y:   %f\n", tileset_origin_x);
+  fprintf(stdout, "  tileset_max_x:      %f\n", tileset_max_x);
+  fprintf(stdout, "  tileset_max_y:      %f\n", tileset_max_y);
+  fprintf(stdout, "  num_tiles_x:        %d\n", num_tiles_x);
+  fprintf(stdout, "  num_tiles_y:        %d\n", num_tiles_y);
+  fprintf(stdout, "  num_tiles:          %d\n", num_tiles);
+  fprintf(stdout, "  tile_xlabel:        %s\n", tile_xlabel);
+  fprintf(stdout, "  tile_ylabel:        %s\n", tile_ylabel);
+  fprintf(stdout, "  tile_zlabel:        %s\n", tile_zlabel);
+  fprintf(stdout, "  tile_title:         %s\n", tile_title);
+
+  mkdir(output_root, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+  mb_path csv_file;
+  sprintf(csv_file, "%s/tiles.csv", output_root);
+  FILE *csv_fp = fopen(csv_file, "w");
+  fprintf(csv_fp, "TileName , Easting , Northing , %d\n", num_tiles);
+
+  // Loop over all tiles
+  int itile = 0;
+  for (int j=0; j<num_tiles_y; j++) {
+    for (int i=0; i<num_tiles_x; i++) {
+      int k = i * num_tiles_y + j;
+      mb_path tile_name;
+      mb_path tile_grid;
+      mb_path tile_bo;
+      sprintf(tile_name, "%s_%4.4d", output_root, itile);
+      sprintf(tile_grid, "%s/%s.grd", output_root, tile_name);
+      sprintf(tile_bo, "%s.bo", tile_name);
+      sprintf(tile_title, "Tile %s", tile_name);
+      int tile_projection_mode = grid_projection_mode;
+      mb_path tile_projection_id;
+      strncpy(tile_projection_id, grid_projection_id, MB_PATH_MAXLINE-1);
+      float tile_nodatavalue = grid_nodatavalue;
+      int tile_nxy = tile_dimension * tile_dimension;
+      int tile_n_columns = tile_dimension;
+      int tile_n_rows = tile_dimension;
+      double tile_min = 0.0;
+      double tile_max = 0.0;
+      double tile_xmin = tileset_origin_x + i * tile_spacing_x - 0.5 * tile_spacing_x;
+      double tile_xcen = tile_xmin + 0.5 * tile_width_x;
+      double tile_xmax = tile_xmin + tile_width_x;
+      double tile_ymin = tileset_origin_y + j * tile_spacing_y - 0.5 * tile_spacing_y;
+      double tile_ycen = tile_ymin + 0.5 * tile_width_y;;
+      double tile_ymax = tile_ymin + tile_width_y;;
+      double tile_dx = grid_dx;
+      double tile_dy = grid_dy;
+      float *tile_data = NULL;
+      status = mb_mallocd(verbose, __FILE__, __LINE__, tile_dimension * tile_dimension * sizeof(float), (void **)&tile_data, &error);
+      if (error != MB_ERROR_NO_ERROR) {
+        char *message = nullptr;
+        mb_error(verbose, MB_ERROR_MEMORY_FAIL, &message);
+        fprintf(outfp, "\nMBIO Error allocating tile array:\n%s\n", message);
+        fprintf(outfp, "\nProgram <%s> Terminated\n", program_name);
+        mb_memory_clear(verbose, &memclear_error);
+        exit(MB_ERROR_MEMORY_FAIL);
+      }
+      for (int kk=0; kk < tile_nxy; kk++)
+        tile_data[kk] = tile_nodatavalue;
+
+      // Get tile origin location in the input grid
+      int ii0 = (int)round((tile_xmin - grid_xmin) / grid_dx);
+      int jj0 = (int)round((tile_ymin - grid_ymin) / grid_dy);
+
+      // Fill in tile data from input_grid
+      bool first = true;
+      for (int jj=0;jj<tile_dimension;jj++) {
+        for (int ii=0;ii<tile_dimension;ii++) {
+          int kk = ii * tile_dimension + jj;
+          int iii = ii0 + ii;
+          int jjj = jj0 + jj;
+          int kkk = iii * grid_n_rows + jjj;
+          if (iii >= 0 && iii < grid_n_columns && jjj >= 0 && jjj < grid_n_rows) {
+            tile_data[kk] = grid_data[kkk];
+            if (tile_data[kk] != tile_nodatavalue) {
+              if (first) {
+                tile_min = tile_data[kk];
+                tile_max = tile_data[kk];
+                first = false;
+              } else {
+                tile_min = MIN(tile_min, tile_data[kk]);
+                tile_max = MAX(tile_max, tile_data[kk]);
+              }
+            }
+          }
+        }
+      }
+
+    fprintf(outfp, "\nTile %d %d: %s\n", i, j, tile_name);
+    status = mb_write_gmt_grd(verbose, tile_grid, tile_data, tile_nodatavalue,
+                              tile_dimension, tile_dimension,
+                              tile_xmin, tile_xmax, tile_ymin, tile_ymax,
+                              tile_min, tile_max, tile_dx, tile_dy,
+                              tile_xlabel, tile_ylabel, tile_zlabel, tile_title,
+                              tile_projection_id, argc, argv, &error);
+    fprintf(csv_fp, "%s , %.2f , %.2f\n", tile_bo, tile_xcen, tile_ycen);
+
+    status = mb_freed(verbose, __FILE__, __LINE__, (void **)&tile_data, &error);
+    itile++;
+    }
+  }
+
+  status = mb_freed(verbose, __FILE__, __LINE__, (void **)&grid_data, &error);
+  fclose(csv_fp);
+
+  // Copy source grid to tiles directory
+  char command[MB_COMMAND_LENGTH];
+  sprintf(command, "cp %s %s/source_grid.grd", input_grid, output_root);
+
+  // Generate octree files from the grids
+  for (int itile=0; itile<num_tiles; itile++) {
+    mb_path tile_name;
+    mb_path tile_pathlet;
+    sprintf(tile_name, "%s_%4.4d", output_root, itile);
+    sprintf(tile_pathlet, "%s/%s", output_root, tile_name);
+    sprintf(command, "mbgrd2octree --input=%s.grd --output=%s.bo",
+                      tile_pathlet, tile_pathlet);
+    fprintf(outfp, "\n-----------------------------------------------------------\nExecuting: %s\n", command);
+    system(command);
+  }
+
+  /* check memory */
+  if ((status = mb_memory_list(verbose, &error)) == MB_FAILURE) {
+    fprintf(stderr, "Program %s completed but failed to deallocate all allocated memory - the code has a memory leak somewhere!\n", program_name);
+  }
+
+	exit(error);
+}
+/*--------------------------------------------------------------------*/

--- a/src/mbtrnutils/mbtrnpp.c
+++ b/src/mbtrnutils/mbtrnpp.c
@@ -589,8 +589,8 @@ s=NULL;\
 #define OPT_TRN_DECS_DFL                  0.0
 #define OPT_COVARIANCE_MAGNITUDE_MAX_DFL  5.0
 #define OPT_CONVERGENCE_REPEAT_MIN        200
-#define OPT_REINIT_SEARCH_XY              60
-#define OPT_REINIT_SEARCH_Z               5
+#define OPT_REINIT_SEARCH_XY              60.0
+#define OPT_REINIT_SEARCH_Z               5.0
 #define OPT_REINIT_GAIN_ENABLE_DFL        false
 #define OPT_REINIT_FILE_ENABLE_DFL        false
 #define OPT_REINIT_XYOFFSET_ENABLE_DFL    false


### PR DESCRIPTION
Mbtrnpp: Added options to set the TRN search area on the command line and in
cfg files. Fixed wrapper script mbtrnpp.sh so that the number of cycles
to be used is set correction.

Mbm_trnplot: Fixed plotting macro to work with the current mbtrnpp output.

Mbgrd2octree: Recast program that translates a topography grid in a projected
coordinate system (like UTM) into a TRN octree model. This program now used
MB-System-like arguments, e.g. mbgrd2octree --input=grid --output=octree

Mbgrdtilemaker: Added new program to generate a tileset of octrees for TRN from a
reference grid in a projected coordinate system (like UTM). This tileset can be
used by mbtrnpp.