### PR TITLE
Fixes for 5.7.9beta69

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@ Distributions that do not include "beta" in the tag name correspond to the major
 announced releases. The source distributions associated with all releases, major
 or beta, are equally accessible as tarballs through the Github interface.
 
+- Version 5.7.9beta69    December 17, 2023
 - Version 5.7.9beta68    November 30, 2023
 - Version 5.7.9beta66    November 18, 2023
 - Version 5.7.9beta65    November 17, 2023
@@ -440,6 +441,22 @@ or beta, are equally accessible as tarballs through the Github interface.
 --
 ### MB-System Version 5.7 Release Notes:
 --
+
+#### 5.7.9beta69 (December 17, 2023)
+
+Format 192 (MBR_IMAGEMBA): Fixed correction of beam amplitude values (previously
+corrected values were not successfully inserted into the data structure).
+
+Mbauvloglist: Program altered so that time and utcTime fields are printed by
+default in format %17.6f and %12.6f, respectively, even though the MBARI Dorado AUV
+log files have default formats of %8.8e instead. Now by default the timestamps are
+printed usefully with precision to microseconds.
+
+Mbbackangle: Fixed bug in which mbbackangle did not process sidescan or amplitude
+data from files in formats that support variable numbers of beams and pixels.
+
+Mbsslayout: Fixed bug in which a command to swap the starboard and port sidescan
+channels was ignored.
 
 #### 5.7.9beta68 (November 30, 2023)
 

--- a/src/macros/mbm_grdplot
+++ b/src/macros/mbm_grdplot
@@ -308,6 +308,7 @@ if ($help)
   print "\t\t-MNA[name_hgt[/P] | P] -MNFformat -MNIdatalist\n";
   print "\t\t-MNN[time_tick/time_annot/date_annot/time_tick_len[/name_hgt] | F | FP]\n";
   print "\t\t-MNP[pingnumber_tick/pingnumber_annot/pingnumber_tick_len]\n";
+  print "\t\t-MNWpen\n";
   print "\t\t-MTCfill -MTDresolution -MTGfill -MTIriver[/pen]\n";
   print "\t\t-MTNborder[/pen] -MTSfill -MTWpen\n";
   print "\t\t-MXGfill -MXIxy_file -MXM -MXSsymbol/size -MXWpen]\n";
@@ -611,6 +612,13 @@ if ($misc)
       $pingnumber_tick_len = 0.10;
       $pingnumber_annot = 100;
       $pingnumber_tick = 50;
+      }
+
+    # set swath navigation pen
+    if ($cmd =~ /^[Nn][Ww]./)
+      {
+      ($nav_pen) = $cmd =~
+        /^[Nn][Ww](\S+)/;
       }
 
     # deal with pscoast options
@@ -2872,6 +2880,14 @@ if ($swathnavdatalist)
     {
     printf FCMD "-M$pingnumber_control \\\n\t";
     }
+  if ($nav_pen)
+    {
+    # Note: This doesn't work because mbcontour is not using the GMT pen attributes but
+    # instead setting PSL postscript values directly with mboncontour_setline() 
+    # and mbcontour_newpen()
+    printf FCMD "-W$nav_pen \\\n\t";
+    }
+
   if ($portrait)
     {
     printf FCMD "-P ";
@@ -3344,6 +3360,10 @@ if ($verbose)
         print "    Name annotation style:    Parallel\n";
         }
       }
+    if ($nav_pen)
+      {
+      print "    Navigation pen:             $nav_pen\n";
+       }
     }
   if (@xyfiles)
     {

--- a/src/mbaux/mb_track.c
+++ b/src/mbaux/mb_track.c
@@ -63,7 +63,7 @@ void mb_track(int verbose, struct swath *data, int *error) {
 	}
 
 	/* set line width */
-	data->contour_setline(0);
+	data->contour_setline(1);
 	data->contour_newpen(0);
 
 	/* draw the time ticks */

--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -37,8 +37,8 @@
 #include <stdint.h>
 
 /* Define version and date for this release */
-#define MB_VERSION "5.7.9beta68"
-#define MB_VERSION_DATE "30 November 2023"
+#define MB_VERSION "5.7.9beta69"
+#define MB_VERSION_DATE "17 December 2023"
 
 /* CMake supports current OS's and so there is only one form of RPC and XDR and no mb_config.h file */
 #ifdef CMAKE_BUILD_SYSTEM

--- a/src/mbio/mbsys_image83p.c
+++ b/src/mbio/mbsys_image83p.c
@@ -1045,6 +1045,7 @@ int mbsys_image83p_insert(int verbose, void *mbio_ptr, void *store_ptr, int kind
 		for (int i = 0; i < nbath; i++) {
 			store->beamflag[i] = beamflag[i];
 			store->bath[i] = bath[i];
+      store->amp[i] = amp[i];
 			store->bathacrosstrack[i] = bathacrosstrack[i];
 			store->bathalongtrack[i] = bathalongtrack[i];
 		}

--- a/src/mbio/mbsys_image83p.h
+++ b/src/mbio/mbsys_image83p.h
@@ -460,7 +460,7 @@ struct mbsys_image83p_struct {
 	float bath[MBSYS_IMAGE83P_BEAMS];
 	float bathacrosstrack[MBSYS_IMAGE83P_BEAMS];
 	float bathalongtrack[MBSYS_IMAGE83P_BEAMS];
-  float amp[MBSYS_IMAGE83P_BEAMS];
+    float amp[MBSYS_IMAGE83P_BEAMS];
 	char beamflag[MBSYS_IMAGE83P_BEAMS];
 
 	/* comment */

--- a/src/utilities/mbauvloglist.cc
+++ b/src/utilities/mbauvloglist.cc
@@ -661,6 +661,7 @@ int main(int argc, char **argv) {
 				fields[nfields].type = TYPE_TIMETAG;
 				fields[nfields].size = 8;
 				fields[nfields].scale = 1.0;
+				strcpy(fields[nfields].format, "%17.6f"); /* reset printing format from "%8.8e" */
 				recordsize += 8;
 			}
 			else if (strcmp(type, "angle") == 0) {
@@ -677,8 +678,10 @@ int main(int argc, char **argv) {
 			}
 
       /* check if kearfott time is in this file */
-      if (strcmp(fields[nfields].name, "utcTime") == 0)
-          ktime_available = true;
+      if (strcmp(fields[nfields].name, "utcTime") == 0) {
+        ktime_available = true;
+				strcpy(fields[nfields].format, "%12.6f"); /* reset printing format from "%8.8e" */
+      }
 
       /* check if kearfott velocity vector is in this file */
       if (strcmp(fields[nfields].name, "mVbodyxK") == 0)

--- a/src/utilities/mbbackangle.cc
+++ b/src/utilities/mbbackangle.cc
@@ -885,11 +885,11 @@ int main(int argc, char **argv) {
 	                   &cvariable_beams, &ctraveltime, &cbeam_flagging, &cplatform_source, &cnav_source,
 	                   &csensordepth_source, &cheading_source, &cattitude_source, &csvp_source, &cbeamwidth_xtrack,
 	                   &cbeamwidth_ltrack, &error);
-			if (amplitude_on && cbeams_amp_max <= 0) {
+			if (amplitude_on && cbeams_amp_max <= 0 && !cvariable_beams) {
 				ok_to_process = false;
 				fprintf(stderr, "Skipping swath file: %s because format %d does not include amplitude data\n", swathfile, format);
 			}
-			if (sidescan_on && cpixels_ss_max <= 0) {
+			if (sidescan_on && cpixels_ss_max <= 0 && !cvariable_beams) {
 				ok_to_process = false;
 				fprintf(stderr, "Skipping swath file: %s because format %d does not include sidescan data\n", swathfile, format);
 			}

--- a/src/utilities/mbprocess.cc
+++ b/src/utilities/mbprocess.cc
@@ -985,7 +985,7 @@ void process_file(int verbose, int thread_id, struct mb_process_struct *process,
     fprintf(stderr, "\nSidescan Corrections:\n");
     if (process->mbp_sscorr_mode == MBP_SSCORR_ON) {
       fprintf(stderr, "  Amplitude vs grazing angle corrections applied to sidescan.\n");
-      fprintf(stderr, "  Sidescan correction file:      %s m\n", process->mbp_sscorrfile);
+      fprintf(stderr, "  Sidescan correction file:      %s\n", process->mbp_sscorrfile);
       if (process->mbp_sscorr_type == MBP_SSCORR_SUBTRACTION)
         fprintf(stderr, "  Sidescan correction by subtraction (dB scale)\n");
       else
@@ -999,7 +999,7 @@ void process_file(int verbose, int thread_id, struct mb_process_struct *process,
         fprintf(stderr, "  Sidescan correction uses swath bathymetry in file\n");
       else {
         fprintf(stderr, "  Sidescan correction uses topography grid\n");
-        fprintf(stderr, "  Topography grid file:      %s m\n", process->mbp_ampsscorr_topofile);
+        fprintf(stderr, "  Topography grid file:      %s\n", process->mbp_ampsscorr_topofile);
       }
       if (process->mbp_sscorr_slope == MBP_SSCORR_IGNORESLOPE || process->mbp_sscorr_slope == MBP_SSCORR_USETOPO)
         fprintf(stderr, "  Sidescan correction ignores seafloor slope\n");
@@ -5153,10 +5153,12 @@ void process_file(int verbose, int thread_id, struct mb_process_struct *process,
             /* apply correction */
             *status = get_anglecorr(verbose, ampcorrtableuse.nangle, ampcorrtableuse.angle,
                                    ampcorrtableuse.amplitude, angle, &correction, error);
-            if (process->mbp_ampcorr_type == MBP_AMPCORR_SUBTRACTION)
+            if (process->mbp_ampcorr_type == MBP_AMPCORR_SUBTRACTION) {
               amp[i] = amp[i] - correction + reference_amp;
-            else
+            }
+            else {
               amp[i] = amp[i] / correction * reference_amp;
+            }
           }
         }
       }
@@ -5465,12 +5467,13 @@ void process_file(int verbose, int thread_id, struct mb_process_struct *process,
               esf.edit[i].beam, esf.edit[i].action, esf.edit[i].use);
       }
     }
-  }
-  if (verbose >= 1) {
-    fprintf(stderr, "          %d flags used\n", neditused);
-    fprintf(stderr, "          %d flags not used\n", neditnotused);
-    fprintf(stderr, "          %d flags tied to null beams\n", neditnull);
-    fprintf(stderr, "          %d duplicate flags\n", neditduplicate);
+    if (verbose >= 1) {
+      fprintf(stderr, "\nBathymetry edit use:\n");
+      fprintf(stderr, "  %d flags used\n", neditused);
+      fprintf(stderr, "  %d flags not used\n", neditnotused);
+      fprintf(stderr, "  %d flags tied to null beams\n", neditnull);
+      fprintf(stderr, "  %d duplicate flags\n", neditduplicate);
+    }
   }
 
   /*--------------------------------------------

--- a/src/utilities/mbsslayout.cc
+++ b/src/utilities/mbsslayout.cc
@@ -252,7 +252,7 @@ int main(int argc, char **argv) {
 	int layout_mode = MBSSLAYOUT_LAYOUT_FLATBOTTOM;
 	int ss_altitude_mode = MBSSLAYOUT_ALTITUDE_ALTITUDE;
 	double bottompick_threshold = 0.5;
-  double bottompick_blank = 0.0;
+    double bottompick_blank = 0.0;
 	bool channel_swap = false;
 	double swath_width = 0.0;
 	int swath_mode = MBSSLAYOUT_SWATHWIDTH_VARIABLE;
@@ -2217,9 +2217,16 @@ int main(int argc, char **argv) {
 				}
 
 				/* call mb_extract_rawss() */
-				/* status = */ mb_extract_rawss(verbose, imbio_ptr, istore_ptr, &kind, &sidescan_type, &sample_interval,
+				if (channel_swap) {
+					/* status = */ mb_extract_rawss(verbose, imbio_ptr, istore_ptr, &kind, &sidescan_type, &sample_interval,
+				                          &beamwidth_xtrack, &beamwidth_ltrack, &num_samples_stbd, raw_samples_stbd,
+				                          &num_samples_port, raw_samples_port, &error);
+				}
+				else {
+					/* status = */ mb_extract_rawss(verbose, imbio_ptr, istore_ptr, &kind, &sidescan_type, &sample_interval,
 				                          &beamwidth_xtrack, &beamwidth_ltrack, &num_samples_port, raw_samples_port,
 				                          &num_samples_stbd, raw_samples_stbd, &error);
+				}
 
 				/* call mb_extract_nav to get attitude */
 				/* status = */ mb_extract_nav(verbose, imbio_ptr, istore_ptr, &kind, time_i, &time_d, &navlon_org, &navlat_org,
@@ -2309,7 +2316,7 @@ int main(int argc, char **argv) {
 
 				/* if specified get altitude from raw sidescan */
 				if (ss_altitude_mode == MBSSLAYOUT_ALTITUDE_BOTTOMPICK) {
-          int istart = bottompick_blank / sample_interval;
+                    int istart = bottompick_blank / sample_interval;
 
 					/* get bottom arrival in port trace */
 					channelmax = 0.0;


### PR DESCRIPTION
#### 5.7.9beta69 (December 17, 2023)

Format 192 (MBR_IMAGEMBA): Fixed correction of beam amplitude values (previously corrected values were not successfully inserted into the data structure).

Mbauvloglist: Program altered so that time and utcTime fields are printed by default in format %17.6f and %12.6f, respectively, even though the MBARI Dorado AUV log files have default formats of %8.8e instead. Now by default the timestamps are printed usefully with precision to microseconds.

Mbbackangle: Fixed bug in which mbbackangle did not process sidescan or amplitude data from files in formats that support variable numbers of beams and pixels.

Mbsslayout: Fixed bug in which a command to swap the starboard and port sidescan channels was ignored.