### PR TITLE
Updated Docker documenation + minor fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,7 @@ or beta, are equally accessible as tarballs through the Github interface.
 ---
 ### MB-System Version 5.8 Releases and Release Notes:
 ---
+- Version 5.8.2beta05    May 17, 2024
 - Version 5.8.2beta04    May 13, 2024
 - Version 5.8.2beta02    May 1, 2024
 - Version 5.8.2beta01    April 29, 2024
@@ -36,6 +37,15 @@ or beta, are equally accessible as tarballs through the Github interface.
 - **Version 5.8.0          January 22, 2024**
 
 ---
+
+#### 5.8.2beta05 (May 17, 2024)
+
+MBextractsegy: changed calculation of section plot bounds to more consistently catch the
+seafloor arrival within the plot.
+
+MBpreprocess: fixed initialization of the --kluge-fix-7k-times option.
+
+Docker image: updated documentation in the Docker directory.
 
 #### 5.8.2beta04 (May 13, 2024)
 

--- a/src/man/man1/mbpreprocess.1
+++ b/src/man/man1/mbpreprocess.1
@@ -129,6 +129,8 @@ Version 5.0
 .br
 \fB--kluge-time-jumps\fP=\fISECONDS\fP
 .br
+\fB--kluge-fix-7k-timestamps\fP=\fITARGETOFFSET\fP
+.br
 \fB--kluge-ancilliary-time-jumps\fP=\fISECONDS\fP
 .br
 \fB--kluge-mbaripressure-time-jumps\fP=\fITHRESHOLD\fP
@@ -832,6 +834,16 @@ to the origin for a dual head lidar system. The only relevant formats are for
 3D at Depth lidars (232 and 233).
 .TP
 .B --kluge-time-jumps=\fISECONDS\fP
+.TP
+.B --kluge-fix-7k-timestamps=\fITARGETOFFSET\fP
+This option was created to fix some Teledyne Reson T50 multibeam data (format 89) collected
+in 2024 with an MBARI Mapping AUV. The sonar ping timestamps jumped considerably (by as
+much as a day!!) while the ancillary nav, sensor depth, and attitude records maintained
+accurate timing. In good data the ping records will occur in the datastream with a fairly
+stable delay from the most recent ancillary records (0.7 seconds in this case). This
+option forces the pings records to have timestamps that have the target offset from the
+most recent ancillary records whenever the recorded offset magnitude is more than four 
+times the target offset.
 .TP
 .B --kluge-ancilliary-time-jumps=\fISECONDS\fP
 .TP

--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -37,8 +37,8 @@
 #include <stdint.h>
 
 /* Define version and date for this release */
-#define MB_VERSION "5.8.2beta04"
-#define MB_VERSION_DATE "13 May 2024"
+#define MB_VERSION "5.8.2beta05"
+#define MB_VERSION_DATE "17 May 2024"
 
 /* CMake supports current OS's and so there is only one form of RPC and XDR and no mb_config.h file */
 #ifdef CMAKE_BUILD_SYSTEM

--- a/src/utilities/mbextractsegy.cc
+++ b/src/utilities/mbextractsegy.cc
@@ -1519,7 +1519,7 @@ int mbes_generateplots(int verbose, FILE *sfp, char *output_root, char *segy_suf
   /* calculate sweep needed for all of the data in the line - if this is more than 1.0 seconds,
     then make section plots using only the sweep needed for each section alone */
   double delay = seafloordepthmin / 750.0;
-  delay = ((int)(delay / 0.05)) * 0.05;
+  delay = ((int)(delay / 0.05) - 1) * 0.05;
   double endofdata = seafloordepthmax / 750.0 + linetracelength;
   endofdata = (1 + (int)(endofdata / 0.05)) * 0.05;
   double sweep = endofdata - delay;
@@ -1539,7 +1539,7 @@ int mbes_generateplots(int verbose, FILE *sfp, char *output_root, char *segy_suf
         seafloordepthmin = seafloordepthminplot[i];
         seafloordepthmax = seafloordepthmaxplot[i];
         delay = seafloordepthmin / 750.0;
-        delay = ((int)(delay / 0.05)) * 0.05;
+        delay = ((int)(delay / 0.05) - 1) * 0.05;
         endofdata = seafloordepthmax / 750.0 + linetracelength;
         endofdata = (1 + (int)(endofdata / 0.05)) * 0.05;
         sweep = endofdata - delay;
@@ -1658,7 +1658,7 @@ int mbes_generateplots(int verbose, FILE *sfp, char *output_root, char *segy_suf
         seafloordepthmin = seafloordepthminplot[i];
         seafloordepthmax = seafloordepthmaxplot[i];
         delay = seafloordepthmin / 750.0;
-        delay = ((int)(delay / 0.05)) * 0.05;
+        delay = ((int)(delay / 0.05) - 1) * 0.05;
         endofdata = seafloordepthmax / 750.0 + linetracelength;
         endofdata = (1 + (int)(endofdata / 0.05)) * 0.05;
         sweep = endofdata - delay;
@@ -1716,7 +1716,7 @@ int mbes_generateplots(int verbose, FILE *sfp, char *output_root, char *segy_suf
         seafloordepthmin = seafloordepthminplot[i];
         seafloordepthmax = seafloordepthmaxplot[i];
         delay = seafloordepthmin / 750.0;
-        delay = ((int)(delay / 0.05)) * 0.05;
+        delay = ((int)(delay / 0.05) - 1) * 0.05;
         endofdata = seafloordepthmax / 750.0 + linetracelength;
         endofdata = (1 + (int)(endofdata / 0.05)) * 0.05;
         sweep = endofdata - delay;
@@ -1725,7 +1725,6 @@ int mbes_generateplots(int verbose, FILE *sfp, char *output_root, char *segy_suf
       char plot_type[32];
       char zbounds[32];
       char colormap[32];
-      
 
       snprintf(plot_type, sizeof(plot_type), "Trace");
       snprintf(zbounds, sizeof(zbounds),  "-%f/%f", zmax, zmax);

--- a/src/utilities/mbpreprocess.cc
+++ b/src/utilities/mbpreprocess.cc
@@ -135,7 +135,7 @@ constexpr char usage_message[] =
     "\t--head1-offsets=x/y/z/heading/roll/pitch\n"
     "\t--head2-offsets=x/y/z/heading/roll/pitch\n"
     "\t--kluge-time-jumps=threshold\n"
-    "\t--kluge-fix-7k-timestamps=threshold/targetoffset\n"
+    "\t--kluge-fix-7k-timestamps=targetoffset\n"
     "\t--kluge-ancilliary-time-jumps=threshold\n"
     "\t--kluge-mbaripressure-time-jumps=threshold\n"
     "\t--kluge-beam-tweak=factor\n"
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
   double kluge_timejumps_threshold = 0.0;
   bool kluge_timejumps = false;
   bool kluge_fix7ktimestamps = true;
-  double kluge_fix7ktimestamps_targetoffset;
+  double kluge_fix7ktimestamps_targetoffset = 0.0;
   double kluge_timejumps_anc_threshold = 0.0;
   bool kluge_timejumps_ancilliary = false;
   double kluge_timejumps_mba_threshold = 0.0;


### PR DESCRIPTION
MBextractsegy: changed calculation of section plot bounds to more consistently catch the seafloor arrival within the plot.

MBpreprocess: fixed initialization of the --kluge-fix-7k-times option.

Docker image: updated documentation in the Docker directory.