### PR TITLE
Cmake build system fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@ Distributions that do not include "beta" in the tag name correspond to the major
 announced releases. The source distributions associated with all releases, major
 or beta, are equally accessible as tarballs through the Github interface.
 
+- Version 5.7.9beta71    January 3, 2024
 - Version 5.7.9beta70    January 2, 2024
 - Version 5.7.9beta69    December 17, 2023
 - Version 5.7.9beta68    November 30, 2023
@@ -442,6 +443,12 @@ or beta, are equally accessible as tarballs through the Github interface.
 --
 ### MB-System Version 5.7 Release Notes:
 --
+
+#### 5.7.9beta71 (January 3, 2024)
+
+CMake build system: Fixed creating the levitus.h header file used by mblevitus
+and mbconfig to define the location of the Levitus database and the OTPS 
+installation, thereby making mblevitus and mbconfig work properly.
 
 #### 5.7.9beta70 (January 2, 2024)
 

--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -37,8 +37,8 @@
 #include <stdint.h>
 
 /* Define version and date for this release */
-#define MB_VERSION "5.7.9beta70"
-#define MB_VERSION_DATE "2 January 2024"
+#define MB_VERSION "5.7.9beta71"
+#define MB_VERSION_DATE "3 January 2024"
 
 /* CMake supports current OS's and so there is only one form of RPC and XDR and no mb_config.h file */
 #ifdef CMAKE_BUILD_SYSTEM

--- a/src/otps/CMakeLists.txt
+++ b/src/otps/CMakeLists.txt
@@ -3,7 +3,7 @@ message("In src/otps")
 add_executable(mbotps mbotps.c otps.h)
 
 file(WRITE otps.h
-	"char *otps_location = \"${otpsDir}\";")
+	"const char *otps_location = \"${otpsDir}\";")
  
 target_link_libraries(mbotps PRIVATE mbio)
 

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -21,7 +21,6 @@ set(executables
     mbsslayout
     mbbackangle
     mbextractsegy
-    mblevitus
     mbrolltimelag
     mbsvplist
     mbclean
@@ -29,7 +28,6 @@ set(executables
     mblist
     mbroutetime
     mbsvpselect
-    mbconfig
     mbformat
     mbmakeplatform
     mbsegygrid
@@ -49,15 +47,24 @@ foreach(executable ${executables})
   target_link_libraries(${executable} PRIVATE mbio mbbsio mbaux mbsapi mbgsf m pthread)
 endforeach()
 
+add_executable(mblevitus mblevitus.cc levitus.h)
+target_link_libraries(mblevitus PRIVATE mbio mbbsio mbaux mbsapi mbgsf m pthread)
+
+add_executable(mbconfig mbconfig.cc levitus.h)
+target_link_libraries(mbconfig PRIVATE mbio mbbsio mbaux mbsapi mbgsf m pthread)
+
+file(WRITE levitus.h
+  "const char *levitusfile = \"${levitusDir}/LevitusAnnual82.dat\";\nconst char *otps_location = \"${otpsDir}\";\n")
+
 target_link_libraries(mbsvpselect PRIVATE LibPROJ::LibPROJ)
 target_link_libraries(mbgrid PRIVATE mbaux)
 target_link_libraries(mbsegypsd PRIVATE FFTW::Double)
 target_compile_definitions(
   mbconfig
   PRIVATE MBSYSTEM_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}"
-          otpsDir="${otpsDir}"
-          LevitusAnnual82="${levitusDir}/LevitusAnnual82.dat")
+          ENV_OTPSDIR="${otpsDir}"
+          ENV_LEVITUSANNUAL82="${levitusDir}/LevitusAnnual82.dat")
 target_compile_definitions(
-  mblevitus PRIVATE LevitusAnnual82="${levitusDir}/LevitusAnnual82.dat")
+  mblevitus PRIVATE ENV_LEVITUSANNUAL82="${levitusDir}/LevitusAnnual82.dat")
 
-install(TARGETS ${executables} DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS ${executables} mbconfig mblevitus DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/utilities/mbconfig.cc
+++ b/src/utilities/mbconfig.cc
@@ -38,15 +38,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-// CMake build system
-#ifdef CMAKE_BUILD_SYSTEM
-const char *levitusfile = "$(levitusDir)/LevitusAnnual82.dat";
-const char *otps_location = "$(otpsDir)";
-
-// Autotools build system
-#else
 #include "levitus.h"
-#endif
 
 #include "mb_define.h"
 #include "mb_format.h"

--- a/src/utilities/mblevitus.cc
+++ b/src/utilities/mblevitus.cc
@@ -50,19 +50,12 @@
 #include <time.h>
 #include <unistd.h>
 
-// CMake build system
-#ifdef CMAKE_BUILD_SYSTEM
-const char *levitusfile = "$(levitusDir)/LevitusAnnual82.dat";
+#include "mb_define.h"
+#include "mb_status.h"
 
-// Autotools build system
-#else
 #ifndef _WIN32
 #include "levitus.h"
 #endif
-#endif
-
-#include "mb_define.h"
-#include "mb_status.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -72,8 +65,7 @@ constexpr double MBLEVITUS_NO_DATA = -1000000000.0;;
 constexpr int NDEPTH_MAX = 46;
 constexpr int NLEVITUS_MAX = 33;
 
-// TODO(schwehr): warning: excess elements in array initializer
-constexpr float depth[48 /* NDEPTH_MAX + 2 */] =
+constexpr float depth[NDEPTH_MAX] =
     {0.0,    10.0,    20.0,    30.0,    50.0,    75.0,   100.0,  125.0,
      150.0,  200.0,   250.0,   300.0,   400.0,   500.0,  600.0,  700.0,
      800.0,  900.0,   1000.0,  1100.0,  1200.0,  1300.0, 1400.0, 1500.0,


### PR DESCRIPTION
Make build system: Fixed creating the levitus.h header file used by mblevitus and mbconfig to define the location of the Levitus database and the OTPS installation, thereby making mblevitus and mbconfig work properly.