### PR TITLE
Fix unsigned wraparound

### DIFF
--- a/src/mbio/mbsys_reson7k.c
+++ b/src/mbio/mbsys_reson7k.c
@@ -6034,7 +6034,7 @@ int mbsys_reson7k_extract(int verbose, void *mbio_ptr, void *store_ptr, int *kin
     *nss = 0;
     if (store->read_processedsidescan) {
       *nss = processedsidescan->number_pixels;
-      for (unsigned int i = 0; i < processedsidescan->number_pixels; i++) {
+      for (int i = 0; i < processedsidescan->number_pixels; i++) {
         ss[i] = processedsidescan->sidescan[i];
         ssacrosstrack[i] = processedsidescan->pixelwidth * (i - (int)processedsidescan->number_pixels / 2);
         ssalongtrack[i] = processedsidescan->alongtrack[i];


### PR DESCRIPTION
A recent change from `int` -> `unsigned int` causes the computation of `ssacrosstrack[i]` to wraparound. The change was made in [this commit](https://github.com/dwcaress/MB-System/commit/996a4ecdac09af702f06b137ec1cccd5a0301b29).

The bug shows up as extremely large bounds when running `mbinfo` on an mb88 dataset, since `ssacrosstrack[i]` eventually is used to compute lat/long for the sidescan pixel.

For example, running
```
mbinfo -I ~/mb88_problems/20091021_162557_ventresca7125.s7k.s7k.mb88
```

prior to this change outputs

```
Limits:
Minimum Longitude:    -121.858863263   Maximum Longitude:    6026.381436848
Minimum Latitude:    -1450.970669383   Maximum Latitude:      489.421090170
```

and after this change outputs

```
Limits:
Minimum Longitude:    -121.858929958   Maximum Longitude:    -121.854400110
Minimum Latitude:       36.728580927   Maximum Latitude:       36.746477990
```

Note that it is likely that there will be other similar bugs caused by signed <-> unsigned changes in the referenced commit.