### PR TITLE
Bug fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,7 +23,7 @@ Distributions that do not include "beta" in the tag name correspond to the major
 announced releases. The source distributions associated with all releases, major
 or beta, are equally accessible as tarballs through the Github interface.
 
-- Version 5.7.9beta52    March 4, 2023
+- Version 5.7.9beta52    March 9, 2023
 - Version 5.7.9beta51    February 14, 2023
 - Version 5.7.9beta50    February 12, 2023
 - Version 5.7.9beta49    January 22, 2023
@@ -429,11 +429,23 @@ or beta, are equally accessible as tarballs through the Github interface.
 ### MB-System Version 5.7 Release Notes:
 --
 
-#### 5.7.9beta52 (March 4)
+#### 5.7.9beta52 (March 9)
+
+Formats 56 (MBF_EM300RAW) and 57 (MBF_EM300MBA): Fixed catastrophic bug introduced in 
+5.7.9beta50 that treated many signed values (like acrosstrack distance) as unsigned.
+
+MBgrdviz: Added ability to export routes as TECDIS LST files for display in a variety of
+marine chart display software. 
 
 Autotools build system: Altered Makefile.am files in third_party/googlemock and 
 third_party/googletest to eliminate benign but alarming error messages during make install 
 and make clean commands.
+
+Mbm_route2mission: Added ability to insert a magnetometer calibration maneuver into an
+AUV mission spiral descent using the -Naltitude/mode command, where altitude is the
+spiral descent termination altitude and mode = 0 for no start survey behavior, 1 for 
+start survey behavior alone, and 2 for start survey plus a magnetometer calibration 
+maneuver.
 
 #### 5.7.9beta51 (February 14)
 

--- a/configure
+++ b/configure
@@ -3293,7 +3293,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
-printf "%s\n" "#define VERSION_DATE \"4 March 2023\"" >>confdefs.h
+printf "%s\n" "#define VERSION_DATE \"9 March 2023\"" >>confdefs.h
 
 
 printf "%s\n" " "

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ dnl--------------------------------------------------------------------
 
 dnl Initialize and set version and version date
 AC_INIT([mbsystem],[5.7.9beta52],[http://listserver.mbari.org/sympa/arc/mbsystem],[mbsystem],[http://www.mbari.org/data/mbsystem/])
-AC_DEFINE(VERSION_DATE, ["4 March 2023"], [Set VERSION_DATE define in mb_config.h])
+AC_DEFINE(VERSION_DATE, ["9 March 2023"], [Set VERSION_DATE define in mb_config.h])
 
 AS_ECHO([" "])
 AS_ECHO(["------------------------------------------------------------------------------"])

--- a/src/macros/mbm_route2mission
+++ b/src/macros/mbm_route2mission
@@ -151,6 +151,9 @@ $depthabort = 6000.0;
 $maxclimbslope = 0.5734;
 
 # spiral descent approach depth
+$spiraldescent = 0;
+$startsurvey = 0;
+$magcalibrate = 0;
 $approachdepth = 50.0;
 
 # assumed ascent and descent rate
@@ -407,21 +410,34 @@ elsif ($deltat)
 	}
 if ($spiraldescentarg =~ /\S+\/\S+/)
 	{
-	($spiraldescentaltitude, $startsurvey) = $spiraldescentarg =~ /(\S+)\/(\S+)/;
-  if ($startsurvey != 0)
-    {
-    $startsurvey = 1;
-    }
+	($spiraldescentaltitude, $spiraldescentmode) = $spiraldescentarg =~ /(\S+)\/(\S+)/;
+	if ($spiraldescentmode == 0)
+		{
+		$startsurvey = 0;
+		$magcalibrate = 0;
+		}
+  	elsif ($spiraldescentmode == 1)
+    	{
+    	$startsurvey = 1;
+		$magcalibrate = 0;
+    	}
+  	elsif ($spiraldescentmode == 2)
+    	{
+    	$startsurvey = 1;
+		$magcalibrate = 1;
+    	}
 	}
 elsif ($spiraldescentarg =~ /\S+/)
 	{
 	($spiraldescentaltitude) = $spiraldescentarg =~ /(\S+)/;
-  $startsurvey = 1;
+  	$startsurvey = 1;
+	$magcalibrate = 0;
 	}
 elsif ($spiraldescent)
 	{
 	$spiraldescentaltitude = $altitudedesired;
-  $startsurvey = 1;
+  	$startsurvey = 1;
+	$magcalibrate = 0;
 	}
 if ($multibeamsettings =~ /\S+\/\S+\/\S+\/\S+/)
 	{
@@ -1003,21 +1019,30 @@ elsif ($verbose)
 	printf "    Way Points:               $nwaypoints\r\n";
 	printf "    Route Points:             $nmissionpoints\r\n";
 	printf "    Survey Behaviors:\r\n";
-        for ($i = 0; $i < 5; $i++)
-                {
-                printf "         Behavior for waypoint mode $i:   $behaviorNames[$behaviorIDs[$i]]\r\n";
-                }
- 	if ($spiraldescent)
+    for ($i = 0; $i < 5; $i++)
+        {
+        printf "         Behavior for waypoint mode $i:   $behaviorNames[$behaviorIDs[$i]]\r\n";
+        }
+	if ($spiraldescent)
 		{
-    if ($startsurvey == 0)
-      {
-		  printf "    Descent style:            Spiral descent without StartSurvey behavior\r\n";
-      }
-    else
-      {
+    	if ($startsurvey == 0)
+      		{
+		  	printf "    Descent style:            Spiral descent without StartSurvey behavior\r\n";
+      		}
+    	else
+      		{
 			printf "    Descent style:            Spiral descent with StartSurvey behavior\r\n";
-      }
-		printf "    Descent altitude:         %f\r\n", $spiraldescentaltitude;
+      		}
+		printf "    Spiral descent depth:     $spiraldescentdepth m\r\n";
+		printf "    Spiral descent altitude:  $spiraldescentaltitude m\r\n";
+		if ($magcalibrate)
+			{
+			printf "    Magnetometer calibration maneuver midway through spiral descent\r\n";
+			}
+		else
+      		{
+		  	printf "    No Magnetometer Calibration\r\n";
+      		}
 		}
 	else
 		{
@@ -1091,16 +1116,24 @@ elsif ($verbose)
 	printf "    Descent Vehicle Depth:      $descentdepth (m)\r\n";
 	if ($spiraldescent)
 		{
-    if ($startsurvey == 0)
-      {
-		  printf "    Descent style:            Spiral descent without StartSurvey behavior\r\n";
-      }
-    else
-      {
+    	if ($startsurvey == 0)
+      		{
+		  	printf "    Descent style:            Spiral descent without StartSurvey behavior\r\n";
+      		}
+    	else
+      		{
 			printf "    Descent style:            Spiral descent with StartSurvey behavior\r\n";
-      }
+      		}
 		printf "    Spiral descent depth:     $spiraldescentdepth m\r\n";
 		printf "    Spiral descent altitude:  $spiraldescentaltitude m\r\n";
+		if ($magcalibrate)
+			{
+			printf "    Magnetometer calibration maneuver midway through spiral descent\r\n";
+			}
+		else
+      		{
+		  	printf "    No Magnetometer Calibration\r\n";
+      		}
 		}
 	if ($forwarddist)
 		{
@@ -1184,13 +1217,21 @@ if (!$outputoff)
 	if ($spiraldescent)
 		{
 		if ($startsurvey == 0)
-      {
-		  printf MFILE "#     Descent style:            Spiral descent without StartSurvey behavior\r\n";
-      }
-    else
-      {
+      		{
+		  	printf MFILE "#     Descent style:            Spiral descent without StartSurvey behavior\r\n";
+      		}
+    	else
+      		{
 			printf MFILE "#     Descent style:            Spiral descent with StartSurvey behavior\r\n";
-      }
+      		}
+		if ($magcalibrate)
+      		{
+		  	printf MFILE "#     Magnetometer Calibration: Magnetometer calibration maneuver midway during spiral descent\r\n";
+      		}
+		else
+      		{
+		  	printf MFILE "#     Magnetometer Calibration: None\r\n";
+      		}
 		}
 	else
 		{
@@ -1319,6 +1360,7 @@ if (!$outputoff)
 	printf MFILE "#define GPS_DURATION               %d\r\n", $gpsduration;
 	printf MFILE "#define DESCENT_DEPTH              %f\r\n", $descentdepth;
 	printf MFILE "#define SPIRAL_DESCENT_DEPTH       %f\r\n", $spiraldescentdepth;
+	printf MFILE "#define SPIRAL_DESCENT_DEPTH_HALF  %f\r\n", 0.5 * $spiraldescentdepth;
 	printf MFILE "#define SPIRAL_DESCENT_ALTITUDE    %f\r\n", $spiraldescentaltitude;
 	printf MFILE "#define DESCEND_DURATION           %d\r\n", $initialdescendtime;
 	printf MFILE "#define SETPOINT_DURATION          %d\r\n", $setpointtime;
@@ -1870,7 +1912,7 @@ print "Behavior: delta_t (startup, logMode = $logmode)\r\n";
 			print MFILE "speed        = ASCENTDESCENT_SPEED; \r\n";
 			print MFILE "} \r\n";
 print "Behavior: waypoint\n";
-  		print MFILE "# \r\n";
+  			print MFILE "# \r\n";
 			print MFILE "# Acoustic update 5 - sent status ping at end of startSurvey - Jordan's squawk \r\n";
 			print MFILE "# This modem squawk was added following the suggestion of Jordan Caress \r\n";
 			print MFILE "# (at the insistence of Eric Martin) \r\n";
@@ -1882,17 +1924,17 @@ print "Behavior: waypoint\n";
 			print MFILE "} \r\n";
 print "Behavior: acousticUpdate\n";
 			print MFILE "# \r\n";
-      if ($startsurvey == 1)
-        {
-  			print MFILE "# Zero speed hang to allow final nav updates over acoustic modem\r\n";
-  			print MFILE "# - must get start survey command over acoustic modem or mission aborts\r\n";
-  			print MFILE "behavior StartSurvey  \r\n";
-  			print MFILE "{ \r\n";
-  			print MFILE "duration     = 300; \r\n";
-  			print MFILE "} \r\n";
+      		if ($startsurvey == 1)
+        		{
+  				print MFILE "# Zero speed hang to allow final nav updates over acoustic modem\r\n";
+  				print MFILE "# - must get start survey command over acoustic modem or mission aborts\r\n";
+  				print MFILE "behavior StartSurvey  \r\n";
+  				print MFILE "{ \r\n";
+  				print MFILE "duration     = 300; \r\n";
+  				print MFILE "} \r\n";
 print "Behavior: startsurvey\n";
-        }
-  		print MFILE "# \r\n";
+        		}
+  			print MFILE "# \r\n";
 			print MFILE "# Acoustic update 4 - sent status ping at end of spiral descent \r\n";
 			print MFILE "# \r\n";
 			print MFILE "behavior acousticUpdate \r\n";
@@ -1901,8 +1943,8 @@ print "Behavior: startsurvey\n";
 			print MFILE "dummy  = 1; \r\n";
 			print MFILE "} \r\n";
 print "Behavior: acousticUpdate\n";
-  		print MFILE "# \r\n";
-  		print MFILE "# Spiral descend behavior to get to proper depth at start of line 1 \r\n";
+  			print MFILE "# \r\n";
+  			print MFILE "# Spiral descend behavior to get to proper depth at start of line 1 \r\n";
 			if ($maxdepthapplied == 0)
 				{
 				printf MFILE "#   Behavior depth of %f meters set by local depth and desired altitude\r\n", $mmissiondepths[$i];
@@ -1911,29 +1953,84 @@ print "Behavior: acousticUpdate\n";
 				{
 				printf MFILE "#   Behavior depth of %f meters set to maximum vehicle depth\r\n", $mmissiondepths[$i];
 				}
-			print MFILE "behavior descend  \r\n";
-			print MFILE "{ \r\n";
-			printf MFILE "duration         = %d; \r\n", $descendtimes[$i];
-			print MFILE "horizontalMode   = rudder; \r\n";
-			print MFILE "horizontal       = DESCENDRUDDER; \r\n";
-			print MFILE "pitch            = DESCENDPITCH; \r\n";
-			print MFILE "speed            = ASCENTDESCENT_SPEED; \r\n";
-			print MFILE "maxDepth         = SPIRAL_DESCENT_DEPTH; \r\n";
-			print MFILE "minAltitude      = SPIRAL_DESCENT_ALTITUDE; \r\n";
-			print MFILE "} \r\n";
-			print MFILE "# \r\n";
+			if (magcalibrate) 
+				{
+				print MFILE "behavior descend  \r\n";
+				print MFILE "{ \r\n";
+				printf MFILE "duration         = %d; \r\n", (0.5 * $descendtimes[$i]);
+				print MFILE "horizontalMode   = rudder; \r\n";
+				print MFILE "horizontal       = DESCENDRUDDER; \r\n";
+				print MFILE "pitch            = DESCENDPITCH; \r\n";
+				print MFILE "speed            = ASCENTDESCENT_SPEED; \r\n";
+				print MFILE "maxDepth         = SPIRAL_DESCENT_DEPTH; \r\n";
+				print MFILE "minAltitude      = SPIRAL_DESCENT_ALTITUDE; \r\n";
+				print MFILE "} \r\n";
+				print MFILE "# \r\n";
+				
+				print MFILE "behavior descend  \r\n";
+				print MFILE "{ \r\n";
+				printf MFILE "duration         = 240; \r\n";
+				print MFILE "horizontalMode   = rudder; \r\n";
+				print MFILE "horizontal       = -DESCENDRUDDER; \r\n";
+				print MFILE "pitch            = 0.0; \r\n";
+				print MFILE "speed            = ASCENTDESCENT_SPEED; \r\n";
+				print MFILE "maxDepth         = SPIRAL_DESCENT_DEPTH; \r\n";
+				print MFILE "minAltitude      = SPIRAL_DESCENT_ALTITUDE; \r\n";
+				print MFILE "} \r\n";
+				print MFILE "# \r\n";
+				
+				print MFILE "behavior descend  \r\n";
+				print MFILE "{ \r\n";
+				printf MFILE "duration         = 240; \r\n";
+				print MFILE "horizontalMode   = rudder; \r\n";
+				print MFILE "horizontal       = DESCENDRUDDER; \r\n";
+				print MFILE "pitch            = 0.0; \r\n";
+				print MFILE "speed            = ASCENTDESCENT_SPEED; \r\n";
+				print MFILE "maxDepth         = SPIRAL_DESCENT_DEPTH; \r\n";
+				print MFILE "minAltitude      = SPIRAL_DESCENT_ALTITUDE; \r\n";
+				print MFILE "} \r\n";
+				print MFILE "# \r\n";
+				
+				print MFILE "behavior descend  \r\n";
+				print MFILE "{ \r\n";
+				printf MFILE "duration         = %d; \r\n", (0.5 * $descendtimes[$i]);
+				print MFILE "horizontalMode   = rudder; \r\n";
+				print MFILE "horizontal       = DESCENDRUDDER; \r\n";
+				print MFILE "pitch            = DESCENDPITCH; \r\n";
+				print MFILE "speed            = ASCENTDESCENT_SPEED; \r\n";
+				print MFILE "maxDepth         = SPIRAL_DESCENT_DEPTH_HALF; \r\n";
+				print MFILE "minAltitude      = SPIRAL_DESCENT_ALTITUDE; \r\n";
+				print MFILE "} \r\n";
+				print MFILE "# \r\n";
+				
 print "Behavior: spiral descend\n";
-      if ($startsurvey == 1)
-        {
-  			print MFILE "# Kearfott behavior - turn DVL aiding off for descent \r\n";
-  			print MFILE "# \r\n";
-  			print MFILE "behavior kearfott \r\n";
-  			print MFILE "{ \r\n";
-  			print MFILE "duration  = 2; \r\n";
-  			print MFILE "enableDopAid = False; \r\n";
-  			print MFILE "} \r\n";
+				}
+			else 
+				{
+				print MFILE "behavior descend  \r\n";
+				print MFILE "{ \r\n";
+				printf MFILE "duration         = %d; \r\n", $descendtimes[$i];
+				print MFILE "horizontalMode   = rudder; \r\n";
+				print MFILE "horizontal       = DESCENDRUDDER; \r\n";
+				print MFILE "pitch            = DESCENDPITCH; \r\n";
+				print MFILE "speed            = ASCENTDESCENT_SPEED; \r\n";
+				print MFILE "maxDepth         = SPIRAL_DESCENT_DEPTH; \r\n";
+				print MFILE "minAltitude      = SPIRAL_DESCENT_ALTITUDE; \r\n";
+				print MFILE "} \r\n";
+				print MFILE "# \r\n";
+print "Behavior: spiral descend\n";
+				}
+      		if ($startsurvey == 1)
+        		{
+  				print MFILE "# Kearfott behavior - turn DVL aiding off for descent \r\n";
+  				print MFILE "# \r\n";
+  				print MFILE "behavior kearfott \r\n";
+  				print MFILE "{ \r\n";
+  				print MFILE "duration  = 2; \r\n";
+  				print MFILE "enableDopAid = False; \r\n";
+  				print MFILE "} \r\n";
 print "Behavior: kearfott (disable DVL aiding)\n";
-      }
+      			}
 			print MFILE "# Acoustic update 3 - sent status ping at start of descent \r\n";
 			print MFILE "# \r\n";
 			print MFILE "behavior acousticUpdate \r\n";

--- a/src/mbgrdviz/mbgrdviz_callbacks.c
+++ b/src/mbgrdviz/mbgrdviz_callbacks.c
@@ -73,10 +73,11 @@
 #define MBGRDVIZ_SAVEDEGDECMIN 13
 #define MBGRDVIZ_SAVELNW 14
 #define MBGRDVIZ_SAVEGREENSEAYML 15
-#define MBGRDVIZ_SAVESITE 16
-#define MBGRDVIZ_SAVESITEWPT 17
-#define MBGRDVIZ_SAVEPROFILE 18
-#define MBGRDVIZ_REALTIME 19
+#define MBGRDVIZ_SAVETECDISLST 16
+#define MBGRDVIZ_SAVESITE 17
+#define MBGRDVIZ_SAVESITEWPT 18
+#define MBGRDVIZ_SAVEPROFILE 19
+#define MBGRDVIZ_REALTIME 20
 
 /* Projection defines */
 #define ModelTypeProjected 1
@@ -144,6 +145,8 @@ void do_mbgrdviz_fileSelectionBox_openvector(Widget w, XtPointer client_data, Xt
 void do_mbgrdviz_fileSelectionBox_opensite(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_fileSelectionBox_opennav(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_fileSelectionBox_openswath(Widget w, XtPointer client_data, XtPointer call_data);
+void do_mbgrdviz_fileSelectionBox_savesite(Widget w, XtPointer client_data, XtPointer call_data);
+void do_mbgrdviz_fileSelectionBox_savesitewpt(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_fileSelectionBox_saveroute(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_fileSelectionBox_saverisiscriptheading(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_fileSelectionBox_saverisiscriptnoheading(Widget w, XtPointer client_data, XtPointer call_data);
@@ -151,22 +154,22 @@ void do_mbgrdviz_fileSelectionBox_savewinfrogpts(Widget w, XtPointer client_data
 void do_mbgrdviz_fileSelectionBox_savewinfrogwpt(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_fileSelectionBox_savedegdecmin(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_fileSelectionBox_savelnw(Widget w, XtPointer client_data, XtPointer call_data);
+void do_mbgrdviz_fileSelectionBox_savetecdislst(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_fileSelectionBox_saveprofile(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_fileSelectionBox_realtime(Widget w, XtPointer client_data, XtPointer call_data);
-void do_mbgrdviz_fileSelectionBox_savesite(Widget w, XtPointer client_data, XtPointer call_data);
-void do_mbgrdviz_fileSelectionBox_savesitewpt(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_openfile(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_close(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_quit(Widget w, XtPointer client_data, XtPointer call_data);
 int do_mbgrdviz_openprimary(char *input_file_ptr);
 int do_mbgrdviz_openoverlay(size_t instance, char *input_file_ptr);
 int do_mbgrdviz_opensite(size_t instance, char *input_file_ptr);
+int do_mbgrdviz_opennav(size_t instance, bool swathbounds, char *input_file_ptr);
+int do_mbgrdviz_openroute(size_t instance, char *input_file_ptr);
+int do_mbgrdviz_openvector(size_t instance, char *input_file_ptr);
 int do_mbgrdviz_savesite(size_t instance, char *output_file_ptr);
 int do_mbgrdviz_savesitewpt(size_t instance, char *output_file_ptr);
-int do_mbgrdviz_openroute(size_t instance, char *input_file_ptr);
 int do_mbgrdviz_saveroute(size_t instance, char *output_file_ptr);
 int do_mbgrdviz_saveroutereversed(size_t instance, char *output_file_ptr);
-int do_mbgrdviz_openvector(size_t instance, char *input_file_ptr);
 int do_mbgrdviz_saverisiscriptheading(size_t instance, char *output_file_ptr);
 int do_mbgrdviz_saverisiscriptnoheading(size_t instance, char *output_file_ptr);
 int do_mbgrdviz_savewinfrogpts(size_t instance, char *output_file_ptr);
@@ -174,8 +177,8 @@ int do_mbgrdviz_savewinfrogwpt(size_t instance, char *output_file_ptr);
 int do_mbgrdviz_savedegdecmin(size_t instance, char *output_file_ptr);
 int do_mbgrdviz_savelnw(size_t instance, char *output_file_ptr);
 int do_mbgrdviz_savegreenseayml(size_t instance, char *output_file_ptr);
+int do_mbgrdviz_savetecdislst(size_t instance, char *output_file_ptr);
 int do_mbgrdviz_saveprofile(size_t instance, char *output_file_ptr);
-int do_mbgrdviz_opennav(size_t instance, bool swathbounds, char *input_file_ptr);
 int do_mbgrdviz_readnav(size_t instance, char *swathfile, int pathstatus, char *pathraw, char *pathprocessed, int format,
                         int formatorg, double weight, int *error);
 int do_mbgrdviz_readgrd(size_t instance, char *grdfile, int *grid_projection_mode, char *grid_projection_id, float *nodatavalue,
@@ -184,11 +187,11 @@ int do_mbgrdviz_readgrd(size_t instance, char *grdfile, int *grid_projection_mod
 int do_mbgrdviz_opentest(size_t instance, double factor1, double factor2, double factor3, int *grid_projection_mode,
                          char *grid_projection_id, float *nodatavalue, int *nxy, int *n_columns, int *n_rows, double *min, double *max,
                          double *xmin, double *xmax, double *ymin, double *ymax, double *dx, double *dy, float **data);
-void do_mbgrdviz_open_region(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_open_mbedit(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_open_mbeditviz(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_open_mbnavedit(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_open_mbvelocitytool(Widget w, XtPointer client_data, XtPointer call_data);
+void do_mbgrdviz_open_region(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_make_survey(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_generate_survey(Widget w, XtPointer client_data, XtPointer call_data);
 void do_mbgrdviz_arearoute_dismiss(Widget w, XtPointer client_data, XtPointer call_data);
@@ -1212,6 +1215,39 @@ void do_mbgrdviz_fileSelectionBox_savegreenseayml(Widget w, XtPointer client_dat
   XmStringFree((XmString)tmp0);
 }
 /*---------------------------------------------------------------------------------------*/
+void do_mbgrdviz_fileSelectionBox_savetecdislst(Widget w, XtPointer client_data, XtPointer call_data) {
+
+  if (verbose >= 2) {
+    fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
+    fprintf(stderr, "dbg2  Input arguments:\n");
+    fprintf(stderr, "dbg2       w:           %p\n", w);
+    fprintf(stderr, "dbg2       client_data: %p\n", client_data);
+    fprintf(stderr, "dbg2       call_data:   %p\n", call_data);
+  }
+
+  const size_t instance = (size_t)client_data;
+
+  /* set title to open file dialog  */
+  Cardinal ac = 0;
+  Arg args[256];
+  XtSetArg(args[ac], XmNtitle, "Save Route as TECDIS LST File");
+  ac++;
+  XtSetValues(dialogShell_open, args, ac);
+  BxManageCB(w, (XtPointer) "fileSelectionBox", call_data);
+
+  /* set fileSelectionBox parameters */
+  ac = 0;
+  Boolean argok;
+  XmString tmp0 = (XmString)BX_CONVERT(dialogShell_open, "*", XmRXmString, 0, &argok);
+  XtSetArg(args[ac], XmNpattern, tmp0);
+  ac++;
+  const size_t actionid = MBGRDVIZ_SAVETECDISLST * MBV_MAX_WINDOWS + instance;
+  XtSetArg(args[ac], XmNuserData, (XtPointer)actionid);
+  ac++;
+  XtSetValues(fileSelectionBox, args, ac);
+  XmStringFree((XmString)tmp0);
+}
+/*---------------------------------------------------------------------------------------*/
 void do_mbgrdviz_fileSelectionBox_saveprofile(Widget w, XtPointer client_data, XtPointer call_data) {
 
   if (verbose >= 2) {
@@ -1503,19 +1539,26 @@ void do_mbgrdviz_openfile(Widget w, XtPointer client_data, XtPointer call_data) 
     /* status = */ do_mbgrdviz_savedegdecmin(instance, file_ptr);
   }
 
-    /* else write route data as Hypack lnw file */
-    else if (mode == MBGRDVIZ_SAVELNW) {
-      /* write route file */
-      do_mbview_message_on("Saving route as Hypack LNW file...", instance);
-      /* status = */ do_mbgrdviz_savelnw(instance, file_ptr);
-    }
+  /* else write route data as Hypack lnw file */
+  else if (mode == MBGRDVIZ_SAVELNW) {
+    /* write route file */
+    do_mbview_message_on("Saving route as Hypack LNW file...", instance);
+    /* status = */ do_mbgrdviz_savelnw(instance, file_ptr);
+  }
 
-      /* else write route data as Hypack lnw file */
-      else if (mode == MBGRDVIZ_SAVEGREENSEAYML) {
-        /* write route file */
-        do_mbview_message_on("Saving route as Greensea YML file...", instance);
-        /* status = */ do_mbgrdviz_savegreenseayml(instance, file_ptr);
-      }
+  /* else write route data as Hypack lnw file */
+  else if (mode == MBGRDVIZ_SAVEGREENSEAYML) {
+    /* write route file */
+    do_mbview_message_on("Saving route as Greensea YML file...", instance);
+    /* status = */ do_mbgrdviz_savegreenseayml(instance, file_ptr);
+  }
+
+  /* else write route data as TECDIS lst file */
+  else if (mode == MBGRDVIZ_SAVETECDISLST) {
+    /* write route file */
+    do_mbview_message_on("Saving route as TECDIS LST file...", instance);
+    /* status = */ do_mbgrdviz_savetecdislst(instance, file_ptr);
+  }
 
   /* else write route data */
   else if (mode == MBGRDVIZ_SAVEPROFILE) {
@@ -1862,6 +1905,8 @@ int do_mbgrdviz_openprimary(char *input_file_ptr) {
         mbview_addaction(verbose, instance, do_mbgrdviz_fileSelectionBox_savelnw, "Save Route as Hypack LNW File",
                          MBV_EXISTMASK_ROUTE, &error);
         mbview_addaction(verbose, instance, do_mbgrdviz_fileSelectionBox_savegreenseayml, "Save Route as Greensea YML File",
+                          MBV_EXISTMASK_ROUTE, &error);
+        mbview_addaction(verbose, instance, do_mbgrdviz_fileSelectionBox_savetecdislst, "Save Route as TECDIS LST File",
                           MBV_EXISTMASK_ROUTE, &error);
         mbview_addaction(verbose, instance, do_mbgrdviz_fileSelectionBox_saveprofile, "Save Profile File",
                          MBV_PICKMASK_TWOPOINT + MBV_PICKMASK_ROUTE + MBV_PICKMASK_NAVTWOPOINT, &error);
@@ -4080,6 +4125,142 @@ int do_mbgrdviz_savegreenseayml(size_t instance, char *output_file_ptr) {
 #ifdef USE_UUID
         status = mb_freed(verbose, __FILE__, __LINE__, (void **)&waypoints_uuid, &error);
 #endif
+      }
+    }
+  }
+
+  /* all done */
+  return (status);
+}
+/*---------------------------------------------------------------------------------------*/
+
+int do_mbgrdviz_savetecdislst(size_t instance, char *output_file_ptr) {
+  int status = MB_SUCCESS;
+  FILE *sfp;
+  int nroute = 0;
+  int npoint = 0;
+  int nintpoint = 0;
+  int npointtotal = 0;
+  int npointalloc = 0;
+  double *routelon = NULL;
+  double *routelat = NULL;
+  int *routewaypoint = NULL;
+  double *routetopo = NULL;
+  double *routebearing = NULL;
+  double *distlateral = NULL;
+  double *distovertopo = NULL;
+  double *slope = NULL;
+  int routecolor;
+  int routesize;
+  mb_path routename;
+  char latNS, lonEW;
+  int latDeg, lonDeg;
+  double latMin, lonMin;
+  int iroute, j, n;
+
+  if (verbose >= 2) {
+    fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
+    fprintf(stderr, "dbg2  Input arguments:\n");
+    fprintf(stderr, "dbg2       instance:        %zu\n", instance);
+    fprintf(stderr, "dbg2       output_file_ptr: %s\n", output_file_ptr);
+  }
+
+  /* read data for valid instance */
+  if (instance != MBV_NO_WINDOW) {
+
+    /* get the number of routes to be written to the output file */
+    status = mbview_getroutecount(verbose, instance, &nroute, &error);
+    if (nroute <= 0) {
+      fprintf(stderr, "Unable to write TECDIS LST route file...\nCurrently %d routes defined for instance %zu!\n", nroute, instance);
+      XBell((Display *)XtDisplay(mainWindow), 100);
+      status = MB_FAILURE;
+    }
+
+    /* initialize the output file */
+    if (status == MB_SUCCESS && nroute > 0) {
+      /* open the output file */
+      if ((sfp = fopen(output_file_ptr, "w")) == NULL) {
+        error = MB_ERROR_OPEN_FAIL;
+        status = MB_FAILURE;
+        fprintf(stderr, "\nUnable to open route file <%s> for writing\n", output_file_ptr);
+        XBell((Display *)XtDisplay(mainWindow), 100);
+      }
+    }
+
+    /* if all ok proceed to extract and output routes */
+    if (status == MB_SUCCESS) {
+      /* loop over routes */
+      for (iroute = 0; iroute < nroute; iroute++) {
+        /* get point count for current route */
+        status = mbview_getroutepointcount(verbose, instance, iroute, &npoint, &nintpoint, &error);
+
+        /* allocate route arrays */
+        npointtotal = npoint + nintpoint;
+        if (status == MB_SUCCESS && npointalloc < npointtotal) {
+          status = mbview_allocroutearrays(verbose, npointtotal, &routelon, &routelat, &routewaypoint, &routetopo,
+                                           &routebearing, &distlateral, &distovertopo, &slope, &error);
+          if (status == MB_SUCCESS) {
+            npointalloc = npointtotal;
+          }
+
+          /* if error initializing memory then cancel dealing with this route */
+          else {
+            fprintf(stderr, "Unable to write TECDIS LST route file...\nArray allocation for %d points failed for instance %zu!\n",
+                    npointtotal, instance);
+            XBell((Display *)XtDisplay(mainWindow), 100);
+            npoint = 0;
+            nintpoint = 0;
+            npointtotal = 0;
+          }
+        }
+
+        /* extract data for route */
+        status =
+            mbview_getroute(verbose, instance, iroute, &npointtotal, routelon, routelat, routewaypoint, routetopo,
+                            routebearing, distlateral, distovertopo, slope, &routecolor, &routesize, routename, &error);
+
+        /* write the route points */
+        n = 0;
+        for (j = 0; j < npointtotal; j++) {
+          if (routewaypoint[j] != MBV_ROUTE_WAYPOINT_NONE) {
+            n++;
+          }
+        }
+        if (iroute > 0)
+          fprintf(sfp, "#\r\n");
+        fprintf(sfp, "# Route: %s\r\n", routename);
+        fprintf(sfp, "# Number of waypoints: %d\r\n", n);
+        for (j = 0; j < npointtotal; j++) {
+          if (routewaypoint[j] != MBV_ROUTE_WAYPOINT_NONE) {
+            if (routelat[j] >= 0.0)
+              latNS = 'N';
+            else
+              latNS = 'S';
+            latDeg = (int)(floor(fabs(routelat[j])));
+            latMin = (fabs(routelat[j]) - (double)latDeg) * 60.0;
+            if (routelon[j] >= 0.0)
+              lonEW = 'E';
+            else
+              lonEW = 'W';
+            lonDeg = (int)(floor(fabs(routelon[j])));
+            lonMin = (fabs(routelon[j]) - (double)lonDeg) * 60.0;
+
+			if (j == 0) {
+              fprintf(sfp, "$PTLKR,0,0,%s\r\n", output_file_ptr);
+              fprintf(sfp, "$PTLKP,8,%2.2d%9.6f,%c,%3.3d%9.6f,%c\r\n", latDeg, latMin, latNS, lonDeg, lonMin, lonEW);
+			}
+            fprintf(sfp, "$PTLKP,9,%2.2d%9.6f,%c,%3.3d%9.6f,%c\r\n", latDeg, latMin, latNS, lonDeg, lonMin, lonEW);
+          }
+        }
+      }
+
+      /* close the output file */
+      fclose(sfp);
+
+      /* deallocate arrays */
+      if (npointalloc > 0) {
+        status = mbview_freeroutearrays(verbose, &routelon, &routelat, &routewaypoint, &routetopo, &routebearing,
+                                        &distlateral, &distovertopo, &slope, &error);
       }
     }
   }

--- a/src/mbio/mbr_em300mba.c
+++ b/src/mbio/mbr_em300mba.c
@@ -344,9 +344,9 @@ int mbr_em300mba_chk_label(int verbose, void *mbio_ptr, char *label, short *type
 int mbr_em300mba_rd_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short type, short sonar,
                           int *version, int *error) {
 	char line[MBSYS_SIMRAD2_BUFFER_SIZE];
-	unsigned short short_val = 0;
+	unsigned short ushort_val = 0;
 	unsigned int read_len = 0;
-  unsigned int len = 0;
+  	unsigned int len = 0;
 	char *comma_ptr = NULL;
 	int i1, i2, i3;
 
@@ -385,12 +385,12 @@ int mbr_em300mba_rd_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 		store->date = store->par_date;
 		mb_get_binary_int(swap, &line[4], &store->par_msec);
 		store->msec = store->par_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->par_line_num = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->par_serial_1 = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		store->par_serial_2 = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->par_line_num = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->par_serial_1 = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		store->par_serial_2 = (int)(ushort_val);
 	}
 
 	/* check for dual head sonars */
@@ -710,7 +710,7 @@ file will return error */
 int mbr_em300mba_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar,
                                   int *error) {
 	char line[EM2_RUN_PARAMETER_SIZE];
-	unsigned short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -747,31 +747,31 @@ int mbr_em300mba_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 		mb_get_binary_int(swap, &line[4], &store->run_msec);
 		if (store->run_date != 0)
 			store->msec = store->run_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->run_ping_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->run_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->run_ping_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->run_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->run_status);
 		store->run_mode = (mb_u_char)line[16];
 		store->run_filter_id = (mb_u_char)line[17];
-		mb_get_binary_short(swap, &line[18], &short_val);
-		store->run_min_depth = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		store->run_max_depth = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[22], &short_val);
-		store->run_absorption = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[24], &short_val);
-		store->run_tran_pulse = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[26], &short_val);
-		store->run_tran_beam = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[18], &ushort_val);
+		store->run_min_depth = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		store->run_max_depth = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		store->run_absorption = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[24], &ushort_val);
+		store->run_tran_pulse = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[26], &ushort_val);
+		store->run_tran_beam = (int)(ushort_val);
 		store->run_tran_pow = (mb_u_char)line[28];
 		store->run_rec_beam = (mb_u_char)line[29];
 		store->run_rec_band = (mb_u_char)line[30];
 		store->run_rec_gain = (mb_u_char)line[31];
 		store->run_tvg_cross = (mb_u_char)line[32];
 		store->run_ssv_source = (mb_u_char)line[33];
-		mb_get_binary_short(swap, &line[34], &short_val);
-		store->run_max_swath = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[34], &ushort_val);
+		store->run_max_swath = (int)(ushort_val);
 		store->run_beam_space = (mb_u_char)line[36];
 		store->run_swath_angle = (mb_u_char)line[37];
 		store->run_stab_mode = (mb_u_char)line[38];
@@ -829,7 +829,7 @@ int mbr_em300mba_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char line[EM2_CLOCK_SIZE];
-	unsigned short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -864,10 +864,10 @@ int mbr_em300mba_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 		store->date = store->clk_date;
 		mb_get_binary_int(swap, &line[4], &store->clk_msec);
 		store->msec = store->clk_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->clk_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->clk_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->clk_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->clk_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->clk_origin_date);
 		mb_get_binary_int(swap, &line[16], &store->clk_origin_msec);
 		store->clk_1_pps_use = (mb_u_char)line[20];
@@ -905,7 +905,8 @@ int mbr_em300mba_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char line[EM2_TIDE_SIZE];
-	unsigned short short_val = 0;
+	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -940,10 +941,10 @@ int mbr_em300mba_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		store->date = store->tid_date;
 		mb_get_binary_int(swap, &line[4], &store->tid_msec);
 		store->msec = store->tid_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->tid_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->tid_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->tid_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->tid_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->tid_origin_date);
 		mb_get_binary_int(swap, &line[16], &store->tid_origin_msec);
 		mb_get_binary_short(swap, &line[20], &short_val);
@@ -982,7 +983,7 @@ int mbr_em300mba_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char line[EM2_HEIGHT_SIZE];
-	unsigned short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1017,10 +1018,10 @@ int mbr_em300mba_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 		store->date = store->hgt_date;
 		mb_get_binary_int(swap, &line[4], &store->hgt_msec);
 		store->msec = store->hgt_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->hgt_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->hgt_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->hgt_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->hgt_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->hgt_height);
 		store->hgt_type = (mb_u_char)line[16];
 #ifdef MBR_EM300MBA_DEBUG
@@ -1057,7 +1058,7 @@ int mbr_em300mba_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 int mbr_em300mba_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	struct mbsys_simrad2_heading_struct *heading;
 	char line[EM2_HEADING_HEADER_SIZE];
-	unsigned short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1095,12 +1096,12 @@ int mbr_em300mba_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 		store->date = heading->hed_date;
 		mb_get_binary_int(swap, &line[4], &heading->hed_msec);
 		store->msec = heading->hed_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		heading->hed_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		heading->hed_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		heading->hed_ndata = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		heading->hed_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		heading->hed_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		heading->hed_ndata = (int)(ushort_val);
 	}
 
 	/* read binary heading values */
@@ -1109,10 +1110,10 @@ int mbr_em300mba_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 			read_len = fread(line, 1, EM2_HEADING_SLICE_SIZE, mbfp);
 			if (read_len == EM2_HEADING_SLICE_SIZE && i < MBSYS_SIMRAD2_MAXHEADING) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				heading->hed_time[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[2], &short_val);
-				heading->hed_heading[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				heading->hed_time[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				heading->hed_heading[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -1173,7 +1174,7 @@ int mbr_em300mba_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 int mbr_em300mba_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	struct mbsys_simrad2_ssv_struct *ssv;
 	char line[EM2_SSV_HEADER_SIZE];
-	unsigned short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1211,12 +1212,12 @@ int mbr_em300mba_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		store->date = ssv->ssv_date;
 		mb_get_binary_int(swap, &line[4], &ssv->ssv_msec);
 		store->msec = ssv->ssv_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ssv->ssv_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ssv->ssv_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		ssv->ssv_ndata = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ssv->ssv_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ssv->ssv_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		ssv->ssv_ndata = (int)(ushort_val);
 	}
 
 	/* read binary heading values */
@@ -1225,10 +1226,10 @@ int mbr_em300mba_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 			read_len = fread(line, 1, EM2_SSV_SLICE_SIZE, mbfp);
 			if (read_len == EM2_SSV_SLICE_SIZE && i < MBSYS_SIMRAD2_MAXSSV) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				ssv->ssv_time[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[2], &short_val);
-				ssv->ssv_ssv[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				ssv->ssv_time[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				ssv->ssv_ssv[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -1287,7 +1288,7 @@ int mbr_em300mba_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 int mbr_em300mba_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	struct mbsys_simrad2_tilt_struct *tilt;
 	char line[EM2_TILT_HEADER_SIZE];
-	unsigned short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1325,12 +1326,12 @@ int mbr_em300mba_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		store->date = tilt->tlt_date;
 		mb_get_binary_int(swap, &line[4], &tilt->tlt_msec);
 		store->msec = tilt->tlt_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		tilt->tlt_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		tilt->tlt_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		tilt->tlt_ndata = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		tilt->tlt_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		tilt->tlt_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		tilt->tlt_ndata = (int)(ushort_val);
 	}
 
 	/* read binary tilt values */
@@ -1339,10 +1340,10 @@ int mbr_em300mba_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 			read_len = fread(line, 1, EM2_TILT_SLICE_SIZE, mbfp);
 			if (read_len == EM2_TILT_SLICE_SIZE && i < MBSYS_SIMRAD2_MAXTILT) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				tilt->tlt_time[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[2], &short_val);
-				tilt->tlt_tilt[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				tilt->tlt_time[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				tilt->tlt_tilt[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -1402,7 +1403,7 @@ int mbr_em300mba_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
                                     int *error) {
 	struct mbsys_simrad2_extraparameters_struct *extraparameters;
 	char line[EM2_EXTRAPARAMETERS_HEADER_SIZE];
-	unsigned short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1440,12 +1441,12 @@ int mbr_em300mba_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 		store->date = extraparameters->xtr_date;
 		mb_get_binary_int(swap, &line[4], &extraparameters->xtr_msec);
 		store->msec = extraparameters->xtr_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		extraparameters->xtr_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		extraparameters->xtr_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		extraparameters->xtr_id = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		extraparameters->xtr_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		extraparameters->xtr_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		extraparameters->xtr_id = (int)(ushort_val);
 	}
 
 	/* read data */
@@ -1538,7 +1539,8 @@ int mbr_em300mba_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 int mbr_em300mba_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	struct mbsys_simrad2_attitude_struct *attitude;
 	char line[EM2_ATTITUDE_HEADER_SIZE];
-	unsigned short short_val = 0;
+	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1576,12 +1578,12 @@ int mbr_em300mba_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 		store->date = attitude->att_date;
 		mb_get_binary_int(swap, &line[4], &attitude->att_msec);
 		store->msec = attitude->att_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		attitude->att_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		attitude->att_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		attitude->att_ndata = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		attitude->att_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		attitude->att_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		attitude->att_ndata = (int)(ushort_val);
 	}
 
 	/* read binary attitude values */
@@ -1590,18 +1592,18 @@ int mbr_em300mba_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 			read_len = fread(line, 1, EM2_ATTITUDE_SLICE_SIZE, mbfp);
 			if (read_len == EM2_ATTITUDE_SLICE_SIZE && i < MBSYS_SIMRAD2_MAXATTITUDE) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				attitude->att_time[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[2], &short_val);
-				attitude->att_sensor_status[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				attitude->att_time[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				attitude->att_sensor_status[i] = (int)(ushort_val);
 				mb_get_binary_short(swap, &line[4], &short_val);
 				attitude->att_roll[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[6], &short_val);
 				attitude->att_pitch[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[8], &short_val);
 				attitude->att_heave[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[10], &short_val);
-				attitude->att_heading[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[10], &ushort_val);
+				attitude->att_heading[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -1662,7 +1664,7 @@ int mbr_em300mba_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char line[MBSYS_SIMRAD2_COMMENT_LENGTH];
-	unsigned short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 	int navchannel;
 
@@ -1698,20 +1700,20 @@ int mbr_em300mba_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		store->date = store->pos_date;
 		mb_get_binary_int(swap, &line[4], &store->pos_msec);
 		store->msec = store->pos_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->pos_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->pos_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->pos_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->pos_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->pos_latitude);
 		mb_get_binary_int(swap, &line[16], &store->pos_longitude);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		store->pos_quality = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[22], &short_val);
-		store->pos_speed = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[24], &short_val);
-		store->pos_course = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[26], &short_val);
-		store->pos_heading = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		store->pos_quality = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		store->pos_speed = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[24], &ushort_val);
+		store->pos_course = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[26], &ushort_val);
+		store->pos_heading = (int)(ushort_val);
 		store->pos_system = (mb_u_char)line[28];
 		store->pos_input_size = (mb_u_char)line[29];
 	}
@@ -1824,7 +1826,7 @@ int mbr_em300mba_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char line[EM2_SVP_HEADER_SIZE];
-	unsigned short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1859,16 +1861,16 @@ int mbr_em300mba_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		store->date = store->svp_use_date;
 		mb_get_binary_int(swap, &line[4], &store->svp_use_msec);
 		store->msec = store->svp_use_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->svp_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->svp_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->svp_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->svp_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->svp_origin_date);
 		mb_get_binary_int(swap, &line[16], &store->svp_origin_msec);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		store->svp_num = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[22], &short_val);
-		store->svp_depth_res = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		store->svp_num = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		store->svp_depth_res = (int)(ushort_val);
 	}
 
 	/* read binary svp values */
@@ -1881,10 +1883,10 @@ int mbr_em300mba_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 			}
 			else if (i < MBSYS_SIMRAD2_MAXSVP) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				store->svp_depth[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[2], &short_val);
-				store->svp_vel[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				store->svp_depth[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				store->svp_vel[i] = (int)(ushort_val);
 			}
 		}
 		store->svp_num = MIN(store->svp_num, MBSYS_SIMRAD2_MAXSVP);
@@ -1941,7 +1943,7 @@ int mbr_em300mba_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 /*--------------------------------------------------------------------*/
 int mbr_em300mba_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	char line[EM2_SVP2_HEADER_SIZE];
-	unsigned short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1976,16 +1978,16 @@ int mbr_em300mba_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		store->date = store->svp_use_date;
 		mb_get_binary_int(swap, &line[4], &store->svp_use_msec);
 		store->msec = store->svp_use_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->svp_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->svp_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->svp_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->svp_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->svp_origin_date);
 		mb_get_binary_int(swap, &line[16], &store->svp_origin_msec);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		store->svp_num = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[22], &short_val);
-		store->svp_depth_res = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		store->svp_num = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		store->svp_depth_res = (int)(ushort_val);
 	}
 
 	/* read binary svp values */
@@ -2058,7 +2060,8 @@ int mbr_em300mba_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
                          int version, int *error) {
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_BATH_MBA_HEADER_SIZE];
-	unsigned short short_val = 0;
+	short short_val = 0;
+	unsigned short ushort_val = 0;
 	int png_count;
 	int png_serial;
 	size_t read_len;
@@ -2095,10 +2098,10 @@ int mbr_em300mba_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 
 	/* in case of EM3002 check if the data are from the second head and switch ping structure if so */
 	if (status == MB_SUCCESS && sonar == MBSYS_SIMRAD2_EM3002 && store->numberheads == 2) {
-		mb_get_binary_short(swap, &line[8], &short_val);
-		png_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		png_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		png_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		png_serial = (int)(ushort_val);
 
 		if (png_count == ping->png_count && png_serial != ping->png_serial) {
 			ping = (struct mbsys_simrad2_ping_struct *)store->ping2;
@@ -2111,26 +2114,26 @@ int mbr_em300mba_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		store->date = ping->png_date;
 		mb_get_binary_int(swap, &line[4], &ping->png_msec);
 		store->msec = ping->png_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ping->png_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ping->png_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ping->png_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ping->png_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &ping->png_latitude);
 		mb_get_binary_int(swap, &line[16], &ping->png_longitude);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		ping->png_speed = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[22], &short_val);
-		ping->png_heading = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[24], &short_val);
-		ping->png_ssv = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[26], &short_val);
-		ping->png_xducer_depth = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		ping->png_speed = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		ping->png_heading = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[24], &ushort_val);
+		ping->png_ssv = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[26], &ushort_val);
+		ping->png_xducer_depth = (int)(ushort_val);
 		ping->png_nbeams_max = (mb_u_char)line[28];
 		ping->png_nbeams = (mb_u_char)line[29];
 		ping->png_depth_res = (mb_u_char)line[30];
 		ping->png_distance_res = (mb_u_char)line[31];
 		mb_get_binary_short(swap, &line[32], &short_val);
-		ping->png_sample_rate = (int)((unsigned short)short_val);
+		ping->png_sample_rate = (int)(short_val);
 	}
 
 	/* check for some indicators of a broken record
@@ -2149,28 +2152,31 @@ int mbr_em300mba_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 			read_len = fread(line, 1, EM2_BATH_MBA_BEAM_SIZE, mbfp);
 			if (read_len == EM2_BATH_MBA_BEAM_SIZE && i < MBSYS_SIMRAD2_MAXBEAMS) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
 				if (store->sonar == MBSYS_SIMRAD2_EM120 || store->sonar == MBSYS_SIMRAD2_EM300 ||
 				    store->sonar == MBSYS_SIMRAD2_EM12S || store->sonar == MBSYS_SIMRAD2_EM12D ||
 				    store->sonar == MBSYS_SIMRAD2_EM121 || store->sonar == MBSYS_SIMRAD2_EM100 ||
-				    store->sonar == MBSYS_SIMRAD2_EM1000)
-					ping->png_depth[i] = (int)((unsigned short)short_val);
-				else
+				    store->sonar == MBSYS_SIMRAD2_EM1000) {
+					mb_get_binary_short(swap, &line[0], &ushort_val);
+					ping->png_depth[i] = (int)(ushort_val);
+				}
+				else {
+					mb_get_binary_short(swap, &line[0], &short_val);
 					ping->png_depth[i] = (int)short_val;
+				}
 				mb_get_binary_short(swap, &line[2], &short_val);
 				ping->png_acrosstrack[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[4], &short_val);
 				ping->png_alongtrack[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[6], &short_val);
 				ping->png_depression[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[8], &short_val);
-				ping->png_azimuth[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[10], &short_val);
-				ping->png_range[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[8], &ushort_val);
+				ping->png_azimuth[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[10], &ushort_val);
+				ping->png_range[i] = (int)(ushort_val);
 				ping->png_quality[i] = (mb_u_char)line[12];
 				ping->png_window[i] = (mb_u_char)line[13];
 				mb_get_binary_short(swap, &line[14], &short_val);
-				ping->png_amp[i] = (int)((short)short_val);
+				ping->png_amp[i] = (int)(short_val);
 				ping->png_beam_num[i] = (mb_u_char)line[16];
 				ping->png_beamflag[i] = (char)line[17];
 			}
@@ -2267,7 +2273,8 @@ int mbr_em300mba_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 int mbr_em300mba_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM_HEADER_SIZE];
-	unsigned short short_val = 0;
+	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -2300,14 +2307,14 @@ int mbr_em300mba_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 		store->date = ping->png_raw_date;
 		mb_get_binary_int(swap, &line[4], &ping->png_raw_msec);
 		store->msec = ping->png_raw_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ping->png_raw_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ping->png_raw_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ping->png_raw_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ping->png_raw_serial = (int)(ushort_val);
 		ping->png_raw_nbeams_max = (mb_u_char)line[12];
 		ping->png_raw_nbeams = (mb_u_char)line[13];
-		mb_get_binary_short(swap, &line[14], &short_val);
-		ping->png_raw_ssv = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[14], &ushort_val);
+		ping->png_raw_ssv = (int)(ushort_val);
 	}
 
 	/* check for some indicators of a broken record
@@ -2330,8 +2337,8 @@ int mbr_em300mba_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 				ping->png_raw_rxpointangle[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[2], &short_val);
 				ping->png_raw_rxtiltangle[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[4], &short_val);
-				ping->png_raw_rxrange[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[4], &ushort_val);
+				ping->png_raw_rxrange[i] = (int)(ushort_val);
 				ping->png_raw_rxamp[i] = (mb_s_char)line[6];
 				ping->png_raw_rxbeam_num[i] = (mb_u_char)line[7];
 			}
@@ -2407,7 +2414,8 @@ int mbr_em300mba_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 int mbr_em300mba_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM2_HEADER_SIZE];
-	unsigned short short_val = 0;
+	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -2440,37 +2448,37 @@ int mbr_em300mba_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 		store->date = ping->png_raw_date;
 		mb_get_binary_int(swap, &line[4], &ping->png_raw_msec);
 		store->msec = ping->png_raw_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ping->png_raw_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ping->png_raw_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		ping->png_raw_heading = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[14], &short_val);
-		ping->png_raw_ssv = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[16], &short_val);
-		ping->png_raw_xducer_depth = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ping->png_raw_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ping->png_raw_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		ping->png_raw_heading = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[14], &ushort_val);
+		ping->png_raw_ssv = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[16], &ushort_val);
+		ping->png_raw_xducer_depth = (int)(ushort_val);
 		ping->png_raw_nbeams_max = (mb_u_char)line[18];
 		ping->png_raw_nbeams = (mb_u_char)line[19];
 		ping->png_raw_depth_res = (mb_u_char)line[20];
 		ping->png_raw_distance_res = (mb_u_char)line[21];
-		mb_get_binary_short(swap, &line[22], &short_val);
-		ping->png_raw_sample_rate = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		ping->png_raw_sample_rate = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[24], &ping->png_raw_status);
-		mb_get_binary_short(swap, &line[28], &short_val);
-		ping->png_raw_rangenormal = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[28], &ushort_val);
+		ping->png_raw_rangenormal = (int)(ushort_val);
 		ping->png_raw_normalbackscatter = (mb_s_char)line[30];
 		ping->png_raw_obliquebackscatter = (mb_s_char)line[31];
 		ping->png_raw_fixedgain = (mb_u_char)line[32];
 		ping->png_raw_txpower = (mb_s_char)line[33];
 		ping->png_raw_mode = (mb_u_char)line[34];
 		ping->png_raw_coverage = (mb_u_char)line[35];
-		mb_get_binary_short(swap, &line[36], &short_val);
-		ping->png_raw_yawstabheading = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[38], &short_val);
-		ping->png_raw_ntx = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[40], &short_val);
-		// spare = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[36], &ushort_val);
+		ping->png_raw_yawstabheading = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[38], &ushort_val);
+		ping->png_raw_ntx = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[40], &ushort_val);
+		// spare = (int)(ushort_val);
 	}
 
 	/* check for some indicators of a broken record
@@ -2490,12 +2498,12 @@ int mbr_em300mba_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 			read_len = fread(line, 1, EM2_RAWBEAM2_TX_SIZE, mbfp);
 			if (read_len == EM2_RAWBEAM2_TX_SIZE && i < MBSYS_SIMRAD2_MAXTX) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				ping->png_raw_txlastbeam[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				ping->png_raw_txlastbeam[i] = (int)(ushort_val);
 				mb_get_binary_short(swap, &line[2], &short_val);
 				ping->png_raw_txtiltangle[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[4], &short_val);
-				ping->png_raw_txheading[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[4], &ushort_val);
+				ping->png_raw_txheading[i] = (int)(ushort_val);
 				mb_get_binary_short(swap, &line[6], &short_val);
 				ping->png_raw_txroll[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[8], &short_val);
@@ -2516,16 +2524,16 @@ int mbr_em300mba_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 			read_len = fread(line, 1, EM2_RAWBEAM2_BEAM_SIZE, mbfp);
 			if (read_len == EM2_RAWBEAM2_BEAM_SIZE && i < MBSYS_SIMRAD2_MAXBEAMS) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				ping->png_raw_rxrange[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				ping->png_raw_rxrange[i] = (int)(ushort_val);
 				ping->png_raw_rxquality[i] = (mb_u_char)line[2];
 				ping->png_raw_rxwindow[i] = (mb_u_char)line[3];
 				ping->png_raw_rxamp[i] = (mb_s_char)line[4];
 				ping->png_raw_rxbeam_num[i] = (mb_u_char)line[5];
 				mb_get_binary_short(swap, &line[6], &short_val);
 				ping->png_raw_rxpointangle[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[8], &short_val);
-				ping->png_raw_rxheading[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[8], &ushort_val);
+				ping->png_raw_rxheading[i] = (int)(ushort_val);
 				mb_get_binary_short(swap, &line[10], &short_val);
 				ping->png_raw_rxroll[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[12], &short_val);
@@ -2632,7 +2640,8 @@ int mbr_em300mba_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 int mbr_em300mba_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[EM2_RAWBEAM3_HEADER_SIZE];
-	unsigned short short_val = 0;
+	short short_val = 0;
+	unsigned short ushort_val = 0;
 	int int_val = 0;
 	int png_raw3_count;
 	int png_raw3_serial;
@@ -2664,10 +2673,10 @@ int mbr_em300mba_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 
 	/* in case of EM3002 check if the data are from the second head and if so switch ping structure */
 	if (status == MB_SUCCESS && sonar == MBSYS_SIMRAD2_EM3002 && store->numberheads == 2) {
-		mb_get_binary_short(swap, &line[8], &short_val);
-		png_raw3_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		png_raw3_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		png_raw3_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		png_raw3_serial = (int)(ushort_val);
 
 		if (png_raw3_count == ping->png_raw3_count && png_raw3_serial != ping->png_raw3_serial) {
 			ping = (struct mbsys_simrad2_ping_struct *)store->ping2;
@@ -2680,22 +2689,22 @@ int mbr_em300mba_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 		store->date = ping->png_raw3_date;
 		mb_get_binary_int(swap, &line[4], &ping->png_raw3_msec);
 		store->msec = ping->png_raw3_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ping->png_raw3_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ping->png_raw3_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		ping->png_raw3_ntx = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[14], &short_val);
-		ping->png_raw3_nbeams = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ping->png_raw3_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ping->png_raw3_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		ping->png_raw3_ntx = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[14], &ushort_val);
+		ping->png_raw3_nbeams = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[16], &int_val);
 		ping->png_raw3_sample_rate = (int)(int_val);
 		mb_get_binary_int(swap, &line[20], &int_val);
 		ping->png_raw3_xducer_depth = (int)(int_val);
-		mb_get_binary_short(swap, &line[24], &short_val);
-		ping->png_raw3_ssv = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[26], &short_val);
-		ping->png_raw3_nbeams_max = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[24], &ushort_val);
+		ping->png_raw3_ssv = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[26], &ushort_val);
+		ping->png_raw3_nbeams_max = (int)(ushort_val);
 	}
 
 	/* check for some indicators of a broken record
@@ -2745,16 +2754,16 @@ int mbr_em300mba_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 				status = MB_SUCCESS;
 				mb_get_binary_short(swap, &line[0], &short_val);
 				ping->png_raw3_rxpointangle[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[2], &short_val);
-				ping->png_raw3_rxrange[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				ping->png_raw3_rxrange[i] = (int)(ushort_val);
 				ping->png_raw3_rxsector[i] = (mb_u_char)line[4];
 				ping->png_raw3_rxamp[i] = (mb_s_char)line[5];
 				ping->png_raw3_rxquality[i] = (mb_u_char)line[6];
 				ping->png_raw3_rxwindow[i] = (mb_u_char)line[7];
 				mb_get_binary_short(swap, &line[8], &short_val);
 				ping->png_raw3_rxbeam_num[i] = (int)((short)short_val);
-				mb_get_binary_short(swap, &line[8], &short_val);
-				ping->png_raw3_rxspare[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[8], &ushort_val);
+				ping->png_raw3_rxspare[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -2844,7 +2853,8 @@ int mbr_em300mba_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
                        int *error) {
 	struct mbsys_simrad2_ping_struct *ping;
 	char line[2 * MBSYS_SIMRAD2_BUFFER_SIZE];
-	unsigned short short_val = 0;
+	short short_val = 0;
+	unsigned short ushort_val = 0;
 	int png_ss_count;
 	int png_ss_serial;
 	size_t read_len;
@@ -2884,10 +2894,10 @@ int mbr_em300mba_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 
 	/* in case of EM3002 check if the data are from the second head and if so switch ping structure */
 	if (status == MB_SUCCESS && sonar == MBSYS_SIMRAD2_EM3002 && store->numberheads == 2) {
-		mb_get_binary_short(swap, &line[8], &short_val);
-		png_ss_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		png_ss_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		png_ss_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		png_ss_serial = (int)(ushort_val);
 
 		if ((png_ss_count == ping->png_ss_count && png_ss_serial != ping->png_ss_serial) ||
 		    (png_ss_count == store->ping2->png_count && png_ss_serial == store->ping2->png_serial)) {
@@ -2901,30 +2911,30 @@ int mbr_em300mba_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 		store->date = ping->png_ss_date;
 		mb_get_binary_int(swap, &line[4], &ping->png_ss_msec);
 		store->msec = ping->png_ss_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ping->png_ss_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ping->png_ss_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		ping->png_max_range = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[14], &short_val);
-		ping->png_r_zero = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[16], &short_val);
-		ping->png_r_zero_corr = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[18], &short_val);
-		ping->png_tvg_start = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		ping->png_tvg_stop = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ping->png_ss_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ping->png_ss_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		ping->png_max_range = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[14], &ushort_val);
+		ping->png_r_zero = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[16], &ushort_val);
+		ping->png_r_zero_corr = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[18], &ushort_val);
+		ping->png_tvg_start = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		ping->png_tvg_stop = (int)(ushort_val);
 		ping->png_bsn = (mb_s_char)line[22];
 		ping->png_bso = (mb_s_char)line[23];
-		mb_get_binary_short(swap, &line[24], &short_val);
-		ping->png_tx = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[24], &ushort_val);
+		ping->png_tx = (int)(ushort_val);
 		ping->png_tvg_crossover = (mb_u_char)line[26];
 		ping->png_nbeams_ss = (mb_u_char)line[27];
-		mb_get_binary_short(swap, &line[28], &short_val);
-		ping->png_pixel_size = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[30], &short_val);
-		ping->png_pixels_ss = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[28], &ushort_val);
+		ping->png_pixel_size = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[30], &ushort_val);
+		ping->png_pixels_ss = (int)(ushort_val);
 	}
 
 	/* check for some indicators of a broken record
@@ -2945,11 +2955,11 @@ int mbr_em300mba_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 				status = MB_SUCCESS;
 				ping->png_beam_index[i] = (mb_u_char)line[0];
 				ping->png_sort_direction[i] = (mb_s_char)line[1];
-				mb_get_binary_short(swap, &line[2], &short_val);
-				ping->png_beam_samples[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				ping->png_beam_samples[i] = (int)(ushort_val);
 				ping->png_start_sample[i] = ping->png_npixels;
-				mb_get_binary_short(swap, &line[4], &short_val);
-				ping->png_center_sample[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[4], &ushort_val);
+				ping->png_center_sample[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -3179,7 +3189,8 @@ int mbr_em300mba_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 int mbr_em300mba_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *error) {
 	struct mbsys_simrad2_watercolumn_struct *wc;
 	char line[EM2_WC_HEADER_SIZE];
-	unsigned short short_val = 0;
+	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -3218,31 +3229,31 @@ int mbr_em300mba_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 		store->date = wc->wtc_date;
 		mb_get_binary_int(swap, &line[4], &wc->wtc_msec);
 		store->msec = wc->wtc_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		wc->wtc_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		wc->wtc_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		wc->wtc_ndatagrams = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[14], &short_val);
-		wc->wtc_datagram = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[16], &short_val);
-		wc->wtc_ntx = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[18], &short_val);
-		wc->wtc_nrx = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		wc->wtc_nbeam = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[22], &short_val);
-		wc->wtc_ssv = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		wc->wtc_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		wc->wtc_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		wc->wtc_ndatagrams = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[14], &ushort_val);
+		wc->wtc_datagram = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[16], &ushort_val);
+		wc->wtc_ntx = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[18], &ushort_val);
+		wc->wtc_nrx = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		wc->wtc_nbeam = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		wc->wtc_ssv = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[24], &(wc->wtc_sfreq));
 		mb_get_binary_short(swap, &line[28], &short_val);
 		wc->wtc_heave = (int)((short)short_val);
-		mb_get_binary_short(swap, &line[30], &short_val);
-		wc->wtc_spare1 = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[32], &short_val);
-		wc->wtc_spare2 = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[34], &short_val);
-		wc->wtc_spare3 = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[30], &ushort_val);
+		wc->wtc_spare1 = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[32], &ushort_val);
+		wc->wtc_spare2 = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[34], &ushort_val);
+		wc->wtc_spare3 = (int)(ushort_val);
 	}
 
 	/* check for some indicators of a broken record
@@ -3277,9 +3288,9 @@ int mbr_em300mba_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 				wc->beam[i].wtc_rxpointangle = (int)(short_val);
 				mb_get_binary_short(swap, &line[2], &short_val);
 				wc->beam[i].wtc_start_sample = (int)(short_val);
-				mb_get_binary_short(swap, &line[4], &short_val);
+				mb_get_binary_short(swap, &line[4], &ushort_val);
 				wc->beam[i].wtc_beam_samples = (int)(unsigned short)(short_val);
-				mb_get_binary_short(swap, &line[6], &short_val);
+				mb_get_binary_short(swap, &line[6], &ushort_val);
 				wc->beam[i].wtc_beam_spare = (int)(unsigned short)(short_val);
 				wc->beam[i].wtc_sector = (int)(mb_u_char)(line[8]);
 				wc->beam[i].wtc_beam = (int)(mb_u_char)(line[9]);
@@ -6387,7 +6398,7 @@ int mbr_em300mba_wr_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		line[29] = (mb_u_char)ping->png_nbeams;
 		line[30] = (mb_u_char)ping->png_depth_res;
 		line[31] = (mb_u_char)ping->png_distance_res;
-		mb_put_binary_short(swap, (unsigned short)ping->png_sample_rate, (void *)&line[32]);
+		mb_put_binary_short(swap, (short)ping->png_sample_rate, (void *)&line[32]);
 
 		/* compute checksum */
 		uchar_ptr = (mb_u_char *)line;

--- a/src/mbio/mbr_em300raw.c
+++ b/src/mbio/mbr_em300raw.c
@@ -365,13 +365,13 @@ int mbr_em300raw_rd_start(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 		store->date = store->par_date;
 		mb_get_binary_int(swap, &line[4], &store->par_msec);
 		store->msec = store->par_msec;
-		short short_val = 0;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->par_line_num = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->par_serial_1 = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		store->par_serial_2 = (int)((unsigned short)short_val);
+		unsigned short ushort_val = 0;
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->par_line_num = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->par_serial_1 = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		store->par_serial_2 = (int)(ushort_val);
 	}
 
 	/* check for dual head sonars */
@@ -735,32 +735,32 @@ int mbr_em300raw_rd_run_parameter(int verbose, FILE *mbfp, int swap, struct mbsy
 		mb_get_binary_int(swap, &line[4], &store->run_msec);
 		if (store->run_date != 0)
 			store->msec = store->run_msec;
-		short short_val = 0;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->run_ping_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->run_serial = (int)((unsigned short)short_val);
+		unsigned short ushort_val = 0;
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->run_ping_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->run_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->run_status);
 		store->run_mode = (mb_u_char)line[16];
 		store->run_filter_id = (mb_u_char)line[17];
-		mb_get_binary_short(swap, &line[18], &short_val);
-		store->run_min_depth = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		store->run_max_depth = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[22], &short_val);
-		store->run_absorption = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[24], &short_val);
-		store->run_tran_pulse = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[26], &short_val);
-		store->run_tran_beam = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[18], &ushort_val);
+		store->run_min_depth = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		store->run_max_depth = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		store->run_absorption = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[24], &ushort_val);
+		store->run_tran_pulse = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[26], &ushort_val);
+		store->run_tran_beam = (int)(ushort_val);
 		store->run_tran_pow = (mb_u_char)line[28];
 		store->run_rec_beam = (mb_u_char)line[29];
 		store->run_rec_band = (mb_u_char)line[30];
 		store->run_rec_gain = (mb_u_char)line[31];
 		store->run_tvg_cross = (mb_u_char)line[32];
 		store->run_ssv_source = (mb_u_char)line[33];
-		mb_get_binary_short(swap, &line[34], &short_val);
-		store->run_max_swath = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[34], &ushort_val);
+		store->run_max_swath = (int)(ushort_val);
 		store->run_beam_space = (mb_u_char)line[36];
 		store->run_swath_angle = (mb_u_char)line[37];
 		store->run_stab_mode = (mb_u_char)line[38];
@@ -857,11 +857,11 @@ int mbr_em300raw_rd_clock(int verbose, FILE *mbfp, int swap, struct mbsys_simrad
 		store->date = store->clk_date;
 		mb_get_binary_int(swap, &line[4], &store->clk_msec);
 		store->msec = store->clk_msec;
-		short short_val = 0;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->clk_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->clk_serial = (int)((unsigned short)short_val);
+		unsigned short ushort_val = 0;
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->clk_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->clk_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->clk_origin_date);
 		mb_get_binary_int(swap, &line[16], &store->clk_origin_msec);
 		store->clk_1_pps_use = (mb_u_char)line[20];
@@ -939,10 +939,11 @@ int mbr_em300raw_rd_tide(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		mb_get_binary_int(swap, &line[4], &store->tid_msec);
 		store->msec = store->tid_msec;
 		short short_val = 0;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->tid_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->tid_serial = (int)((unsigned short)short_val);
+		unsigned short ushort_val = 0;
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->tid_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->tid_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->tid_origin_date);
 		mb_get_binary_int(swap, &line[16], &store->tid_origin_msec);
 		mb_get_binary_short(swap, &line[20], &short_val);
@@ -1020,11 +1021,11 @@ int mbr_em300raw_rd_height(int verbose, FILE *mbfp, int swap, struct mbsys_simra
 		store->date = store->hgt_date;
 		mb_get_binary_int(swap, &line[4], &store->hgt_msec);
 		store->msec = store->hgt_msec;
-		short short_val = 0;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->hgt_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->hgt_serial = (int)((unsigned short)short_val);
+		unsigned short ushort_val = 0;
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->hgt_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->hgt_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->hgt_height);
 		store->hgt_type = (mb_u_char)line[16];
 		if (line[EM2_HEIGHT_SIZE - 7] == EM2_END)
@@ -1102,13 +1103,13 @@ int mbr_em300raw_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 		store->date = heading->hed_date;
 		mb_get_binary_int(swap, &line[4], &heading->hed_msec);
 		store->msec = heading->hed_msec;
-		short short_val = 0;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		heading->hed_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		heading->hed_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		heading->hed_ndata = (int)((unsigned short)short_val);
+		unsigned short ushort_val = 0;
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		heading->hed_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		heading->hed_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		heading->hed_ndata = (int)(ushort_val);
 	}
 
 	/* read binary heading values */
@@ -1117,11 +1118,11 @@ int mbr_em300raw_rd_heading(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 			read_len = fread(line, 1, EM2_HEADING_SLICE_SIZE, mbfp);
 			if (read_len == EM2_HEADING_SLICE_SIZE && i < MBSYS_SIMRAD2_MAXHEADING) {
 				status = MB_SUCCESS;
-				short short_val = 0;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				heading->hed_time[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[2], &short_val);
-				heading->hed_heading[i] = (int)((unsigned short)short_val);
+				unsigned short ushort_val = 0;
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				heading->hed_time[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				heading->hed_heading[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -1223,13 +1224,13 @@ int mbr_em300raw_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		store->date = ssv->ssv_date;
 		mb_get_binary_int(swap, &line[4], &ssv->ssv_msec);
 		store->msec = ssv->ssv_msec;
-		short short_val = 0;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ssv->ssv_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ssv->ssv_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		ssv->ssv_ndata = (int)((unsigned short)short_val);
+		unsigned short ushort_val = 0;
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ssv->ssv_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ssv->ssv_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		ssv->ssv_ndata = (int)(ushort_val);
 	}
 
 	/* read binary ssv values */
@@ -1238,11 +1239,11 @@ int mbr_em300raw_rd_ssv(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 			read_len = fread(line, 1, EM2_SSV_SLICE_SIZE, mbfp);
 			if (read_len == EM2_SSV_SLICE_SIZE && i < MBSYS_SIMRAD2_MAXSSV) {
 				status = MB_SUCCESS;
-				short short_val = 0;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				ssv->ssv_time[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[2], &short_val);
-				ssv->ssv_ssv[i] = (int)((unsigned short)short_val);
+				unsigned short ushort_val = 0;
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				ssv->ssv_time[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				ssv->ssv_ssv[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -1342,13 +1343,13 @@ int mbr_em300raw_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		store->date = tilt->tlt_date;
 		mb_get_binary_int(swap, &line[4], &tilt->tlt_msec);
 		store->msec = tilt->tlt_msec;
-		short short_val = 0;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		tilt->tlt_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		tilt->tlt_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		tilt->tlt_ndata = (int)((unsigned short)short_val);
+		unsigned short ushort_val = 0;
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		tilt->tlt_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		tilt->tlt_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		tilt->tlt_ndata = (int)(ushort_val);
 	}
 
 	/* read binary tilt values */
@@ -1357,11 +1358,11 @@ int mbr_em300raw_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 			read_len = fread(line, 1, EM2_TILT_SLICE_SIZE, mbfp);
 			if (read_len == EM2_TILT_SLICE_SIZE && i < MBSYS_SIMRAD2_MAXTILT) {
 				status = MB_SUCCESS;
-				short short_val = 0;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				tilt->tlt_time[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[2], &short_val);
-				tilt->tlt_tilt[i] = (int)((unsigned short)short_val);
+				unsigned short ushort_val = 0;
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				tilt->tlt_time[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				tilt->tlt_tilt[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -1423,7 +1424,7 @@ int mbr_em300raw_rd_tilt(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 int mbr_em300raw_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar,
                                     int *goodend, int *error) {
 	char line[EM2_EXTRAPARAMETERS_HEADER_SIZE];
-	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1465,12 +1466,12 @@ int mbr_em300raw_rd_extraparameters(int verbose, FILE *mbfp, int swap, struct mb
 		store->date = extraparameters->xtr_date;
 		mb_get_binary_int(swap, &line[4], &extraparameters->xtr_msec);
 		store->msec = extraparameters->xtr_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		extraparameters->xtr_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		extraparameters->xtr_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		extraparameters->xtr_id = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		extraparameters->xtr_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		extraparameters->xtr_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		extraparameters->xtr_id = (int)(ushort_val);
 	}
 
 	/* read data */
@@ -1568,6 +1569,7 @@ int mbr_em300raw_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
                              int *error) {
 	char line[EM2_ATTITUDE_HEADER_SIZE];
 	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1608,12 +1610,12 @@ int mbr_em300raw_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 		store->date = attitude->att_date;
 		mb_get_binary_int(swap, &line[4], &attitude->att_msec);
 		store->msec = attitude->att_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		attitude->att_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		attitude->att_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		attitude->att_ndata = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		attitude->att_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		attitude->att_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		attitude->att_ndata = (int)(ushort_val);
 	}
 
 	/* read binary attitude values */
@@ -1622,18 +1624,18 @@ int mbr_em300raw_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 			read_len = fread(line, 1, EM2_ATTITUDE_SLICE_SIZE, mbfp);
 			if (read_len == EM2_ATTITUDE_SLICE_SIZE && i < MBSYS_SIMRAD2_MAXATTITUDE) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				attitude->att_time[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[2], &short_val);
-				attitude->att_sensor_status[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				attitude->att_time[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				attitude->att_sensor_status[i] = (int)(ushort_val);
 				mb_get_binary_short(swap, &line[4], &short_val);
 				attitude->att_roll[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[6], &short_val);
 				attitude->att_pitch[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[8], &short_val);
 				attitude->att_heave[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[10], &short_val);
-				attitude->att_heading[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[10], &ushort_val);
+				attitude->att_heading[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -1698,7 +1700,7 @@ int mbr_em300raw_rd_attitude(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 int mbr_em300raw_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                         int *error) {
 	char line[MBSYS_SIMRAD2_COMMENT_LENGTH];
-	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1736,20 +1738,20 @@ int mbr_em300raw_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		store->date = store->pos_date;
 		mb_get_binary_int(swap, &line[4], &store->pos_msec);
 		store->msec = store->pos_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->pos_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->pos_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->pos_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->pos_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->pos_latitude);
 		mb_get_binary_int(swap, &line[16], &store->pos_longitude);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		store->pos_quality = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[22], &short_val);
-		store->pos_speed = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[24], &short_val);
-		store->pos_course = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[26], &short_val);
-		store->pos_heading = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		store->pos_quality = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		store->pos_speed = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[24], &ushort_val);
+		store->pos_course = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[26], &ushort_val);
+		store->pos_heading = (int)(ushort_val);
 		store->pos_system = (mb_u_char)line[28];
 		store->pos_input_size = (mb_u_char)line[29];
 	}
@@ -1868,7 +1870,7 @@ int mbr_em300raw_rd_pos(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 int mbr_em300raw_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                         int *error) {
 	char line[EM2_SVP_HEADER_SIZE];
-	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -1906,16 +1908,16 @@ int mbr_em300raw_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 		store->date = store->svp_use_date;
 		mb_get_binary_int(swap, &line[4], &store->svp_use_msec);
 		store->msec = store->svp_use_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->svp_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->svp_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->svp_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->svp_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->svp_origin_date);
 		mb_get_binary_int(swap, &line[16], &store->svp_origin_msec);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		store->svp_num = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[22], &short_val);
-		store->svp_depth_res = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		store->svp_num = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		store->svp_depth_res = (int)(ushort_val);
 	}
 
 	/* read binary svp values */
@@ -1928,10 +1930,10 @@ int mbr_em300raw_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 			}
 			else if (i < MBSYS_SIMRAD2_MAXSVP) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				store->svp_depth[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[2], &short_val);
-				store->svp_vel[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				store->svp_depth[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				store->svp_vel[i] = (int)(ushort_val);
 			}
 		}
 		store->svp_num = MIN(store->svp_num, MBSYS_SIMRAD2_MAXSVP);
@@ -1992,7 +1994,7 @@ int mbr_em300raw_rd_svp(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_
 int mbr_em300raw_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int *goodend,
                          int *error) {
 	char line[EM2_SVP2_HEADER_SIZE];
-	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -2030,16 +2032,16 @@ int mbr_em300raw_rd_svp2(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		store->date = store->svp_use_date;
 		mb_get_binary_int(swap, &line[4], &store->svp_use_msec);
 		store->msec = store->svp_use_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		store->svp_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		store->svp_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		store->svp_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		store->svp_serial = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[12], &store->svp_origin_date);
 		mb_get_binary_int(swap, &line[16], &store->svp_origin_msec);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		store->svp_num = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[22], &short_val);
-		store->svp_depth_res = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		store->svp_num = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		store->svp_depth_res = (int)(ushort_val);
 	}
 
 	/* read binary svp values */
@@ -2115,6 +2117,7 @@ int mbr_em300raw_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
                          int version, int *goodend, int *error) {
 	char line[EM2_BATH_HEADER_SIZE];
 	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -2152,10 +2155,10 @@ int mbr_em300raw_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 
 	/* in case of dual head EM2002 check if the data are from the second head and switch ping structure if so */
 	if (status == MB_SUCCESS && sonar == MBSYS_SIMRAD2_EM3002 && store->numberheads == 2) {
-		mb_get_binary_short(swap, &line[8], &short_val);
-		const int png_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		const int png_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		const int png_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		const int png_serial = (int)(ushort_val);
 
 		if (png_count == ping->png_count && png_serial != ping->png_serial) {
 			ping = (struct mbsys_simrad2_ping_struct *)store->ping2;
@@ -2168,22 +2171,22 @@ int mbr_em300raw_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		store->date = ping->png_date;
 		mb_get_binary_int(swap, &line[4], &ping->png_msec);
 		store->msec = ping->png_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ping->png_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ping->png_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		ping->png_heading = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[14], &short_val);
-		ping->png_ssv = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[16], &short_val);
-		ping->png_xducer_depth = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ping->png_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ping->png_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		ping->png_heading = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[14], &ushort_val);
+		ping->png_ssv = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[16], &ushort_val);
+		ping->png_xducer_depth = (int)(ushort_val);
 		ping->png_nbeams_max = (mb_u_char)line[18];
 		ping->png_nbeams = (mb_u_char)line[19];
 		ping->png_depth_res = (mb_u_char)line[20];
 		ping->png_distance_res = (mb_u_char)line[21];
-		mb_get_binary_short(swap, &line[22], &short_val);
-		ping->png_sample_rate = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		ping->png_sample_rate = (int)(ushort_val);
 	}
 
 	/* check for some indicators of a broken record
@@ -2202,11 +2205,14 @@ int mbr_em300raw_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 			read_len = fread(line, 1, EM2_BATH_BEAM_SIZE, mbfp);
 			if (read_len == EM2_BATH_BEAM_SIZE && i < MBSYS_SIMRAD2_MAXBEAMS) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				if (store->sonar == MBSYS_SIMRAD2_EM120 || store->sonar == MBSYS_SIMRAD2_EM300)
-					ping->png_depth[i] = (int)((unsigned short)short_val);
-				else
+				if (store->sonar == MBSYS_SIMRAD2_EM120 || store->sonar == MBSYS_SIMRAD2_EM300) {
+					mb_get_binary_short(swap, &line[0], &ushort_val);
+					ping->png_depth[i] = (int)(ushort_val);
+				}
+				else {
+					mb_get_binary_short(swap, &line[0], &short_val);
 					ping->png_depth[i] = (int)short_val;
+				}
 
 				mb_get_binary_short(swap, &line[2], &short_val);
 				ping->png_acrosstrack[i] = (int)short_val;
@@ -2214,10 +2220,10 @@ int mbr_em300raw_rd_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 				ping->png_alongtrack[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[6], &short_val);
 				ping->png_depression[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[8], &short_val);
-				ping->png_azimuth[i] = (int)((unsigned short)short_val);
-				mb_get_binary_short(swap, &line[10], &short_val);
-				ping->png_range[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[8], &ushort_val);
+				ping->png_azimuth[i] = (int)(ushort_val);
+				mb_get_binary_short(swap, &line[10], &ushort_val);
+				ping->png_range[i] = (int)(ushort_val);
 				ping->png_quality[i] = (mb_u_char)line[12];
 				ping->png_window[i] = (mb_u_char)line[13];
 				ping->png_amp[i] = (mb_s_char)line[14];
@@ -2326,6 +2332,7 @@ int mbr_em300raw_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
                             int *error) {
 	char line[EM2_RAWBEAM_HEADER_SIZE];
 	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -2361,14 +2368,14 @@ int mbr_em300raw_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 		store->date = ping->png_raw_date;
 		mb_get_binary_int(swap, &line[4], &ping->png_raw_msec);
 		store->msec = ping->png_raw_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ping->png_raw_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ping->png_raw_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ping->png_raw_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ping->png_raw_serial = (int)(ushort_val);
 		ping->png_raw_nbeams_max = (mb_u_char)line[12];
 		ping->png_raw_nbeams = (mb_u_char)line[13];
-		mb_get_binary_short(swap, &line[14], &short_val);
-		ping->png_raw_ssv = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[14], &ushort_val);
+		ping->png_raw_ssv = (int)(ushort_val);
 	}
 
 	/* check for some indicators of a broken record
@@ -2391,8 +2398,8 @@ int mbr_em300raw_rd_rawbeam(int verbose, FILE *mbfp, int swap, struct mbsys_simr
 				ping->png_raw_rxpointangle[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[2], &short_val);
 				ping->png_raw_rxtiltangle[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[4], &short_val);
-				ping->png_raw_rxrange[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[4], &ushort_val);
+				ping->png_raw_rxrange[i] = (int)(ushort_val);
 				ping->png_raw_rxamp[i] = (mb_s_char)line[6];
 				ping->png_raw_rxbeam_num[i] = (mb_u_char)line[7];
 			}
@@ -2472,6 +2479,7 @@ int mbr_em300raw_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
                              int *error) {
 	char line[EM2_RAWBEAM2_HEADER_SIZE];
 	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -2507,37 +2515,37 @@ int mbr_em300raw_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 		store->date = ping->png_raw_date;
 		mb_get_binary_int(swap, &line[4], &ping->png_raw_msec);
 		store->msec = ping->png_raw_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ping->png_raw_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ping->png_raw_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		ping->png_raw_heading = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[14], &short_val);
-		ping->png_raw_ssv = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[16], &short_val);
-		ping->png_raw_xducer_depth = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ping->png_raw_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ping->png_raw_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		ping->png_raw_heading = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[14], &ushort_val);
+		ping->png_raw_ssv = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[16], &ushort_val);
+		ping->png_raw_xducer_depth = (int)(ushort_val);
 		ping->png_raw_nbeams_max = (mb_u_char)line[18];
 		ping->png_raw_nbeams = (mb_u_char)line[19];
 		ping->png_raw_depth_res = (mb_u_char)line[20];
 		ping->png_raw_distance_res = (mb_u_char)line[21];
-		mb_get_binary_short(swap, &line[22], &short_val);
-		ping->png_raw_sample_rate = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		ping->png_raw_sample_rate = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[24], &ping->png_raw_status);
-		mb_get_binary_short(swap, &line[28], &short_val);
-		ping->png_raw_rangenormal = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[28], &ushort_val);
+		ping->png_raw_rangenormal = (int)(ushort_val);
 		ping->png_raw_normalbackscatter = (mb_s_char)line[30];
 		ping->png_raw_obliquebackscatter = (mb_s_char)line[31];
 		ping->png_raw_fixedgain = (mb_u_char)line[32];
 		ping->png_raw_txpower = (mb_s_char)line[33];
 		ping->png_raw_mode = (mb_u_char)line[34];
 		ping->png_raw_coverage = (mb_u_char)line[35];
-		mb_get_binary_short(swap, &line[36], &short_val);
-		ping->png_raw_yawstabheading = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[38], &short_val);
-		ping->png_raw_ntx = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[40], &short_val);
-		/* spare = (int)((unsigned short)short_val); */
+		mb_get_binary_short(swap, &line[36], &ushort_val);
+		ping->png_raw_yawstabheading = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[38], &ushort_val);
+		ping->png_raw_ntx = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[40], &ushort_val);
+		/* spare = (int)(ushort_val); */
 	}
 
 	/* check for some indicators of a broken record
@@ -2557,12 +2565,12 @@ int mbr_em300raw_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 			read_len = fread(line, 1, EM2_RAWBEAM2_TX_SIZE, mbfp);
 			if (read_len == EM2_RAWBEAM2_TX_SIZE && i < MBSYS_SIMRAD2_MAXTX) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				ping->png_raw_txlastbeam[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				ping->png_raw_txlastbeam[i] = (int)(ushort_val);
 				mb_get_binary_short(swap, &line[2], &short_val);
 				ping->png_raw_txtiltangle[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[4], &short_val);
-				ping->png_raw_txheading[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[4], &ushort_val);
+				ping->png_raw_txheading[i] = (int)(ushort_val);
 				mb_get_binary_short(swap, &line[6], &short_val);
 				ping->png_raw_txroll[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[8], &short_val);
@@ -2583,16 +2591,16 @@ int mbr_em300raw_rd_rawbeam2(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 			read_len = fread(line, 1, EM2_RAWBEAM2_BEAM_SIZE, mbfp);
 			if (read_len == EM2_RAWBEAM2_BEAM_SIZE && i < MBSYS_SIMRAD2_MAXBEAMS) {
 				status = MB_SUCCESS;
-				mb_get_binary_short(swap, &line[0], &short_val);
-				ping->png_raw_rxrange[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[0], &ushort_val);
+				ping->png_raw_rxrange[i] = (int)(ushort_val);
 				ping->png_raw_rxquality[i] = (mb_u_char)line[2];
 				ping->png_raw_rxwindow[i] = (mb_u_char)line[3];
 				ping->png_raw_rxamp[i] = (mb_s_char)line[4];
 				ping->png_raw_rxbeam_num[i] = (mb_u_char)line[5];
 				mb_get_binary_short(swap, &line[6], &short_val);
 				ping->png_raw_rxpointangle[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[8], &short_val);
-				ping->png_raw_rxheading[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[8], &ushort_val);
+				ping->png_raw_rxheading[i] = (int)(ushort_val);
 				mb_get_binary_short(swap, &line[10], &short_val);
 				ping->png_raw_rxroll[i] = (int)short_val;
 				mb_get_binary_short(swap, &line[12], &short_val);
@@ -2703,6 +2711,7 @@ int mbr_em300raw_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
                              int *error) {
 	char line[EM2_RAWBEAM3_HEADER_SIZE];
 	short short_val = 0;
+	unsigned short ushort_val = 0;
 	int int_val = 0;
 	size_t read_len;
 
@@ -2735,10 +2744,10 @@ int mbr_em300raw_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 
 	/* in case of dual head EM2002 check if the data are from the second head and if so switch ping structure */
 	if (status == MB_SUCCESS && sonar == MBSYS_SIMRAD2_EM3002 && store->numberheads == 2) {
-		mb_get_binary_short(swap, &line[8], &short_val);
-		const int png_raw3_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		const int png_raw3_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		const int png_raw3_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		const int png_raw3_serial = (int)(ushort_val);
 
 		if (png_raw3_count == ping->png_raw3_count && png_raw3_serial != ping->png_raw3_serial) {
 			ping = (struct mbsys_simrad2_ping_struct *)store->ping2;
@@ -2751,22 +2760,22 @@ int mbr_em300raw_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 		store->date = ping->png_raw3_date;
 		mb_get_binary_int(swap, &line[4], &ping->png_raw3_msec);
 		store->msec = ping->png_raw3_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ping->png_raw3_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ping->png_raw3_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		ping->png_raw3_ntx = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[14], &short_val);
-		ping->png_raw3_nbeams = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ping->png_raw3_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ping->png_raw3_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		ping->png_raw3_ntx = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[14], &ushort_val);
+		ping->png_raw3_nbeams = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[16], &int_val);
 		ping->png_raw3_sample_rate = (int)(int_val);
 		mb_get_binary_int(swap, &line[20], &int_val);
 		ping->png_raw3_xducer_depth = (int)(int_val);
-		mb_get_binary_short(swap, &line[24], &short_val);
-		ping->png_raw3_ssv = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[26], &short_val);
-		ping->png_raw3_nbeams_max = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[24], &ushort_val);
+		ping->png_raw3_ssv = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[26], &ushort_val);
+		ping->png_raw3_nbeams_max = (int)(ushort_val);
 	}
 
 	/* check for some indicators of a broken record
@@ -2816,16 +2825,16 @@ int mbr_em300raw_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 				status = MB_SUCCESS;
 				mb_get_binary_short(swap, &line[0], &short_val);
 				ping->png_raw3_rxpointangle[i] = (int)short_val;
-				mb_get_binary_short(swap, &line[2], &short_val);
-				ping->png_raw3_rxrange[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				ping->png_raw3_rxrange[i] = (int)(ushort_val);
 				ping->png_raw3_rxsector[i] = (mb_u_char)line[4];
 				ping->png_raw3_rxamp[i] = (mb_s_char)line[5];
 				ping->png_raw3_rxquality[i] = (mb_u_char)line[6];
 				ping->png_raw3_rxwindow[i] = (mb_u_char)line[7];
 				mb_get_binary_short(swap, &line[8], &short_val);
-				ping->png_raw3_rxbeam_num[i] = (int)((short)short_val);
-				mb_get_binary_short(swap, &line[10], &short_val);
-				ping->png_raw3_rxspare[i] = (int)((unsigned short)short_val);
+				ping->png_raw3_rxbeam_num[i] = (int)(short_val);
+				mb_get_binary_short(swap, &line[10], &ushort_val);
+				ping->png_raw3_rxspare[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -2917,7 +2926,7 @@ int mbr_em300raw_rd_rawbeam3(int verbose, FILE *mbfp, int swap, struct mbsys_sim
 int mbr_em300raw_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_struct *store, short sonar, int length, bool *match,
                        int *goodend, int *error) {
 	char line[EM2_SS_HEADER_SIZE];
-	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 	int junk_bytes;
 
@@ -2956,10 +2965,10 @@ int mbr_em300raw_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 
 	/* in case of dual head EM2002 check if the data are from the second head and if so switch ping structure */
 	if (status == MB_SUCCESS && sonar == MBSYS_SIMRAD2_EM3002 && store->numberheads == 2) {
-		mb_get_binary_short(swap, &line[8], &short_val);
-		const int png_ss_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		const int png_ss_serial = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		const int png_ss_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		const int png_ss_serial = (int)(ushort_val);
 
 		if ((png_ss_count == ping->png_ss_count && png_ss_serial != ping->png_ss_serial) ||
 		    (png_ss_count == store->ping2->png_count && png_ss_serial == store->ping2->png_serial)) {
@@ -2973,24 +2982,24 @@ int mbr_em300raw_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 		store->date = ping->png_ss_date;
 		mb_get_binary_int(swap, &line[4], &ping->png_ss_msec);
 		store->msec = ping->png_ss_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		ping->png_ss_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		ping->png_ss_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		ping->png_max_range = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[14], &short_val);
-		ping->png_r_zero = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[16], &short_val);
-		ping->png_r_zero_corr = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[18], &short_val);
-		ping->png_tvg_start = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		ping->png_tvg_stop = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		ping->png_ss_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		ping->png_ss_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		ping->png_max_range = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[14], &ushort_val);
+		ping->png_r_zero = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[16], &ushort_val);
+		ping->png_r_zero_corr = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[18], &ushort_val);
+		ping->png_tvg_start = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		ping->png_tvg_stop = (int)(ushort_val);
 		ping->png_bsn = (mb_s_char)line[22];
 		ping->png_bso = (mb_s_char)line[23];
-		mb_get_binary_short(swap, &line[24], &short_val);
-		ping->png_tx = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[24], &ushort_val);
+		ping->png_tx = (int)(ushort_val);
 		ping->png_tvg_crossover = (mb_u_char)line[26];
 		ping->png_nbeams_ss = (mb_u_char)line[27];
 	}
@@ -3013,11 +3022,11 @@ int mbr_em300raw_rd_ss(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 				status = MB_SUCCESS;
 				ping->png_beam_index[i] = (mb_u_char)line[0];
 				ping->png_sort_direction[i] = (mb_s_char)line[1];
-				mb_get_binary_short(swap, &line[2], &short_val);
-				ping->png_beam_samples[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[2], &ushort_val);
+				ping->png_beam_samples[i] = (int)(ushort_val);
 				ping->png_start_sample[i] = ping->png_npixels;
-				mb_get_binary_short(swap, &line[4], &short_val);
-				ping->png_center_sample[i] = (int)((unsigned short)short_val);
+				mb_get_binary_short(swap, &line[4], &ushort_val);
+				ping->png_center_sample[i] = (int)(ushort_val);
 			}
 			else {
 				status = MB_FAILURE;
@@ -3197,6 +3206,7 @@ int mbr_em300raw_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
                        int *error) {
 	char line[EM2_WC_HEADER_SIZE];
 	short short_val = 0;
+	unsigned short ushort_val = 0;
 	size_t read_len;
 
 	if (verbose >= 2) {
@@ -3238,31 +3248,31 @@ int mbr_em300raw_rd_wc(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2_s
 		store->date = wc->wtc_date;
 		mb_get_binary_int(swap, &line[4], &wc->wtc_msec);
 		store->msec = wc->wtc_msec;
-		mb_get_binary_short(swap, &line[8], &short_val);
-		wc->wtc_count = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[10], &short_val);
-		wc->wtc_serial = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[12], &short_val);
-		wc->wtc_ndatagrams = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[14], &short_val);
-		wc->wtc_datagram = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[16], &short_val);
-		wc->wtc_ntx = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[18], &short_val);
-		wc->wtc_nrx = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[20], &short_val);
-		wc->wtc_nbeam = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[22], &short_val);
-		wc->wtc_ssv = (int)((unsigned short)short_val);
+		mb_get_binary_short(swap, &line[8], &ushort_val);
+		wc->wtc_count = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[10], &ushort_val);
+		wc->wtc_serial = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[12], &ushort_val);
+		wc->wtc_ndatagrams = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[14], &ushort_val);
+		wc->wtc_datagram = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[16], &ushort_val);
+		wc->wtc_ntx = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[18], &ushort_val);
+		wc->wtc_nrx = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[20], &ushort_val);
+		wc->wtc_nbeam = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[22], &ushort_val);
+		wc->wtc_ssv = (int)(ushort_val);
 		mb_get_binary_int(swap, &line[24], &(wc->wtc_sfreq));
 		mb_get_binary_short(swap, &line[28], &short_val);
-		wc->wtc_heave = (int)((short)short_val);
-		mb_get_binary_short(swap, &line[30], &short_val);
-		wc->wtc_spare1 = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[32], &short_val);
-		wc->wtc_spare2 = (int)((unsigned short)short_val);
-		mb_get_binary_short(swap, &line[34], &short_val);
-		wc->wtc_spare3 = (int)((unsigned short)short_val);
+		wc->wtc_heave = (int)(short_val);
+		mb_get_binary_short(swap, &line[30], &ushort_val);
+		wc->wtc_spare1 = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[32], &ushort_val);
+		wc->wtc_spare2 = (int)(ushort_val);
+		mb_get_binary_short(swap, &line[34], &ushort_val);
+		wc->wtc_spare3 = (int)(ushort_val);
 	}
 
 	/* check for some indicators of a broken record
@@ -6634,7 +6644,7 @@ int mbr_em300raw_wr_bath(int verbose, FILE *mbfp, int swap, struct mbsys_simrad2
 		line[19] = (mb_u_char)ping->png_nbeams;
 		line[20] = (mb_u_char)ping->png_depth_res;
 		line[21] = (mb_u_char)ping->png_distance_res;
-		mb_put_binary_short(swap, (unsigned short)ping->png_sample_rate, (void *)&line[22]);
+		mb_put_binary_short(swap, (short)ping->png_sample_rate, (void *)&line[22]);
 
 		/* compute checksum */
 		uchar_ptr = (mb_u_char *)line;

--- a/src/mbio/mbr_kemkmall.c
+++ b/src/mbio/mbr_kemkmall.c
@@ -1002,13 +1002,13 @@ int mbr_kemkmall_rd_svp(int verbose, char *buffer, void *store_ptr, void *header
 
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values read in MBIO function <%s>\n", __func__);
-    fprintf(stderr, " dbg5       numBytesDgm:     %u\n", svp->header.numBytesDgm);
-    fprintf(stderr, " dbg5       dgmType:         %s\n", svp->header.dgmType);
-    fprintf(stderr, " dbg5       dgmVersion:      %u\n", svp->header.dgmVersion);
-    fprintf(stderr, " dbg5       systemID:        %u\n", svp->header.systemID);
-    fprintf(stderr, " dbg5       echoSounderID:   %u\n", svp->header.echoSounderID);
-    fprintf(stderr, " dbg5       time_sec:        %u\n", svp->header.time_sec);
-    fprintf(stderr, " dbg5       time_nanosec:    %u\n", svp->header.time_nanosec);
+    fprintf(stderr, "dbg5       numBytesDgm:     %u\n", svp->header.numBytesDgm);
+    fprintf(stderr, "dbg5       dgmType:         %.4s\n", svp->header.dgmType);
+    fprintf(stderr, "dbg5       dgmVersion:      %u\n", svp->header.dgmVersion);
+    fprintf(stderr, "dbg5       systemID:        %u\n", svp->header.systemID);
+    fprintf(stderr, "dbg5       echoSounderID:   %u\n", svp->header.echoSounderID);
+    fprintf(stderr, "dbg5       time_sec:        %u\n", svp->header.time_sec);
+    fprintf(stderr, "dbg5       time_nanosec:    %u\n", svp->header.time_nanosec);
 
     fprintf(stderr, "dbg5       numBytesCmnPart:  %u\n", svp->numBytesCmnPart);
     fprintf(stderr, "dbg5       numSamples:       %u\n", svp->numSamples);
@@ -4144,7 +4144,7 @@ int mbr_kemkmall_index_data(int verbose, void *mbio_ptr, void *store_ptr, int *e
 
 #ifdef MBR_KEMKMALL_DEBUG
   fprintf(stderr, "\n\nIndexed %ld valid EM datagrams:\n", dgm_index_table->dgm_count);
-  for (int i=0; i<dgm_index_table->dgm_count; i++)
+  for (unsigned int i=0; i<dgm_index_table->dgm_count; i++)
   {
     fprintf(stderr, "ID: %4d, ", i);
     fprintf(stderr, "file_pos: %8.zu, ", dgm_index_table->indextable[i].file_pos);
@@ -4385,7 +4385,7 @@ numOfDgms, dgmNum, header.numBytesDgm, dgm_index->index_org, dgm_index->ping_num
           break;
 
         case SVT:
-          /* #SVP - Sensor sound Velocity measured at Transducer */
+          /* #SVT - Sensor sound Velocity measured at Transducer */
           status = mbr_kemkmall_rd_svt(verbose, buffer, store_ptr, (void *)&header, error);
           if (status == MB_SUCCESS)
             done = true;
@@ -5065,7 +5065,7 @@ int mbr_kemkmall_wr_spo(int verbose, size_t *bufferalloc, char **bufferptr, void
   }
 
 #ifdef MBR_KEMKMALL_DEBUG
-  fprintf(stderr, "KEMKMALL datagram type %.4s read - time: %d.%9.9d status:%d error:%d\n",
+  fprintf(stderr, "KEMKMALL datagram type %.4s written - time: %d.%9.9d status:%d error:%d\n",
           spo->header.dgmType, spo->header.time_sec, spo->header.time_nanosec, status, *error);
 #endif
 
@@ -5283,7 +5283,7 @@ int mbr_kemkmall_wr_skm(int verbose, size_t *bufferalloc, char **bufferptr, void
   }
 
 #ifdef MBR_KEMKMALL_DEBUG
-  fprintf(stderr, "KEMKMALL datagram type %.4s read - time: %d.%9.9d status:%d error:%d\n",
+  fprintf(stderr, "KEMKMALL datagram type %.4s written - time: %d.%9.9d status:%d error:%d\n",
           skm->header.dgmType, skm->header.time_sec, skm->header.time_nanosec, status, *error);
 #endif
 
@@ -5312,16 +5312,18 @@ int mbr_kemkmall_wr_svp(int verbose, size_t *bufferalloc, char **bufferptr, void
 
   /* datagram version being written */
   svp->header.dgmVersion = MBSYS_KMBES_SVP_VERSION;
+  svp->numBytesCmnPart = 28;
+  svp->header.numBytesDgm = MBSYS_KMBES_HEADER_SIZE + svp->numBytesCmnPart + svp->numSamples * 20 + sizeof(int);
 
   if (verbose >= 5) {
     fprintf(stderr, "\ndbg5  Values to be written in MBIO function <%s>\n", __func__);
-    fprintf(stderr, " dbg5       numBytesDgm:     %u\n", svp->header.numBytesDgm);
-    fprintf(stderr, " dbg5       dgmType:         %s\n", svp->header.dgmType);
-    fprintf(stderr, " dbg5       dgmVersion:      %u\n", svp->header.dgmVersion);
-    fprintf(stderr, " dbg5       systemID:        %u\n", svp->header.systemID);
-    fprintf(stderr, " dbg5       echoSounderID:   %u\n", svp->header.echoSounderID);
-    fprintf(stderr, " dbg5       time_sec:        %u\n", svp->header.time_sec);
-    fprintf(stderr, " dbg5       time_nanosec:    %u\n", svp->header.time_nanosec);
+    fprintf(stderr, "dbg5       numBytesDgm:     %u\n", svp->header.numBytesDgm);
+    fprintf(stderr, "dbg5       dgmType:         %.4s\n", svp->header.dgmType);
+    fprintf(stderr, "dbg5       dgmVersion:      %u\n", svp->header.dgmVersion);
+    fprintf(stderr, "dbg5       systemID:        %u\n", svp->header.systemID);
+    fprintf(stderr, "dbg5       echoSounderID:   %u\n", svp->header.echoSounderID);
+    fprintf(stderr, "dbg5       time_sec:        %u\n", svp->header.time_sec);
+    fprintf(stderr, "dbg5       time_nanosec:    %u\n", svp->header.time_nanosec);
 
     fprintf(stderr, "dbg5       numBytesCmnPart:  %u\n", svp->numBytesCmnPart);
     fprintf(stderr, "dbg5       numSamples:       %u\n", svp->numSamples);
@@ -5359,7 +5361,7 @@ int mbr_kemkmall_wr_svp(int verbose, size_t *bufferalloc, char **bufferptr, void
     buffer = (char *) *bufferptr;
 
     /* insert the header */
-        mbr_kemkmall_wr_header(verbose, bufferptr, (void *)&svp->header, error);
+    mbr_kemkmall_wr_header(verbose, bufferptr, (void *)&svp->header, error);
 
     /* insert the data */
     index = MBSYS_KMBES_HEADER_SIZE;
@@ -5405,7 +5407,7 @@ int mbr_kemkmall_wr_svp(int verbose, size_t *bufferalloc, char **bufferptr, void
   }
 
 #ifdef MBR_KEMKMALL_DEBUG
-  fprintf(stderr, "KEMKMALL datagram type %.4s read - time: %d.%9.9d status:%d error:%d\n",
+  fprintf(stderr, "KEMKMALL datagram type %.4s written - time: %d.%9.9d status:%d error:%d\n",
           svp->header.dgmType, svp->header.time_sec, svp->header.time_nanosec, status, *error);
 #endif
 
@@ -5536,7 +5538,7 @@ int mbr_kemkmall_wr_svt(int verbose, size_t *bufferalloc, char **bufferptr, void
   }
 
 #ifdef MBR_KEMKMALL_DEBUG
-  fprintf(stderr, "KEMKMALL datagram type %.4s read - time: %d.%9.9d status:%d error:%d\n",
+  fprintf(stderr, "KEMKMALL datagram type %.4s written - time: %d.%9.9d status:%d error:%d\n",
           svt->header.dgmType, svt->header.time_sec, svt->header.time_nanosec, status, *error);
 #endif
 
@@ -5646,7 +5648,7 @@ int mbr_kemkmall_wr_scl(int verbose, size_t *bufferalloc, char **bufferptr, void
   }
 
 #ifdef MBR_KEMKMALL_DEBUG
-  fprintf(stderr, "KEMKMALL datagram type %.4s read - time: %d.%9.9d status:%d error:%d\n",
+  fprintf(stderr, "KEMKMALL datagram type %.4s written - time: %d.%9.9d status:%d error:%d\n",
           scl->header.dgmType, scl->header.time_sec, scl->header.time_nanosec, status, *error);
 #endif
 
@@ -5765,7 +5767,7 @@ int mbr_kemkmall_wr_sde(int verbose, size_t *bufferalloc, char **bufferptr, void
   }
 
 #ifdef MBR_KEMKMALL_DEBUG
-  fprintf(stderr, "KEMKMALL datagram type %.4s read - time: %d.%9.9d status:%d error:%d\n",
+  fprintf(stderr, "KEMKMALL datagram type %.4s written - time: %d.%9.9d status:%d error:%d\n",
           sde->header.dgmType, sde->header.time_sec, sde->header.time_nanosec, status, *error);
 #endif
 
@@ -5875,7 +5877,7 @@ int mbr_kemkmall_wr_shi(int verbose, size_t *bufferalloc, char **bufferptr, void
   }
 
 #ifdef MBR_KEMKMALL_DEBUG
-  fprintf(stderr, "KEMKMALL datagram type %.4s read - time: %d.%9.9d status:%d error:%d\n",
+  fprintf(stderr, "KEMKMALL datagram type %.4s written - time: %d.%9.9d status:%d error:%d\n",
           shi->header.dgmType, shi->header.time_sec, shi->header.time_nanosec, status, *error);
 #endif
 

--- a/src/mbio/mbsys_simrad3.c
+++ b/src/mbio/mbsys_simrad3.c
@@ -982,7 +982,7 @@ int mbsys_simrad3_preprocess(int verbose,     /* in: verbosity level set on comm
 		double navlon;
 		double navlat;
 		int jnav;
-    int interp_error = MB_ERROR_NO_ERROR;
+    	int interp_error = MB_ERROR_NO_ERROR;
 		mb_linear_interp_longitude(verbose, pars->nav_time_d - 1, pars->nav_lon - 1, pars->n_nav, time_d, &navlon,
 		                                           &jnav, &interp_error);
 		if (navlon < -180.0)

--- a/src/utilities/mbauvloglist.cc
+++ b/src/utilities/mbauvloglist.cc
@@ -227,7 +227,7 @@ int main(int argc, char **argv) {
 	char file[MB_PATH_MAXLINE] = "";
 	mb_path nav_file = "";
 	bool nav_merge = false;
-  bool nav_merge_clip = false;
+    bool nav_merge_clip = false;
 	output_t output_mode = OUTPUT_MODE_TAB;
 	int nprintfields = 0;
 	struct printfield printfields[NFIELDSMAX];
@@ -235,11 +235,11 @@ int main(int argc, char **argv) {
 	bool calc_soundspeed = false;
 	bool calc_density = false;
 	bool calc_ktime = false;
-  bool calc_kspeed = false;
+    bool calc_kspeed = false;
 	bool recalculate_ctd = false;
 	int ctd_calibration_id = 0;
 	bool angles_in_degrees = false;
-  bool calculate_time_interval  = false;
+    bool calculate_time_interval  = false;
 
 	{
 		bool errflg = false;
@@ -308,8 +308,8 @@ int main(int argc, char **argv) {
 					calc_ktime = true;
 				if (strcmp(printfields[nprintfields].name, "calcKSpeed") == 0)
 					calc_kspeed = true;
-        if (strcmp(printfields[nprintfields].name, "timeInterval") == 0)
-          calculate_time_interval = true;
+        		if (strcmp(printfields[nprintfields].name, "timeInterval") == 0)
+          			calculate_time_interval = true;
 				printfields[nprintfields].index = -1;
 				nprintfields++;
 				break;
@@ -655,11 +655,11 @@ int main(int argc, char **argv) {
 	    }
 	}
 
-  /* if calculating speed from Kearfott velocity vector check for available Kearfott data */
-  if (calc_kspeed && !kvelocity_available) {
+    /* if calculating speed from Kearfott velocity vector check for available Kearfott data */
+    if (calc_kspeed && !kvelocity_available) {
 		fprintf(stderr, "\nUnable to calculate speed from Kearfott data as requested, Kearfoot velocity data not in file <%s>\n", file);
 		exit(MB_ERROR_BAD_FORMAT);
-  }
+    }
 
 	/* check the fields to be printed */
 	for (int i = 0; i < nprintfields; i++) {
@@ -825,8 +825,8 @@ int main(int argc, char **argv) {
 	double soundspeed_calc = 0.0;
 	double potentialtemperature_calc = 0.0;
 	double density_calc = 0.0;
-  double time_interval = 0.0;
-  double prior_time_d = 0.0;
+    double time_interval = 0.0;
+    double prior_time_d = 0.0;
 
 	/* read the data records in the auv log file */
 	int nrecord = 0;


### PR DESCRIPTION
Formats 56 (MBF_EM300RAW) and 57 (MBF_EM300MBA): Fixed catastrophic bug introduced in 5.7.9beta50 that treated many signed values (like acrosstrack distance) as unsigned.

MBgrdviz: Added ability to export routes as TECDIS LST files for display in a variety of marine chart display software.

Autotools build system: Altered Makefile.am files in third_party/googlemock and third_party/googletest to eliminate benign but alarming error messages during make install and make clean commands.

Mbm_route2mission: Added ability to insert a magnetometer calibration maneuver into an AUV mission spiral descent using the -Naltitude/mode command, where altitude is the spiral descent termination altitude and mode = 0 for no start survey behavior, 1 for start survey behavior alone, and 2 for start survey plus a magnetometer calibration maneuver.