### PR TITLE
Mbphotomosaic

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
----
+txt---
 ## MB-System ChangeLog File:
 
 This file lists changes to the source code of the MB-System open
@@ -23,10 +23,17 @@ or beta, are equally accessible as tarballs through the Github interface.
 ### MB-System Version 5.8 Releases and Release Notes:
 ---
 
+- Version 5.8.1beta02    February 7, 2024
 - Version 5.8.1beta01    February 1, 2024
 - **Version 5.8.0          January 22, 2024**
 
 ---
+
+#### 5.8.1beta02 (February 7, 2024)
+
+Mbphotomosaic: Added options to detect and correct dark images (for when strobe lights
+partially drop out), to ignore dark images, and to allow image prioritization on
+the basis of camera heading.
 
 #### 5.8.1beta01 (February 1, 2024)
 

--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -37,8 +37,8 @@
 #include <stdint.h>
 
 /* Define version and date for this release */
-#define MB_VERSION "5.8.1beta01"
-#define MB_VERSION_DATE "1 February 2024"
+#define MB_VERSION "5.8.1beta02"
+#define MB_VERSION_DATE "7 February 2024"
 
 /* CMake supports current OS's and so there is only one form of RPC and XDR and no mb_config.h file */
 #ifdef CMAKE_BUILD_SYSTEM

--- a/src/mbio/mb_read_init.c
+++ b/src/mbio/mb_read_init.c
@@ -729,8 +729,12 @@ int mb_read_init_altnav(int verbose, char *file, int format, int pings,
                  		beams_bath, beams_amp, pixels_ss, error);
 
 	/* if possible load the alternative navigation */
-	if (status == MB_SUCCESS && *error == MB_ERROR_NO_ERROR && astatus == MB_ALTNAV_USE) {
+	if (status == MB_SUCCESS && *error == MB_ERROR_NO_ERROR) {
 		mb_io_ptr = (struct mb_io_struct *) *mbio_ptr;
+	}
+
+	/* if possible load the alternative navigation */
+	if (status == MB_SUCCESS && *error == MB_ERROR_NO_ERROR && astatus == MB_ALTNAV_USE) {
 //fprintf(stderr, "%s:%d:%s: Loading apath:      %s\n", __FILE__, __LINE__, __FUNCTION__, apath);
 
 		mb_io_ptr->alternative_navigation = false;


### PR DESCRIPTION
Mbphotomosaic: Added options to detect and correct dark images (for when strobe lights partially drop out), to ignore dark images, and to allow image prioritization on the basis of camera heading.