### PR TITLE
Fixes to mbnavadjust, mbinfo, mblist, mbtrnpp, CMake build system

### DIFF
--- a/BuildAndInstall.md
+++ b/BuildAndInstall.md
@@ -266,11 +266,11 @@ software for MB-System.
 
 * Install MB-System prerequisites:
 
-	    sudo apt install libnetcdf-bin libnetcdf-dev libgdal-dev \
+	    sudo apt install netcdf-bin libnetcdf-dev libgdal-dev \
 	      gmt libgmt6 libgmt-dev libproj-dev \
 	      libfftw3-3 libfftw3-dev libmotif-dev \
 	      xfonts-100dpi libglu1-mesa-dev \
-	      libopencv-dev gfortran
+	      libopencv-dev cmake gfortran
 
   MB-System also requires Python3 and the Pillow library for Python3. Both of these packages
   are installed by default in Ubuntu 20 and 22.
@@ -784,7 +784,7 @@ Once Cygwin and the prerequisite packages are installed, proceed as follows:
 	    
 
 ---
-### Updating an MB-System installation
+### Updating an MB-System Installation
 ---
 
 When one updates to a new MB-System version, we recommend uninstalling the previous 
@@ -799,7 +799,6 @@ whether using the Autotools or the CMake build system:
 Then follow the appropriate installation instructions starting with downloading the next 
 version from GitHub.
 
-
 ---
 ### Docker Container with MB-System
 ---
@@ -812,6 +811,13 @@ The MB-System docker image is available at
 Documentation is available at:
     https://github.com/dwcaress/MB-System/tree/master/docker/user
     https://github.com/dwcaress/MB-System/blob/master/docker/user/README-win11.md
+
+
+---
+### Packaged MB-System Distributions
+---
+
+There currently are no packaged distributions of MB-System. We are working on establishing them again.
 
 
 ---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,12 +48,12 @@ message("Build shared/static libraries with -DBUILD_SHARED_LIBS=ON/OFF")
 message("Disable building TRN software with -DbuildTRN=OFF")
 message("Disable building photomosaicing software with -DbuildOpenCV=OFF")
 message("Build Qt-based GUIs with -DbuildQt=ON")
-message("Build unit tests with -DbuildTests=ON")
+message("Disable unit tests with -DbuildTests=OFF (run unit tests with make test)")
 message("Print out all CMake variables with -Dverbose=1")
 message("----------------------------------------------------------")
 
 # Define minimum CMake version required
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 
 # Define project
 project(MB-System 
@@ -97,7 +97,7 @@ option(buildOpenCV "build OpenCV tools" ON)
 option(buildTRN "build MBTRN tools" ON)
 option(buildPCL "build point-cloud-library" OFF)
 option(buildQt "build Qt tools" OFF)
-option(buildTests "build unit tests exercised by make check" OFF)
+option(buildTests "build unit tests exercised by make test" ON)
 
 set(CMAKE_INSTALL_MANPAGES /usr/local/share/man) 
 set(CMAKE_INSTALL_DOC /usr/local/share/doc) 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@ Distributions that do not include "beta" in the tag name correspond to the major
 announced releases. The source distributions associated with all releases, major
 or beta, are equally accessible as tarballs through the Github interface.
 
+- Version 5.7.9beta65    November 17, 2023
 - Version 5.7.9beta64    November 16, 2023
 - Version 5.7.9beta63    November 10, 2023
 - Version 5.7.9beta62    November 3, 2023
@@ -437,6 +438,24 @@ or beta, are equally accessible as tarballs through the Github interface.
 --
 ### MB-System Version 5.7 Release Notes:
 --
+
+#### 5.7.9beta65 (November 17, 2023)
+
+Mbinfo and mblist: Fixed bug introduced with the alternate navigation capability that
+caused mbinfo and mblist to fail when running on single files rather than through datalists.
+
+Mbnavadjust: Improved handling of reference grids. The list of reference grids now starts
+with an option "<Previously Selected Reference Grid>" that will cause loading a section 
+with a global tie set to also load the reference grid (if any) loaded when the tie was
+created. If a specific reference grid is selected from the reference grid list, then that
+reference grid will be loaded when any section is loaded, regardless of whether a prior
+global tie already exists. 
+
+Mbtrnpp: Fixed bug identified by Kent Headley that caused divide by zeros when calculating swath
+width filtering of soundings.
+
+CMake build system: Fixed the unit testing, and enabled building unit tests by default.
+After "make all" is run, the unit tests can be run with "make test".
 
 #### 5.7.9beta64 (November 16, 2023)
 

--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -37,8 +37,8 @@
 #include <stdint.h>
 
 /* Define version and date for this release */
-#define MB_VERSION "5.7.9beta64"
-#define MB_VERSION_DATE "16 November 2023"
+#define MB_VERSION "5.7.9beta65"
+#define MB_VERSION_DATE "17 November 2023"
 
 /* CMake supports current OS's and so there is only one form of RPC and XDR and no mb_config.h file */
 #ifdef CMAKE_BUILD_SYSTEM

--- a/src/mbnavadjust/mbnavadjust_callbacks.c
+++ b/src/mbnavadjust/mbnavadjust_callbacks.c
@@ -601,7 +601,7 @@ void do_update_status() {
   if (project.refgrid_select >= 0 && project.refgrid_select < project.num_refgrids)
     strcpy(refgrid_name, project.refgrid_names[project.refgrid_select]);
   else
-    strcpy(refgrid_name, "NONE");
+    strcpy(refgrid_name, "<Previously Selected Reference Grid>");
   mb_command string = "";
   snprintf(string, sizeof(string), 
     ":::t\"Project: %s\""
@@ -682,20 +682,23 @@ void do_update_status() {
     if (mbna_verbose > 0)
       fprintf(stderr, "%s\n", string);
     if (project.num_refgrids > 0) {
-      XmString *xstr = (XmString *)malloc(project.num_refgrids * sizeof(XmString));
+      XmString *xstr = (XmString *)malloc((project.num_refgrids + 1) * sizeof(XmString));
+      xstr[0] = XmStringCreateLocalized("<Previously Selected Grid>");
+      if (mbna_verbose > 0)
+        fprintf(stderr, "<Previously Selected Grid>\n");
       for (int i = 0; i < project.num_refgrids; i++) {
-        xstr[i] = XmStringCreateLocalized(project.refgrid_names[i]);
+        xstr[i+1] = XmStringCreateLocalized(project.refgrid_names[i]);
         if (mbna_verbose > 0)
           fprintf(stderr, "%s\n", project.refgrid_names[i]);
       }
-      XmListAddItems(list_data, xstr, project.num_refgrids, 0);
-      for (int i = 0; i < project.num_refgrids; i++) {
+      XmListAddItems(list_data, xstr, project.num_refgrids + 1, 0);
+      for (int i = 0; i < project.num_refgrids + 1; i++) {
         XmStringFree(xstr[i]);
       }
       free(xstr);
     }
-    XmListSelectPos(list_data, project.refgrid_select + 1, 0);
-    XmListSetPos(list_data, MAX(project.refgrid_select + 1 - 5, 1));
+    XmListSelectPos(list_data, project.refgrid_select + 2, 0);
+    XmListSetPos(list_data, MAX(project.refgrid_select + 2 - 5, 1));
   }
   else if (mbna_view_list == MBNA_VIEW_LIST_SURVEYS) {
     snprintf(string, sizeof(string), "Surveys:");
@@ -1718,19 +1721,19 @@ void do_update_status() {
   }
   else if (mbna_view_list == MBNA_VIEW_LIST_GLOBALTIES) {
     if (mbna_view_mode == MBNA_VIEW_MODE_ALL)
-      snprintf(string, sizeof(string), "Global Ties:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr");
+      snprintf(string, sizeof(string), "Global Ties:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr");
     else if (mbna_view_mode == MBNA_VIEW_MODE_SURVEY)
-      snprintf(string, sizeof(string), "Global Ties of Survey %d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select);
+      snprintf(string, sizeof(string), "Global Ties of Survey %d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select);
     else if (mbna_view_mode == MBNA_VIEW_MODE_BLOCK)
-      snprintf(string, sizeof(string), "Global Ties of Survey-vs-Survey Block %d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_block_select);
+      snprintf(string, sizeof(string), "Global Ties of Survey-vs-Survey Block %d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_block_select);
     else if (mbna_view_mode == MBNA_VIEW_MODE_FILE)
-      snprintf(string, sizeof(string), "Global Ties of File %d:%d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select);
+      snprintf(string, sizeof(string), "Global Ties of File %d:%d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select);
     else if (mbna_view_mode == MBNA_VIEW_MODE_WITHSURVEY)
-      snprintf(string, sizeof(string), "Global Ties with Survey %d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select);
+      snprintf(string, sizeof(string), "Global Ties with Survey %d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select);
     else if (mbna_view_mode == MBNA_VIEW_MODE_WITHFILE)
-      snprintf(string, sizeof(string), "Global Ties of File %d:%d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select);
+      snprintf(string, sizeof(string), "Global Ties of File %d:%d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select);
     else if (mbna_view_mode == MBNA_VIEW_MODE_WITHSECTION)
-      snprintf(string, sizeof(string), "Global Ties of Section %d:%d:%d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select, mbna_section_select);
+      snprintf(string, sizeof(string), "Global Ties of Section %d:%d:%d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select, mbna_section_select);
     else
       snprintf(string, sizeof(string), "Global Ties:");
     set_label_string(label_listdata, string);
@@ -1791,24 +1794,24 @@ void do_update_status() {
               tiestatus = tiestatus_z_f;
             if (section->globaltie.inversion_status == MBNA_INVERSION_CURRENT)
               sprintf(string,
-                "%2.2d:%4.4d:%3.3d:%2.2d %s %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %6.3f",
-                project.files[i].block, i, j, section->globaltie.snav, tiestatus,
+                "%2.2d:%4.4d:%3.3d:%2.2d %s %2d %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %6.3f",
+                project.files[i].block, i, j, section->globaltie.snav, tiestatus, section->globaltie.refgrid_id, 
                 section->globaltie.offset_x_m, section->globaltie.offset_y_m, section->globaltie.offset_z_m,
                 section->globaltie.sigmar1, section->globaltie.sigmar2, section->globaltie.sigmar3,
                 section->globaltie.dx_m, section->globaltie.dy_m, section->globaltie.dz_m,
                 section->globaltie.sigma_m, section->globaltie.rsigma_m);
             else if (section->globaltie.inversion_status == MBNA_INVERSION_OLD)
               sprintf(string,
-                "%2.2d:%4.4d:%3.3d:%2.2d %s %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %6.3f ***",
-                project.files[i].block, i, j, section->globaltie.snav, tiestatus,
+                "%2.2d:%4.4d:%3.3d:%2.2d %s %2d %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %6.3f ***",
+                project.files[i].block, i, j, section->globaltie.snav, tiestatus, section->globaltie.refgrid_id,
                 section->globaltie.offset_x_m, section->globaltie.offset_y_m, section->globaltie.offset_z_m,
                 section->globaltie.sigmar1, section->globaltie.sigmar2, section->globaltie.sigmar3,
                 section->globaltie.dx_m, section->globaltie.dy_m, section->globaltie.dz_m,
                 section->globaltie.sigma_m, section->globaltie.rsigma_m);
             else
               sprintf(string,
-                "%2.2d:%4.4d:%3.3d:%2.2d %s %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f",
-                project.files[i].block, i, j, section->globaltie.snav, tiestatus,
+                "%2.2d:%4.4d:%3.3d:%2.2d %s %2d %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f",
+                project.files[i].block, i, j, section->globaltie.snav, tiestatus, section->globaltie.refgrid_id,
                 section->globaltie.offset_x_m, section->globaltie.offset_y_m, section->globaltie.offset_z_m,
                 section->globaltie.sigmar1, section->globaltie.sigmar2, section->globaltie.sigmar3);
             xstr[num_globalties] = XmStringCreateLocalized(string);
@@ -1834,19 +1837,19 @@ void do_update_status() {
   }
   else if (mbna_view_list == MBNA_VIEW_LIST_GLOBALTIESSORTED) {
     if (mbna_view_mode == MBNA_VIEW_MODE_ALL)
-      snprintf(string, sizeof(string), "Global Ties:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr");
+      snprintf(string, sizeof(string), "Global Ties:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr");
     else if (mbna_view_mode == MBNA_VIEW_MODE_SURVEY)
-      snprintf(string, sizeof(string), "Global Ties of Survey %d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select);
+      snprintf(string, sizeof(string), "Global Ties of Survey %d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select);
     else if (mbna_view_mode == MBNA_VIEW_MODE_BLOCK)
-      snprintf(string, sizeof(string), "Global Ties of Survey-vs-Survey Block %d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_block_select);
+      snprintf(string, sizeof(string), "Global Ties of Survey-vs-Survey Block %d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_block_select);
     else if (mbna_view_mode == MBNA_VIEW_MODE_FILE)
-      snprintf(string, sizeof(string), "Global Ties of File %d:%d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select);
+      snprintf(string, sizeof(string), "Global Ties of File %d:%d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select);
     else if (mbna_view_mode == MBNA_VIEW_MODE_WITHSURVEY)
-      snprintf(string, sizeof(string), "Global Ties with Survey %d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select);
+      snprintf(string, sizeof(string), "Global Ties with Survey %d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select);
     else if (mbna_view_mode == MBNA_VIEW_MODE_WITHFILE)
-      snprintf(string, sizeof(string), "Global Ties of File %d:%d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select);
+      snprintf(string, sizeof(string), "Global Ties of File %d:%d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select);
     else if (mbna_view_mode == MBNA_VIEW_MODE_WITHSECTION)
-      snprintf(string, sizeof(string), "Global Ties of Section %d:%d:%d:  Xing Tie Stat Sur1:Fil1:Sec1:Nv1 Sur2:Fil2:Sec2:Nv2 Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select, mbna_section_select);
+      snprintf(string, sizeof(string), "Global Ties of Section %d:%d:%d:  Sur:File:Sec:Nv Stat RefGrid  Offx Offy Offz | S1 S2 S3 | Ex Ey Ez | Se Sr", mbna_survey_select, mbna_file_select, mbna_section_select);
     else
       snprintf(string, sizeof(string), "Global Ties:");
     set_label_string(label_listdata, string);
@@ -1921,30 +1924,30 @@ void do_update_status() {
           tiestatus = tiestatus_z_f;
         if (section->globaltie.inversion_status == MBNA_INVERSION_CURRENT)
           sprintf(string,
-            "%2.2d:%4.4d:%3.3d:%2.2d %s %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %6.3f",
+            "%2.2d:%4.4d:%3.3d:%2.2d %s %2d %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %6.3f",
             project.files[section->file_id].block,
             section->file_id, section->section_id,
-            section->globaltie.snav, tiestatus,
+            section->globaltie.snav, tiestatus, section->globaltie.refgrid_id,
             section->globaltie.offset_x_m, section->globaltie.offset_y_m, section->globaltie.offset_z_m,
             section->globaltie.sigmar1, section->globaltie.sigmar2, section->globaltie.sigmar3,
             section->globaltie.dx_m, section->globaltie.dy_m, section->globaltie.dz_m,
             section->globaltie.sigma_m, section->globaltie.rsigma_m);
         else if (section->globaltie.inversion_status == MBNA_INVERSION_OLD)
           sprintf(string,
-            "%2.2d:%4.4d:%3.3d:%2.2d %s %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %6.3f ***",
+            "%2.2d:%4.4d:%3.3d:%2.2d %s %2d %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f | %8.2f %6.3f ***",
             project.files[section->file_id].block,
             section->file_id, section->section_id,
-            section->globaltie.snav, tiestatus,
+            section->globaltie.snav, tiestatus, section->globaltie.refgrid_id,
             section->globaltie.offset_x_m, section->globaltie.offset_y_m, section->globaltie.offset_z_m,
             section->globaltie.sigmar1, section->globaltie.sigmar2, section->globaltie.sigmar3,
             section->globaltie.dx_m, section->globaltie.dy_m, section->globaltie.dz_m,
             section->globaltie.sigma_m, section->globaltie.rsigma_m);
         else
           sprintf(string,
-            "%2.2d:%4.4d:%3.3d:%2.2d %s %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f",
+            "%2.2d:%4.4d:%3.3d:%2.2d %s %2d %8.2f %8.2f %8.2f | %8.2f %8.2f %8.2f",
             project.files[section->file_id].block,
             section->file_id, section->section_id,
-            section->globaltie.snav, tiestatus,
+            section->globaltie.snav, tiestatus, section->globaltie.refgrid_id,
             section->globaltie.offset_x_m, section->globaltie.offset_y_m, section->globaltie.offset_z_m,
             section->globaltie.sigmar1, section->globaltie.sigmar2, section->globaltie.sigmar3);
         xstr[kk] = XmStringCreateLocalized(string);
@@ -2914,7 +2917,7 @@ void do_list_data_select(Widget w, XtPointer client_data, XtPointer call_data) {
     bool found = true;
 
     if (mbna_view_list == MBNA_VIEW_LIST_REFERENCEGRIDS) {
-      project.refgrid_select = position_list[0] - 1;
+      project.refgrid_select = position_list[0] - 2;
 fprintf(stderr,"mbna_referencegrid_select:%d of %d\n", project.refgrid_select, project.num_refgrids);
     }
     else if (mbna_view_list == MBNA_VIEW_LIST_SURVEYS) {

--- a/src/mbnavadjust/mbnavadjust_io.h
+++ b/src/mbnavadjust/mbnavadjust_io.h
@@ -409,6 +409,7 @@ struct mbna_project {
   int inversion_status;
 
   int refgrid_status;
+  int refgrid_loaded;
   int refgrid_select;
   struct mbna_grid refgrid;
   struct mbna_section reference_section;

--- a/src/mbtrnutils/mbtrnpp.c
+++ b/src/mbtrnutils/mbtrnpp.c
@@ -3985,8 +3985,13 @@ int main(int argc, char **argv) {
           beam_end = 0;
           for (int j = 0; j < ping[i_ping_process].beams_bath; j++) {
             if (mb_beam_ok(ping[i_ping_process].beamflag_filter[j])) {
-              tangent = ping[i_ping_process].bathacrosstrack[j] /
-                        (ping[i_ping_process].bath[j] - ping[i_ping_process].sensordepth);
+              if(ping[i_ping_process].bath[j] <= ping[i_ping_process].sensordepth) {
+                // invalidate tangent calculation because the denominator zero or negative
+                tangent = threshold_tangent + 1.0;
+              } else {
+                tangent = ping[i_ping_process].bathacrosstrack[j]
+                            / (ping[i_ping_process].bath[j] - ping[i_ping_process].sensordepth);
+              }
               if (fabs(tangent) > threshold_tangent && mb_beam_ok(ping[i_ping_process].beamflag_filter[j])) {
                 ping[i_ping_process].beamflag_filter[j] = MB_FLAG_FLAG + MB_FLAG_FILTER;
                 n_soundings_trimmed++;

--- a/src/utilities/mbinfo.cc
+++ b/src/utilities/mbinfo.cc
@@ -549,7 +549,7 @@ int main(int argc, char **argv) {
       char apath[MB_PATH_MAXLINE] = "";
       char dpath[MB_PATH_MAXLINE] = "";
       int pstatus;
-      int astatus;
+      int astatus = 0;
       if (read_datalist) {
         const int look_processed = MB_DATALIST_LOOK_UNSET;
         if (mb_datalist_open(verbose, &datalist, read_file, look_processed, &error) != MB_SUCCESS) {
@@ -563,6 +563,7 @@ int main(int argc, char **argv) {
         // else copy single filename to be read
         strcpy(path, read_file);
         read_data = true;
+        astatus = 0;
       }
 
       /* loop over all files to be read */

--- a/src/utilities/mblist.cc
+++ b/src/utilities/mblist.cc
@@ -1159,7 +1159,7 @@ int main(int argc, char **argv) {
   char dpath[MB_PATH_MAXLINE] = "";
   double file_weight;
   int pstatus;
-  int astatus;
+  int astatus = 0;
 
   /* open file list */
   if (read_datalist) {
@@ -1175,6 +1175,7 @@ int main(int argc, char **argv) {
     // else copy single filename to be read
     strcpy(path, read_file);
     read_data = true;
+    astatus = 0;
   }
 
   double btime_d;

--- a/test/mbio/CMakeLists.txt
+++ b/test/mbio/CMakeLists.txt
@@ -1,10 +1,12 @@
 ##find_package(GTest REQUIRED)
+message("In test/mbio")
 
 set(tests mb_defaults_test mb_error_test mb_format_test mb_mem_test
           mb_read_init_test mb_time_test)
 
 foreach(test ${tests})
   add_executable(${test} ${test}.cc)
+  target_include_directories(${test} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ../../src)
   target_link_libraries(${test} PRIVATE mbio GTest::gmock_main)
   add_test(NAME ${test} COMMAND ${test})
 endforeach()


### PR DESCRIPTION
Mbinfo and mblist: Fixed bug introduced with the alternate navigation capability that caused mbinfo and mblist to fail when running on single files rather than through datalists.

Mbnavadjust: Improved handling of reference grids. The list of reference grids now starts with an option "<Previously Selected Reference Grid>" that will cause loading a section with a global tie set to also load the reference grid (if any) loaded when the tie was created. If a specific reference grid is selected from the reference grid list, then that reference grid will be loaded when any section is loaded, regardless of whether a prior global tie already exists.

Mbtrnpp: Fixed bug identified by Kent Headley that caused divide by zeros when calculating swath width filtering of soundings.

CMake build system: Fixed the unit testing, and enabled building unit tests by default. After "make all" is run, the unit tests can be run with "make test".