### PR TITLE
Read backscatter from 83p files

### DIFF
--- a/src/mbio/mbr_image83p.c
+++ b/src/mbio/mbr_image83p.c
@@ -440,6 +440,14 @@ int mbr_rt_image83p(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		store->ping_number = int_val;
 		index += 159;
 
+		if (store->version >= 10) {
+			/* backscatter added in v1.1 */
+			store->has_intensity = buffer[117];
+		}
+		else {
+			store->has_intensity = 0;
+		}
+
 		/* fix unexpected zero values */
 		if (store->pitch == 0)
 			store->pitch = 900;
@@ -456,10 +464,15 @@ int mbr_rt_image83p(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 		}
 
 		/* get amplitudes */
-		for (int i = 0; i < store->num_beams; i++) {
-			mb_get_binary_short(swap, &buffer[index], &short_val);
-			index += 2;
-			store->amp[i] = (int)((unsigned short)short_val);
+		if (store->has_intensity) {
+			for (int i = 0; i < store->num_beams; i++) {
+				mb_get_binary_short(swap, &buffer[index], &short_val);
+				index += 2;
+				store->amp[i] = (int)((unsigned short)short_val);
+			}
+		}
+		else {
+			memset(store->amp, 0, store->num_beams * sizeof(short));
 		}
 	}
 	mb_io_ptr->new_kind = store->kind;

--- a/src/mbio/mbr_image83p.c
+++ b/src/mbio/mbr_image83p.c
@@ -64,7 +64,7 @@ int mbr_info_image83p(int verbose, int *system, int *beams_bath_max, int *beams_
 	*error = MB_ERROR_NO_ERROR;
 	*system = MB_SYS_IMAGE83P;
 	*beams_bath_max = 480;
-	*beams_amp_max = 0;
+	*beams_amp_max = 480;
 	*pixels_ss_max = 0;
 	strncpy(format_name, "IMAGE83P", MB_NAME_LENGTH);
 	strncpy(system_name, "IMAGE83P", MB_NAME_LENGTH);
@@ -453,6 +453,13 @@ int mbr_rt_image83p(int verbose, void *mbio_ptr, void *store_ptr, int *error) {
 			mb_get_binary_short(swap, &buffer[index], &short_val);
 			index += 2;
 			store->range[i] = (int)((unsigned short)short_val);
+		}
+
+		/* get amplitudes */
+		for (int i = 0; i < store->num_beams; i++) {
+			mb_get_binary_short(swap, &buffer[index], &short_val);
+			index += 2;
+			store->amp[i] = (int)((unsigned short)short_val);
 		}
 	}
 	mb_io_ptr->new_kind = store->kind;

--- a/src/mbio/mbsys_image83p.c
+++ b/src/mbio/mbsys_image83p.c
@@ -188,11 +188,12 @@ int mbsys_image83p_extract(int verbose, void *mbio_ptr, void *store_ptr, int *ki
 
 		/* read distance and depth values into storage arrays */
 		*nbath = store->num_proc_beams;
-		*namp = 0;
+		*namp = store->num_proc_beams;
 		*nss = 0;
 		for (int i = 0; i < *nbath; i++) {
 			beamflag[i] = store->beamflag[i];
 			bath[i] = store->bath[i];
+			amp[i] = store->amp[i];
 			bathacrosstrack[i] = store->bathacrosstrack[i];
 			bathalongtrack[i] = store->bathalongtrack[i];
 		}

--- a/src/mbio/mbsys_image83p.h
+++ b/src/mbio/mbsys_image83p.h
@@ -72,6 +72,7 @@ struct mbsys_image83p_struct {
 	int profile_tilt_angle; /* degrees + 180.0 */
 	int rep_rate;           /* msec */
 	int ping_number;
+	int has_intensity;
 	int range[MBSYS_IMAGE83P_BEAMS];
 	int amp[MBSYS_IMAGE83P_BEAMS];
 

--- a/src/mbio/mbsys_image83p.h
+++ b/src/mbio/mbsys_image83p.h
@@ -73,6 +73,7 @@ struct mbsys_image83p_struct {
 	int rep_rate;           /* msec */
 	int ping_number;
 	int range[MBSYS_IMAGE83P_BEAMS];
+	int amp[MBSYS_IMAGE83P_BEAMS];
 
 	/* important values not in vendor format */
 	float sonar_depth;


### PR DESCRIPTION
This PR adds support to read backscatter amplitudes from `v1.1` `83p` files. 

This is relatively simple as the `83p` code already reads a 2176 byte buffer sized to hold the ping header plus 480 range 16-bit unsigned ints plus 480 amplitude 16-bit unsigned ints (see [here](https://github.com/dwcaress/MB-System/blob/master/src/mbio/mbr_image83p.c#L49)). All we need to do is store those amplitudes and later extract them into the generic `double` amplitudes array. Note that no scaling or other conversion is applied when converting the raw amplitude integers into floating-point, since there is no scaling specified in the `83p` [`v1.1` docs](http://www3.mbari.org/products/mbsystem/formatdoc/83P_v1.1.pdf). 

`v1.0` doesn't have backscatter amplitudes, so we just fill `store->amp[:]` with zeros. In `v1.1`, byte `117` signifies whether amplitudes are present; if not, then `store->amp[:]` is zeroed.

Note that after this change, `mbinfo` will always report that the data has `<# beams>` amplitude beams, regardless of version or byte `117`:
```
Amplitude Data (480 beams):
  Number of Beams:          2588640
  Number of Good Beams:     2421012     93.52%
  Number of Zero Beams:      167628      6.48%
  Number of Flagged Beams:        0      0.00%
```
It's not clear to me how to accurately report this, because the current structure of the code doesn't provide much format info into the `mbr_info_image83p()` call, which is called from `mb_format_description()` before the file is read. The alternative here would be to create a separate `83pv11` format, but that still wouldn't accurately reflect byte `117`, i.e. whether backscatter is present.