### PR TITLE
Mbnavadjustmerge reimport function

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,7 @@ or beta, are equally accessible as tarballs through the Github interface.
 ---
 ### MB-System Version 5.8 Releases and Release Notes:
 ---
+- Version 5.8.2beta12    August 22, 2024
 - Version 5.8.2beta11    August 19, 2024
 - Version 5.8.2beta10    August 16, 2024
 - Version 5.8.2beta09    August 4, 2024
@@ -43,6 +44,12 @@ or beta, are equally accessible as tarballs through the Github interface.
 - **Version 5.8.0          January 22, 2024**
 
 ---
+
+#### 5.8.2beta12 (August 22, 2024)
+
+Mbnavadjustmerge: Fixed (again, this time hopefully for real) the --reimport-all-files 
+option so that large projects can be reimported with a single command. Added a 
+--reimport-survey option.
 
 #### 5.8.2beta11 (August 19, 2024)
 

--- a/src/mbaux/mb_delaun.c
+++ b/src/mbaux/mb_delaun.c
@@ -307,7 +307,7 @@ int mb_delaun(int verbose, int npts, double *p1, double *p2, int *ed, int *ntri,
 			circumcenter and circumcircle of the enclosing
 			equilateral triangle */
 			else {
-				fprintf(stderr, "\nmb_delaun Warning. Zero denominator\n");
+				fprintf(stderr, "\nmb_delaun Warning: three linear points cannot be a triangle\n");
 				fprintf(stderr, "%d %f %f\n", i1, p1[i1], p2[i1]);
 				fprintf(stderr, "%d %f %f\n", i2, p1[i2], p2[i2]);
 				fprintf(stderr, "%d %f %f\n", nuc, p1[nuc], p2[nuc]);

--- a/src/mbaux/mb_truecont.c
+++ b/src/mbaux/mb_truecont.c
@@ -678,6 +678,12 @@ int mb_triangulate(int verbose, struct swath *data, int *error) {
     status &= mb_reallocd(verbose, __FILE__, __LINE__, data->npts_alloc * sizeof(double), (void **)&data->x, error);
     status &= mb_reallocd(verbose, __FILE__, __LINE__, data->npts_alloc * sizeof(double), (void **)&data->y, error);
     status &= mb_reallocd(verbose, __FILE__, __LINE__, data->npts_alloc * sizeof(double), (void **)&data->z, error);
+    memset(data->edge, 0, data->npts_alloc * sizeof(int));
+    memset(data->pingid, 0, data->npts_alloc * sizeof(int));
+    memset(data->beamid, 0, data->npts_alloc * sizeof(int));
+    memset(data->x, 0, data->npts_alloc * sizeof(double));
+    memset(data->y, 0, data->npts_alloc * sizeof(double));
+    memset(data->z, 0, data->npts_alloc * sizeof(double));
   }
   if (ntri_cnt > data->ntri_alloc) {
     data->ntri_alloc = ntri_cnt;
@@ -687,6 +693,11 @@ int mb_triangulate(int verbose, struct swath *data, int *error) {
       status &= mb_reallocd(verbose, __FILE__, __LINE__, ntri_cnt * sizeof(int), (void **)&(data->cs[i]), error);
       status &= mb_reallocd(verbose, __FILE__, __LINE__, ntri_cnt * sizeof(int), (void **)&(data->ed[i]), error);
       status &= mb_reallocd(verbose, __FILE__, __LINE__, ntri_cnt * sizeof(int), (void **)&(data->flag[i]), error);
+      memset(data->iv[i], 0, ntri_cnt * sizeof(int));
+      memset(data->ct[i], 0, ntri_cnt * sizeof(int));
+      memset(data->cs[i], 0, ntri_cnt * sizeof(int));
+      memset(data->ed[i], 0, ntri_cnt * sizeof(int));
+      memset(data->flag[i], 0, ntri_cnt * sizeof(int));
     }
     status &= mb_reallocd(verbose, __FILE__, __LINE__, ntri_cnt * sizeof(double), (void **)&(data->v1), error);
     status &= mb_reallocd(verbose, __FILE__, __LINE__, ntri_cnt * sizeof(double), (void **)&(data->v2), error);
@@ -696,6 +707,14 @@ int mb_triangulate(int verbose, struct swath *data, int *error) {
     status &= mb_reallocd(verbose, __FILE__, __LINE__, 3 * ntri_cnt * sizeof(int), (void **)&(data->kv2), error);
     status &= mb_reallocd(verbose, __FILE__, __LINE__, (4 * ntri_cnt + 1) * sizeof(double), (void **)&(data->xsave), error);
     status &= mb_reallocd(verbose, __FILE__, __LINE__, (4 * ntri_cnt + 1) * sizeof(double), (void **)&(data->ysave), error);
+    memset(data->v1, 0, ntri_cnt * sizeof(double));
+    memset(data->v2, 0, ntri_cnt * sizeof(double));
+    memset(data->v3, 0, ntri_cnt * sizeof(double));
+    memset(data->istack, 0, ntri_cnt * sizeof(int));
+    memset(data->kv1, 0, 3 * ntri_cnt * sizeof(int));
+    memset(data->kv2, 0, 3 * ntri_cnt * sizeof(int));
+    memset(data->xsave, 0, (4 * ntri_cnt + 1) * sizeof(double));
+    memset(data->ysave, 0, (4 * ntri_cnt + 1) * sizeof(double));
   }
 
   /* construct list of good soundings */

--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -37,8 +37,8 @@
 #include <stdint.h>
 
 /* Define version and date for this release */
-#define MB_VERSION "5.8.2beta10"
-#define MB_VERSION_DATE "16 August 2024"
+#define MB_VERSION "5.8.2beta12"
+#define MB_VERSION_DATE "22 August 2024"
 
 /* CMake supports current OS's and so there is only one form of RPC and XDR and no mb_config.h file */
 #ifdef CMAKE_BUILD_SYSTEM

--- a/src/mbnavadjust/mbnavadjustmerge.c
+++ b/src/mbnavadjust/mbnavadjustmerge.c
@@ -1333,7 +1333,7 @@ int main(int argc, char **argv) {
       else if (strcmp("reimport-file", options[option_index].name) == 0) {
         if (num_mods < NUMBER_MODS_MAX) {
           int nscan;
-          if ((nscan = sscanf(optarg, "%d", &mods[num_mods].file1)) == 2) {
+          if ((nscan = sscanf(optarg, "%d", &mods[num_mods].file1)) == 1) {
             mods[num_mods].mode = MOD_MODE_REIMPORT_FILE;
             num_mods++;
           }
@@ -1345,7 +1345,7 @@ int main(int argc, char **argv) {
       else if (strcmp("reimport-survey", options[option_index].name) == 0) {
         if (num_mods < NUMBER_MODS_MAX) {
           int nscan;
-          if ((nscan = sscanf(optarg, "%d", &mods[num_mods].file1)) == 2) {
+          if ((nscan = sscanf(optarg, "%d", &mods[num_mods].file1)) == 1) {
             mods[num_mods].mode = MOD_MODE_REIMPORT_SURVEY;
             num_mods++;
           }


### PR DESCRIPTION
Mbnavadjustmerge: Fixed (again, this time hopefully for real) the --reimport-all-files option so that large projects can be reimported with a single command. Added a --reimport-survey option.