### PR TITLE
sync with build changes in libtrnav

### DIFF
--- a/src/mbtrnav/CMakeLists.txt
+++ b/src/mbtrnav/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(geolib
 
 target_compile_options(geolib PRIVATE
 "-Wno-deprecated-non-prototype"
+"-Wno-unused-result"
 )
 
 #

--- a/src/mbtrnav/CMakeLists.txt
+++ b/src/mbtrnav/CMakeLists.txt
@@ -142,6 +142,11 @@ add_library(geolib
        gctp/source/sphdz.c
        gctp/source/br_gctp.c
 )
+
+target_compile_options(geolib PRIVATE
+"-Wno-deprecated-non-prototype"
+)
+
 #
 #------------------------------------------------------------------------------
 #

--- a/src/mbtrnav/build-utils/FindLibPROJ.cmake
+++ b/src/mbtrnav/build-utils/FindLibPROJ.cmake
@@ -1,0 +1,106 @@
+#[==[
+Provides the following variables:
+
+  * `LibPROJ_FOUND`: Whether NetCDF was found or not.
+  * `LibPROJ_INCLUDE_DIRS`: Include directories necessary to use NetCDF.
+  * `LibPROJ_LIBRARIES`: Libraries necessary to use NetCDF.
+  * `LibPROJ_VERSION`: The version of NetCDF found.
+#]==]
+
+find_path(LibPROJ_INCLUDE_DIR
+  NAMES proj.h
+  DOC "libproj include directories"
+  PATH_SUFFIXES include
+  PATHS /sw
+        /opt/sw
+        /opt/local
+        /opt/local/lib/proj9 
+        /opt/local/lib/proj8
+        /opt/csw
+        /opt
+        /usr/local)
+mark_as_advanced(LibPROJ_INCLUDE_DIR)
+
+find_library(LibPROJ_LIBRARY_RELEASE
+  NAMES proj
+  DOC "libproj release library"
+  PATH_SUFFIXES lib
+  PATHS /sw
+        /opt/sw
+        /opt/local
+        /opt/local/lib/proj9 
+        /opt/local/lib/proj8
+        /opt/csw
+        /opt
+        /usr/local)
+mark_as_advanced(LibPROJ_LIBRARY_RELEASE)
+
+find_library(LibPROJ_LIBRARY_DEBUG
+  NAMES projd
+  DOC "libproj debug library"
+  PATH_SUFFIXES lib
+  PATHS /sw
+        /opt/sw
+        /opt/local
+        /opt/local/lib/proj9 
+        /opt/local/lib/proj8
+        /opt/csw # Blastwave
+        /opt
+        /usr/local)
+mark_as_advanced(LibPROJ_LIBRARY_DEBUG)
+
+include(SelectLibraryConfigurations)
+select_library_configurations(LibPROJ)
+
+if (LibPROJ_INCLUDE_DIR)
+  if (EXISTS "${LibPROJ_INCLUDE_DIR}/proj.h")
+    file(STRINGS "${LibPROJ_INCLUDE_DIR}/proj.h" _libproj_version_lines REGEX "#define[ \t]+PROJ_VERSION_(MAJOR|MINOR|PATCH)")
+    string(REGEX REPLACE ".*PROJ_VERSION_MAJOR *\([0-9]*\).*" "\\1" _libproj_version_major "${_libproj_version_lines}")
+    string(REGEX REPLACE ".*PROJ_VERSION_MINOR *\([0-9]*\).*" "\\1" _libproj_version_minor "${_libproj_version_lines}")
+    string(REGEX REPLACE ".*PROJ_VERSION_PATCH *\([0-9]*\).*" "\\1" _libproj_version_patch "${_libproj_version_lines}")
+  else ()
+    file(STRINGS "${LibPROJ_INCLUDE_DIR}/proj_api.h" _libproj_version_lines REGEX "#define[ \t]+PJ_VERSION")
+    string(REGEX REPLACE ".*PJ_VERSION *\([0-9]*\).*" "\\1" _libproj_version "${_libproj_version_lines}")
+    math(EXPR _libproj_version_major "${_libproj_version} / 100")
+    math(EXPR _libproj_version_minor "(${_libproj_version} % 100) / 10")
+    math(EXPR _libproj_version_patch "${_libproj_version} % 10")
+  endif ()
+  set(LibPROJ_VERSION "${_libproj_version_major}.${_libproj_version_minor}.${_libproj_version_patch}")
+  set(LibPROJ_MAJOR_VERSION "${_libproj_version_major}")
+  unset(_libproj_version_major)
+  unset(_libproj_version_minor)
+  unset(_libproj_version_patch)
+  unset(_libproj_version)
+  unset(_libproj_version_lines)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibPROJ
+  REQUIRED_VARS LibPROJ_LIBRARY LibPROJ_INCLUDE_DIR
+  VERSION_VAR LibPROJ_VERSION)
+
+if (LibPROJ_FOUND)
+  set(LibPROJ_INCLUDE_DIRS "${LibPROJ_INCLUDE_DIR}")
+  set(LibPROJ_LIBRARIES "${LibPROJ_LIBRARY}")
+
+  if (NOT TARGET LibPROJ::LibPROJ)
+    add_library(LibPROJ::LibPROJ UNKNOWN IMPORTED)
+    set_target_properties(LibPROJ::LibPROJ PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${LibPROJ_INCLUDE_DIR}")
+    if (LibPROJ_LIBRARY_RELEASE)
+      set_property(TARGET LibPROJ::LibPROJ APPEND PROPERTY
+        IMPORTED_CONFIGURATIONS RELEASE)
+      set_target_properties(LibPROJ::LibPROJ PROPERTIES
+        IMPORTED_LOCATION_RELEASE "${LibPROJ_LIBRARY_RELEASE}")
+    endif ()
+    if (LibPROJ_LIBRARY_DEBUG)
+      set_property(TARGET LibPROJ::LibPROJ APPEND PROPERTY
+        IMPORTED_CONFIGURATIONS DEBUG)
+      set_target_properties(LibPROJ::LibPROJ PROPERTIES
+        IMPORTED_LOCATION_DEBUG "${LibPROJ_LIBRARY_DEBUG}")
+    endif ()
+  endif ()
+  message(" LibPROJ found")
+else()
+  message(" LibPROJ NOT found")
+endif ()

--- a/src/mbtrnav/build-utils/FindNetCDF.cmake
+++ b/src/mbtrnav/build-utils/FindNetCDF.cmake
@@ -1,0 +1,134 @@
+#[==[
+Provides the following variables:
+
+  * `NetCDF_FOUND`: Whether NetCDF was found or not.
+  * `NetCDF_INCLUDE_DIRS`: Include directories necessary to use NetCDF.
+  * `NetCDF_LIBRARIES`: Libraries necessary to use NetCDF.
+  * `NetCDF_VERSION`: The version of NetCDF found.
+  * `NetCDF::NetCDF`: A target to use with `target_link_libraries`.
+  * `NetCDF_HAS_PARALLEL`: Whether or not NetCDF was found with parallel IO support.
+#]==]
+
+function(FindNetCDF_get_is_parallel_aware include_dir)
+  file(STRINGS "${include_dir}/netcdf_meta.h" _netcdf_lines
+    REGEX "#define[ \t]+NC_HAS_PARALLEL[ \t]")
+  string(REGEX REPLACE ".*NC_HAS_PARALLEL[ \t]*([0-1]+).*" "\\1" _netcdf_has_parallel "${_netcdf_lines}")
+  if (_netcdf_has_parallel)
+    set(NetCDF_HAS_PARALLEL TRUE PARENT_SCOPE)
+  else()
+    set(NetCDF_HAS_PARALLEL FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Try to find a CMake-built NetCDF.
+find_package(netCDF CONFIG QUIET)
+if (netCDF_FOUND)
+  # Forward the variables in a consistent way.
+  set(NetCDF_FOUND "${netCDF_FOUND}")
+  set(NetCDF_INCLUDE_DIRS "${netCDF_INCLUDE_DIR}")
+  set(NetCDF_LIBRARIES "${netCDF_LIBRARIES}")
+  set(NetCDF_VERSION "${NetCDFVersion}")
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(NetCDF
+    REQUIRED_VARS NetCDF_INCLUDE_DIRS NetCDF_LIBRARIES
+    VERSION_VAR NetCDF_VERSION)
+
+  if (NOT TARGET NetCDF::NetCDF)
+    add_library(NetCDF::NetCDF INTERFACE IMPORTED)
+    if (TARGET "netCDF::netcdf")
+      # 4.7.3
+      set_target_properties(NetCDF::NetCDF PROPERTIES
+        INTERFACE_LINK_LIBRARIES "netCDF::netcdf")
+    elseif (TARGET "netcdf")
+      set_target_properties(NetCDF::NetCDF PROPERTIES
+        INTERFACE_LINK_LIBRARIES "netcdf")
+    else ()
+      set_target_properties(NetCDF::NetCDF PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${netCDF_LIBRARIES}")
+    endif ()
+  endif ()
+
+  FindNetCDF_get_is_parallel_aware("${NetCDF_INCLUDE_DIRS}")
+  # Skip the rest of the logic in this file.
+  return ()
+endif ()
+
+find_package(PkgConfig QUIET)
+if (PkgConfig_FOUND)
+  pkg_check_modules(_NetCDF QUIET netcdf IMPORTED_TARGET)
+  if (_NetCDF_FOUND)
+    # Forward the variables in a consistent way.
+    set(NetCDF_FOUND "${_NetCDF_FOUND}")
+    set(NetCDF_INCLUDE_DIRS "${_NetCDF_INCLUDE_DIRS}")
+    set(NetCDF_LIBRARIES "${_NetCDF_LIBRARIES}")
+    set(NetCDF_VERSION "${_NetCDF_VERSION}")
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(NetCDF
+      REQUIRED_VARS NetCDF_LIBRARIES
+      # This is not required because system-default include paths are not
+      # reported by `FindPkgConfig`, so this might be empty. Assume that if we
+      # have a library, the include directories are fine (if any) since
+      # PkgConfig reported that the package was found.
+      # NetCDF_INCLUDE_DIRS
+      VERSION_VAR NetCDF_VERSION)
+
+    if (NOT TARGET NetCDF::NetCDF)
+      add_library(NetCDF::NetCDF INTERFACE IMPORTED)
+      set_target_properties(NetCDF::NetCDF PROPERTIES
+        INTERFACE_LINK_LIBRARIES "PkgConfig::_NetCDF")
+    endif ()
+
+    FindNetCDF_get_is_parallel_aware("${_NetCDF_INCLUDEDIR}")
+    # Skip the rest of the logic in this file.
+    return ()
+  endif ()
+endif ()
+
+find_path(NetCDF_INCLUDE_DIR
+  NAMES netcdf.h
+  DOC "netcdf include directories")
+mark_as_advanced(NetCDF_INCLUDE_DIR)
+
+find_library(NetCDF_LIBRARY
+  NAMES netcdf
+  DOC "netcdf library")
+mark_as_advanced(NetCDF_LIBRARY)
+
+if (NetCDF_INCLUDE_DIR)
+  file(STRINGS "${NetCDF_INCLUDE_DIR}/netcdf_meta.h" _netcdf_version_lines
+    REGEX "#define[ \t]+NC_VERSION_(MAJOR|MINOR|PATCH|NOTE)")
+  string(REGEX REPLACE ".*NC_VERSION_MAJOR *\([0-9]*\).*" "\\1" _netcdf_version_major "${_netcdf_version_lines}")
+  string(REGEX REPLACE ".*NC_VERSION_MINOR *\([0-9]*\).*" "\\1" _netcdf_version_minor "${_netcdf_version_lines}")
+  string(REGEX REPLACE ".*NC_VERSION_PATCH *\([0-9]*\).*" "\\1" _netcdf_version_patch "${_netcdf_version_lines}")
+  string(REGEX REPLACE ".*NC_VERSION_NOTE *\"\([^\"]*\)\".*" "\\1" _netcdf_version_note "${_netcdf_version_lines}")
+  set(NetCDF_VERSION "${_netcdf_version_major}.${_netcdf_version_minor}.${_netcdf_version_patch}${_netcdf_version_note}")
+  unset(_netcdf_version_major)
+  unset(_netcdf_version_minor)
+  unset(_netcdf_version_patch)
+  unset(_netcdf_version_note)
+  unset(_netcdf_version_lines)
+
+  FindNetCDF_get_is_parallel_aware("${NetCDF_INCLUDE_DIR}")
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(NetCDF
+  REQUIRED_VARS NetCDF_LIBRARY NetCDF_INCLUDE_DIR
+  VERSION_VAR NetCDF_VERSION)
+
+if (NetCDF_FOUND)
+  set(NetCDF_INCLUDE_DIRS "${NetCDF_INCLUDE_DIR}")
+  set(NetCDF_LIBRARIES "${NetCDF_LIBRARY}")
+
+  if (NOT TARGET NetCDF::NetCDF)
+    add_library(NetCDF::NetCDF UNKNOWN IMPORTED)
+    set_target_properties(NetCDF::NetCDF PROPERTIES
+      IMPORTED_LOCATION "${NetCDF_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${NetCDF_INCLUDE_DIR}")
+  endif ()
+  message(-- NetCDF found!)
+else()
+  message("-- NetCDF NOT found...")
+endif ()

--- a/src/mbtrnav/cmake/Libtrnav.cmake.in
+++ b/src/mbtrnav/cmake/Libtrnav.cmake.in
@@ -1,12 +1,12 @@
 # - Config file for the Libtrnav package
 # It defines the following variables
-#  Libtrnav_INCLUDE_DIR - include directories for Libtrnav
-#  Libtrnav_LIBRARIES   - libraries to link against
+#  Libtrnav_INCLUDE_DIRS - include directories for Libtrnav
+#  Libtrnav_LIBRARIES    - libraries to link against
 
 # initialize relocatable config
 @PACKAGE_INIT@
 
-set_and_check(Libtrnav_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set_and_check(Libtrnav_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
 
 check_required_components(Libtrnav)
 
@@ -21,15 +21,17 @@ endif()
 # These are IMPORTED targets created by LibtrnavTargets.cmake
 set(Libtrnav_LIBRARIES
 geolib
+geocon
 newmat
 qnx
 tnav
 trnw
+trnwc
 netif
 trnucli
 )
 
-message(" >>> LibtrnavConfig -   Libtrnav_INCLUDE_DIR ${Libtrnav_INCLUDE_DIR}")
-message(" >>> LibtrnavConfig -     Libtrnav_LIBRARIES ${Libtrnav_LIBRARIES}")
-message(" >>> LibtrnavConfig - CMAKE_CURRENT_LIST_FILE ${CMAKE_CURRENT_LIST_FILE}")
+message(" LibtrnavConfig : Libtrnav_INCLUDE_DIRS   ${Libtrnav_INCLUDE_DIR}")
+message(" LibtrnavConfig : Libtrnav_LIBRARIES      ${Libtrnav_LIBRARIES}")
+message(" LibtrnavConfig : CMAKE_CURRENT_LIST_FILE ${CMAKE_CURRENT_LIST_FILE}")
 

--- a/src/mbtrnav/newmat/bandmat.cpp
+++ b/src/mbtrnav/newmat/bandmat.cpp
@@ -124,8 +124,8 @@ void BandMatrix::ReSizeForAdd(const GeneralMatrix& A, const GeneralMatrix& B)
    REPORT
    Tracer tr("BandMatrix::ReSizeForAdd");
    MatrixBandWidth A_BW = A.BandWidth(); MatrixBandWidth B_BW = B.BandWidth();
-   if ((A_BW.Lower() < 0) | (A_BW.Upper() < 0) | (B_BW.Lower() < 0)
-      | (A_BW.Upper() < 0))
+   if ((A_BW.Lower() < 0) || (A_BW.Upper() < 0) || (B_BW.Lower() < 0)
+      || (A_BW.Upper() < 0))
          Throw(ProgramException("Can't ReSize to BandMatrix" ));
    // already know A and B are square
    ReSize(A.Nrows(), my_max(A_BW.Lower(), B_BW.Lower()),
@@ -137,8 +137,8 @@ void BandMatrix::ReSizeForSP(const GeneralMatrix& A, const GeneralMatrix& B)
    REPORT
    Tracer tr("BandMatrix::ReSizeForSP");
    MatrixBandWidth A_BW = A.BandWidth(); MatrixBandWidth B_BW = B.BandWidth();
-   if ((A_BW.Lower() < 0) | (A_BW.Upper() < 0) | (B_BW.Lower() < 0)
-      | (A_BW.Upper() < 0))
+   if ((A_BW.Lower() < 0) || (A_BW.Upper() < 0) || (B_BW.Lower() < 0)
+      || (A_BW.Upper() < 0))
          Throw(ProgramException("Can't ReSize to BandMatrix" ));
    // already know A and B are square
    ReSize(A.Nrows(), my_min(A_BW.Lower(), B_BW.Lower()),
@@ -486,7 +486,7 @@ void SymmetricBandMatrix::ReSizeForAdd(const GeneralMatrix& A,
    REPORT
    Tracer tr("SymmetricBandMatrix::ReSizeForAdd");
    MatrixBandWidth A_BW = A.BandWidth(); MatrixBandWidth B_BW = B.BandWidth();
-   if ((A_BW.Lower() < 0) | (B_BW.Lower() < 0))
+   if ((A_BW.Lower() < 0) || (B_BW.Lower() < 0))
          Throw(ProgramException("Can't ReSize to SymmetricBandMatrix" ));
    // already know A and B are square
    ReSize(A.Nrows(), my_max(A_BW.Lower(), B_BW.Lower()));
@@ -498,7 +498,7 @@ void SymmetricBandMatrix::ReSizeForSP(const GeneralMatrix& A,
    REPORT
    Tracer tr("SymmetricBandMatrix::ReSizeForSP");
    MatrixBandWidth A_BW = A.BandWidth(); MatrixBandWidth B_BW = B.BandWidth();
-   if ((A_BW.Lower() < 0) | (B_BW.Lower() < 0))
+   if ((A_BW.Lower() < 0) || (B_BW.Lower() < 0))
          Throw(ProgramException("Can't ReSize to SymmetricBandMatrix" ));
    // already know A and B are square
    ReSize(A.Nrows(), my_min(A_BW.Lower(), B_BW.Lower()));

--- a/src/mbtrnav/opt/Makefile
+++ b/src/mbtrnav/opt/Makefile
@@ -20,6 +20,7 @@ TRNW_DIR=../trnw
 DOC_DIR=../doc
 DORADO_DIR=./dorado
 LRAUV_DIR=./lrauv
+ROV_DIR=./rov
 REPO_TOP_DIR=..
 
 ifeq ($(shell uname),Darwin)
@@ -99,6 +100,11 @@ CFLAGS  =       #-O (or whatever you need)
 #       dont' define these unelss they're common to all subdirectories
 LDFLAGS =      # -lm (or whatever you need)
 
+$(info "INFO +++ opt - OPT_USE_PROJ ${OPT_USE_PROJ}")
+$(info "INFO +++ opt - PROJ_LIB ${PROJ_LIB}")
+$(info "INFO +++ opt - OPT_PROJ_INC ${OPT_PROJ_INC}")
+$(info "INFO +++ opt - OPT_PROJ_LIB ${OPT_PROJ_LIB}")
+
 ########################################
 # Target Definitions
 
@@ -108,7 +114,7 @@ libs:
 	@echo "Building libs..."
 	cd $(REPO_TOP_DIR); make
 
-apps: dorado lrauv
+apps: dorado lrauv rov
 
 dorado: libs
 	@echo "Building dorado..."
@@ -118,12 +124,17 @@ lrauv: libs
 	@echo "Building lrauv..."
 	cd $(LRAUV_DIR); make
 
+rov: libs
+	@echo "Building rov..."
+	cd $(ROV_DIR); make
+
 help:
 	@echo
 	@echo "make [clean all dorado lrauv]"
 	@echo "apps        build libraries and applications"
 	@echo "dorado      build libraries and dorado apps"
 	@echo "lrauv       build libraries and lrauv apps"
+	@echo "rov         build libraries and rov apps"
 	@echo "clean       remove build products (not including doc)"
 #	@echo "dist-clean remove build products (including doc)"
 	@echo ""
@@ -155,6 +166,7 @@ install:
 .PHONY: apps
 .PHONY: dorado
 .PHONY: lrauv
+.PHONY: rov
 .PHONY: clean
 .PHONY: dist-clean
 #.PHONY: dist
@@ -164,6 +176,7 @@ clean:
 	@echo "Clean app..."
 	cd $(DORADO_DIR); make clean
 	cd $(LRAUV_DIR); make clean
+	cd $(ROV_DIR); make clean
 
 dist-clean: clean
 	@echo "Clean doc..."

--- a/src/mbtrnav/opt/rov/Makefile
+++ b/src/mbtrnav/opt/rov/Makefile
@@ -1,4 +1,5 @@
 ########################################
+# opt/rov Makefile
 # Build Environment
 # version and build configuration
 
@@ -17,28 +18,33 @@ C_STD= -std=c99
 
 # Platform-specific options
 ifeq ($(shell uname),Linux)
- OS_CFLAGS=
- OS_INC_PATH=
- OS_LIB_PATH=
- OS_LIBS=-lrt
+	 OS_CFLAGS=
+	 OS_INC_PATH=
+	 OS_LIB_PATH=
+	 OS_LIBS=-lrt
 endif
 
 ifeq ($(shell uname),Darwin)
-OS_CFLAGS=
-OS_INC_PATH=-I/opt/local/include
-OS_LIB_PATH=-L/opt/local/lib
-OS_LIBS=
+	OS_CFLAGS=
+	OS_INC_PATH=-I/opt/local/include
+	OS_LIB_PATH=-L/opt/local/lib
+	OS_LIBS=
 endif
 
 ifeq ($(shell uname),Cygwin)
-OS_CFLAGS=
-OS_INC_PATH=-I/opt/local/include
-OS_LIB_PATH=-L/opt/local/lib
-OS_LIBS=-lrt
+	OS_CFLAGS=
+	OS_INC_PATH=-I/opt/local/include
+	OS_LIB_PATH=-L/opt/local/lib
+	OS_LIBS=-lrt
 endif
 
+$(info "INFO +++ opt/rov - OPT_USE_PROJ ${OPT_USE_PROJ}")
+$(info "INFO +++ opt/rov - PROJ_LIB ${PROJ_LIB}")
+$(info "INFO +++ opt/rov - OPT_PROJ_INC ${OPT_PROJ_INC}")
+$(info "INFO +++ opt/rov - OPT_PROJ_LIB ${OPT_PROJ_LIB}")
+
 # Build options
-BUILD_OPTIONS = $(STD) -D_GNU_SOURCE $(OPT_APP_BUILD)  $(OPT_TRNXPP_VER)
+BUILD_OPTIONS = $(STD) -D_GNU_SOURCE $(OPT_APP_BUILD)  $(OPT_TRNXPP_VER) ${OPT_USE_PROJ}
 
 # Build directories
 OUTPUT_DIR=../../bin
@@ -71,11 +77,11 @@ CFLAGS = -g -O2 $(C_STD) $(SANI_FLAG) $(WARN_FLAGS) $(GPROF) $(BUILD_OPTIONS) $(
 CXXFLAGS = -g -O2 $(CXX_STD) $(SANI_FLAG) $(WARN_FLAGS) $(GPROF) $(BUILD_OPTIONS) $(OS_CFLAGS)
 CPPFLAGS += #-MM -MMD
 INC_PATHS =  -I.  -I$(NEWMAT_DIR) -I$(QNX_DIR) \
--I$(TRN_DIR) -I$(UTILS_DIR) -I$(TRNW_DIR) $(OS_INC_PATH)
+-I$(TRN_DIR) -I$(UTILS_DIR) -I$(TRNW_DIR) $(OPT_PROJ_INC) $(OS_INC_PATH)
 
 # Linker flags
 LD_FLAGS = -g $(GPROF)
-LIB_PATHS = -L$(OUTPUT_DIR) $(OS_LIB_PATH) -L/usr/local/lib
+LIB_PATHS = -L$(OUTPUT_DIR) $(OS_LIB_PATH) -L/usr/local/lib $(OPT_PROJ_LIB)
 
 ########################################
 # Target Definitions
@@ -148,7 +154,7 @@ TRNXPP=trnxpp
 TRNXPP_SRC= trnxpp_app.cpp
 TRNXPP_HPP= trnxpp.hpp
 TRNXPP_OBJ = $(TRNXPP_SRC:%.cpp=$(BUILD_DIR)/%.o)
-TRNXPP_LIBS =  -llcm -lstdc++ -lmb1 -ltrncli -ltrn  -lnewmat -lqnx -lnetcdf -lm -lpthread -lgeocon -lgeolib  -ludpms $(OS_LIBS) -ltrnxplug
+TRNXPP_LIBS = -ludpms   -ltrnxplug   -ltrncli -lmb1  -ltrn -lgeocon -lqnx -lgeolib  -lpthread  -lnewmat $(PROJ_LIB) -lnetcdf -lm -llcm -lstdc++  $(OS_LIBS)
 
 FVTEST=fv-test
 FVTEST_SRC = flag_var_test.cpp
@@ -164,7 +170,7 @@ LIBUDPMS_LIBS=
 LIBTRNXPLUG = libtrnxplug.a
 LIBTRNXPLUG_SRC = plug-common.cpp plug-idtlass.cpp plug-oisledx.cpp plug-dvl.cpp plug-idt.cpp  plug-oisled.cpp plug-oisled2.cpp plug-lassmb.cpp plug-xmb1.cpp
 LIBTRNXPLUG_OBJ = $(LIBTRNXPLUG_SRC:%.cpp=$(BUILD_DIR)/%.o)
-LIBTRNXPLUG_LIBS = -lnewmat -lgeocon  -lgeolib -ltrnw -lqnx -lmb1 -ltrn -ludpms -ltrncli -lnetcdf -llcm
+LIBTRNXPLUG_LIBS = -ludpms -ltrncli -lmb1  -ltrn -ltrnw  -lgeocon  -lqnx  -lgeolib   -lnewmat -lnetcdf -llcm
 
 ########################################
 # Build Files (mostly for cleanup)

--- a/src/mbtrnav/opt/sentry/README-trndev-build.md
+++ b/src/mbtrnav/opt/sentry/README-trndev-build.md
@@ -52,14 +52,47 @@ sudo ./trndev-build-cmake.sh -i [-d <path> -p <path>]
 ```
 Description: build/install trndev using cmake
 
-usage: trndev-build-cmake.sh [options]
-Options:
--d <s> : set DESTDIR for install/uninstall []
--p <s> : set PREFIX for install/uninstall [/usr/local]
--i     : install
--u     : uninstall
--h     : help message
--v     : verbose output
+ usage: trndev-build-cmake.sh [options]
+ Options:
+  -d <s> : set DESTDIR for install/uninstall []
+  -p <s> : set PREFIX for install/uninstall [/usr/local]
+  -i     : install
+  -u     : uninstall
+  -m <s> : libmframe cmake options
+  -t <s> : libtrnav cmake options
+  -h     : help message
+  -v     : verbose output
+
+Use Notes:
+ This script is typically run twice:
+   build (optionally using -t, -m)
+   then
+   install (using -i, optionally -p, -d)
+   or
+   uninstall (using -u)
+
+   When uninstalling, use the same -p, -d options
+   used to install
+
+Examples:
+
+ # build
+   trndev-build-cmake.sh
+
+ # build using cmake TRN options
+   trndev-build-cmake.sh -t "-DbuildUseProj=ON"
+
+ # install to default directory /usr/local
+   sudo trndev-build-cmake.sh -i
+
+ # uninstall from default directory /usr/local
+   sudo trndev-build-cmake.sh -u
+
+ # install to staging directory w/ default PREFIX (as non-root)
+   trndev-build-cmake.sh -id $PWD/stage
+
+ # uninstall from staging directory w/ custom PREFIX (as non-root)
+   trndev-build-cmake.sh -ud $PWD/stage -p /foo/bar
 ```
 
 ### trndev-build-gnu.sh

--- a/src/mbtrnav/qnx-utils/DataLogReader.cc
+++ b/src/mbtrnav/qnx-utils/DataLogReader.cc
@@ -62,8 +62,7 @@ void DataLogReader::readHeader()
     mnem = type = format = lname = units = NULL;
 
     // Read a line
-    fgets(buffer, sizeof(buffer), fileStream());
-
+    if(fgets(buffer, sizeof(buffer), fileStream()) == NULL){;}
 
     if (buffer[strlen(buffer)-1] == '\n') 
       // Strip off trailing newlien

--- a/src/mbtrnav/qnx-utils/TimeP.cc
+++ b/src/mbtrnav/qnx-utils/TimeP.cc
@@ -125,7 +125,7 @@ void TimeP::secsToHourMinSec(double secs, char *timestring)
   }
   secs = isecs + (secs - (int )secs);
 
-  snprintf(timestring, 15, "%03d:%02d:%02d:%02.1f", days, hrs, min, secs);
+  snprintf(timestring, 32, "%03d:%02d:%02d:%02.1f", days, hrs, min, secs);
 
   return;
 }

--- a/src/mbtrnav/terrain-nav/TNavPointMassFilter.cpp
+++ b/src/mbtrnav/terrain-nav/TNavPointMassFilter.cpp
@@ -624,8 +624,6 @@ Matrix TNavPointMassFilter::generateCorrelationSurf(bool& containsNaN) {
 	//normalization constants used to sum the likelihood scores
 	double alpha = 0;
 	double beta = 0;
-	int numAlpha = 0;
-	int numBeta = 0;
 
 	if(saveDirectory != NULL) {
 		//save corrData values to file for debugging
@@ -727,7 +725,6 @@ Matrix TNavPointMassFilter::generateCorrelationSurf(bool& containsNaN) {
 				//probability to the uniform distribution
 				Like(i, j) = 1.0 / (Like.Nrows() * Like.Ncols());
 				beta += Like(i, j);
-				numBeta++;
 			} else {
 				//normalization constant for gaussian distribution with
 				//dimension N = numBeamsCorrelated
@@ -753,7 +750,6 @@ Matrix TNavPointMassFilter::generateCorrelationSurf(bool& containsNaN) {
 				
 				alpha += Like(i, j);
 				GaussianProb(i, j) = 1;
-				numAlpha++;
 			}
 		}
 	}

--- a/src/mbtrnav/trnw/Makefile
+++ b/src/mbtrnav/trnw/Makefile
@@ -13,7 +13,6 @@ OPT_TRN_BUILD=-DLIBTRN_BUILD=$(build_date)
 mb1rs_ver ?=0.0.0b1
 OPT_MB1RS_VER=-DMB1RS_VER=$(mb1rs_ver)
 OPT_MB1RS_BUILD=-DMB1RS_BUILD=$(build_date)
-OPT_USE_PROJ= #-DTRN_USE_PROJ
 
 # C standard e.g. -std=c99 -std=gnu99
 # may be needed for Cygwin (e.g. for loop declare/init)
@@ -21,22 +20,27 @@ OPT_USE_PROJ= #-DTRN_USE_PROJ
 
 # Platform-specific options
 ifeq ($(shell uname),Linux)
-OS_CFLAGS=
-OS_INC_PATH=
-OS_LIB_PATH=
+	OS_CFLAGS=
+	OS_INC_PATH=
+	OS_LIB_PATH=
 endif
 
 ifeq ($(shell uname),Darwin)
-OS_CFLAGS=
-OS_INC_PATH=-I/opt/local/include
-OS_LIB_PATH=-L/opt/local/lib
+	OS_CFLAGS=
+	OS_INC_PATH=-I/opt/local/include
+	OS_LIB_PATH=-L/opt/local/lib
 endif
 
 ifeq ($(shell uname),Cygwin)
-OS_CFLAGS=
-OS_INC_PATH=-I/opt/local/include
-OS_LIB_PATH=-L/opt/local/lib
+	OS_CFLAGS=
+	OS_INC_PATH=-I/opt/local/include
+	OS_LIB_PATH=-L/opt/local/lib
 endif
+
+$(info "INFO +++ trnw - OPT_USE_PROJ ${OPT_USE_PROJ}")
+$(info "INFO +++ trnw - PROJ_LIB ${PROJ_LIB}")
+$(info "INFO +++ trnw - OPT_PROJ_INC ${OPT_PROJ_INC}")
+$(info "INFO +++ trnw - OPT_PROJ_LIB ${OPT_PROJ_LIB}")
 
 # for TRN clients or to force
 # netif default MMDEBUG config
@@ -71,7 +75,6 @@ BUILD_DIR=../build
 QNX_DIR=../qnx-utils
 NEWMAT_DIR=../newmat
 TNAV_DIR=../terrain-nav
-PROJ_INC_DIR=/opt/local/lib/proj9/include
 
 # mframe is required to build TRN clients
 # MFRAME_INC_DIR: location of mframe headers
@@ -89,16 +92,6 @@ endif
 
 MFRAME_LIB=# $(MFRAME_LIB_DIR)/libmframe.a
 
-ifndef PROJ_INC_DIR
-PROJ_INC_DIR=/opt/local/lib/proj9/include
-endif
-
-ifndef PROJ_LIB_DIR
-PROJ_LIB_DIR=/opt/local/lib/proj9/lib
-endif
-
-PROJ_LIB=-lproj
-
 # Compilation Options
 CXX = gcc
 CPP = g++ -std=c++11
@@ -110,26 +103,26 @@ WARN_FLAGS=-Wall
 
 # Compiler flags
 CFLAGS = -g -O2 $(WARN_FLAGS) $(GPROF) $(BUILD_OPTIONS) $(OS_CFLAGS)
-INC_PATHS = -I. -I$(MFRAME_INC_DIR) -I$(TNAV_DIR) -I$(NEWMAT_DIR) -I$(QNX_DIR) -I$(PROJ_INC_DIR) $(OS_INC_PATH)
+INC_PATHS = -I. -I$(MFRAME_INC_DIR) -I$(TNAV_DIR) -I$(NEWMAT_DIR) -I$(QNX_DIR) $(OPT_PROJ_INC) $(OS_INC_PATH)
 
 # Linker flags
 LD_FLAGS = -g $(GPROF)
-LIB_PATHS = -L$(OUTPUT_DIR) -L$(MFRAME_LIB_DIR) -L$(PROJ_LIB_DIR) $(OS_LIB_PATH) -L/usr/local/lib
+LIB_PATHS = -L$(OUTPUT_DIR) -L$(MFRAME_LIB_DIR) $(OPT_PROJ_LIB) $(OS_LIB_PATH) -L/usr/local/lib
 
 ########################################
 # Target Definitions
 
 # libgeocon: Geoconversion wrapper for NavUtils/GCTP, PROJ
-LIBGCON=libgeocon.a
-LIBGCON_SRC = GeoCon.cpp
-LIBGCON_OBJ=$(LIBGCON_SRC:%.cpp=$(BUILD_DIR)/%.o)
-LIBGCON_LIBS = -lqnx $(PROJ_LIB)
+LIBGEOCON=libgeocon.a
+LIBGEOCON_SRC = GeoCon.cpp
+LIBGEOCON_OBJ=$(LIBGEOCON_SRC:%.cpp=$(BUILD_DIR)/%.o)
+LIBGEOCON_LIBS = -lqnx -lgeolib  $(PROJ_LIB)
 
 # libtrnw: TRN C wrappers
 LIBTRNW=libtrnw.a
 LIBTRNW_SRC=trnw.cpp
 LIBTRNW_OBJ=$(LIBTRNW_SRC:%.cpp=$(BUILD_DIR)/%.o)
-LIBTRNW_LIBS = -ltrn -lqnx -lnewmat $(PROJ_LIB) -lpthread
+LIBTRNW_LIBS = -ltrn -lqnx -lgeolib -lnewmat $(PROJ_LIB) -lpthread
 
 LIBMB1=libmb1.a
 LIBMB1_SRC = mb1_msg.c
@@ -163,13 +156,13 @@ $(BUILD_DIR)/matrixArrayCalcs.o
 LIBTRNCLI=libtrncli.a
 LIBTRNCLI_SRC=trn_cli.c
 LIBTRNCLI_OBJ=$(LIBTRNCLI_SRC:%.c=$(BUILD_DIR)/%.o)
-LIBTRNCLI_LIBS = -lmframe -lpthread -lm
+LIBTRNCLI_LIBS = -lgeocon -lqnx -lgeolib -lmframe -lpthread -lm
 
 # trncli-test: trn_cli unit test
 TRNCLI_TEST=trncli-test
 TRNCLI_TEST_SRC=trncli_test.c mb1_msg.c
 TRNCLI_TEST_OBJ=$(TRNCLI_TEST_SRC:%.c=$(BUILD_DIR)/%.o)
-TRNCLI_TEST_LIBS = -lmframe -ltrnw -lpthread -lm -lqnx -lnewmat -ltrn -ltrncli -lgeocon -lnetcdf -lgeolib $(PROJ_LIB) -lstdc++
+TRNCLI_TEST_LIBS = -lmframe -ltrnw  -ltrn -ltrncli -lgeocon -lqnx -lgeolib  -lnewmat -lnetcdf  $(PROJ_LIB) -lpthread -lm  -lstdc++
 
 # libtrnucli: TRNU client lib
 LIBTRNUCLI=libtrnucli.a
@@ -222,12 +215,17 @@ MMCSUB_LIBS = $(MFRAME_LIB) -lmframe -lm -lstdc++
 TRNIF_TEST=trnif-test
 TRNIF_TEST_SRC=trnif_test.c trnif_proto.c trnif_msg.c
 TRNIF_TEST_OBJ = $(TRNIF_TEST_SRC:%.c=$(BUILD_DIR)/%.o)
-TRNIF_TEST_LIBS = -lnetif -lmframe -ltrnw -lpthread -lm -lqnx -lnewmat -ltrn -lnetcdf -lgeolib -lgeocon $(PROJ_LIB) -lstdc++
+TRNIF_TEST_LIBS = -lnetif -lmframe -ltrnw -lpthread -lm  -lnewmat -ltrn -lnetcdf -lgeocon -lqnx -lgeolib  $(PROJ_LIB) -lstdc++
 
 MB1RS=mb1rs
 MB1RS_SRC=mb1_msg.c mb1rs.c mb1rs-app.c
 MB1RS_OBJ=$(MB1RS_SRC:%.c=$(BUILD_DIR)/%.o)
 MB1RS_LIBS = $(MFRAME_LIB) -lmframe -lm -lpthread -lstdc++
+
+GEOCON_TEST=geocon-test
+GEOCON_TEST_SRC=geocon_test.cpp
+GEOCON_TEST_OBJ=$(GEOCON_TEST_SRC:%.cpp=$(BUILD_DIR)/%.o)
+GEOCON_TEST_LIBS = -lgeocon -lqnx -lgeolib $(PROJ_LIB) -lstdc++
 
 # TRN clients
 TRNC_SRC+= $(LIBTRNCLI_SRC) \
@@ -245,7 +243,7 @@ $(MB1RS_SRC)
 
 TRNC_TARGETS+=  $(OUTPUT_DIR)/$(LIBTRNCLI) \
 $(OUTPUT_DIR)/$(LIBTRNUCLI) \
-$(OUTPUT_DIR)/$(LIBGCON) \
+$(OUTPUT_DIR)/$(LIBGEOCON) \
 $(OUTPUT_DIR)/$(TRNCLI_TEST) \
 $(OUTPUT_DIR)/$(TRNUCLI_TEST)\
 $(OUTPUT_DIR)/$(TRNUSVR_TEST) \
@@ -265,10 +263,10 @@ TRNW_OBJECTS = $(TRNW_SOURCES:%.cpp=$(BUILD_DIR)/%.o)
 TRNC_DEPENDS = $(TRNC_SOURCES:%.c=$(BUILD_DIR)/%.d)
 TRNW_DEPENDS = $(TRNW_SOURCES:%.cpp=$(BUILD_DIR)/%.d)
 CLEAN_OBJECTS = $(TRNC_OBJECTS) $(TRNW_OBJECTS) $(MCSUB_OBJ) $(MMCSUB_OBJ) $(LIBNETIF_OBJ) \
-$(LIBMB1_OBJ)
-CLEAN_DEPENDS = $(TRNC_DEPENDS) $(TRNW_DEPENDS) 
+$(LIBMB1_OBJ) $(GEOCON_TEST_OBJ) $(LIBGEOCON_OBJ)
+CLEAN_DEPENDS = $(TRNC_DEPENDS) $(TRNW_DEPENDS)
 BINARIES =  $(OUTPUT_DIR)/$(LIBTRNW) $(OUTPUT_DIR)/$(TRNC_TARGETS) $(OUTPUT_DIR)/$(LIBNETIF) \
-$(OUTPUT_DIR)/$(LIBMB1)
+$(OUTPUT_DIR)/$(LIBMB1) $(OUTPUT_DIR)/$(GEOCON_TEST)
 
 CLEANUP = gmon.out
 # dSYMs : XCode debug symbol file folders
@@ -277,7 +275,7 @@ CLEANUP = gmon.out
 
 ########################################
 # Rules: build targets
-all: $(OUTPUT_DIR)/$(LIBTRNW) $(OUTPUT_DIR)/$(LIBMB1) $(OUTPUT_DIR)/$(LIBGCON)
+all: $(OUTPUT_DIR)/$(LIBTRNW) $(OUTPUT_DIR)/$(LIBMB1) $(OUTPUT_DIR)/$(LIBGEOCON) $(OUTPUT_DIR)/$(GEOCON_TEST)
 
 
 trnc: $(OUTPUT_DIR)/$(LIBTRNW) $(OUTPUT_DIR)/$(LIBNETIF) $(TRNC_TARGETS)
@@ -304,9 +302,10 @@ $(OUTPUT_DIR)/$(LIBTRNCLI): $(LIBTRNCLI_OBJ)
 	ar rcs $@ $(LIBTRNCLI_OBJ) $(BUILD_DIR)/*.o
 
 # build GeoConverter library
-$(OUTPUT_DIR)/$(LIBGCON): $(LIBGCON_OBJ)
+#	--record-libdeps="$(LIB_PATHS) $(LIBGEOCON_LIBS)"
+$(OUTPUT_DIR)/$(LIBGEOCON): $(LIBGEOCON_OBJ)
 	@echo building $@...
-	ar -r $@ $(LIBGCON_OBJ)
+	ar rcs $@ $(LIBGEOCON_OBJ)
 
 # build trncli-test utility
 $(OUTPUT_DIR)/$(TRNCLI_TEST): $(TRNCLI_TEST_OBJ) $(LIBTRNW_OBJ) $(LIBTRNCLI_OBJ)
@@ -359,11 +358,19 @@ $(OUTPUT_DIR)/$(MMCSUB): $(MMCSUB_OBJ)
 $(OUTPUT_DIR)/$(TRNIF_TEST): $(TRNIF_TEST_OBJ)
 	@echo building $@...
 	$(CXX) $(INC_PATHS) $(LIB_PATHS) $^ -o $@ $(LD_FLAGS) $(TRNIF_TEST_LIBS)
+	@echo
 
 # build mb1rs MB1 server
 $(OUTPUT_DIR)/$(MB1RS): $(MB1RS_OBJ)
 	@echo building $@...
 	$(CXX) $(INC_PATHS) $(LIB_PATHS) $^ -o $@ $(LD_FLAGS) $(MB1RS_LIBS)
+	@echo
+
+# build geocon-test utility
+$(OUTPUT_DIR)/$(GEOCON_TEST): $(GEOCON_TEST_OBJ)
+	@echo building $@...
+	$(CPP) $(INC_PATHS) $(LIB_PATHS)  $^ -o $@ $(LD_FLAGS) $(GEOCON_TEST_LIBS)
+	@echo
 
 # include the dependencies
 ifeq ($(MAKECMDGOALS),trnc)

--- a/src/mbtrnutils/mbtrnpp.c
+++ b/src/mbtrnutils/mbtrnpp.c
@@ -8329,7 +8329,7 @@ int64_t mbtrnpp_em710raw_update_buffer(int fd, byte *buf, size_t len, const byte
                 } else if(em_ser_flow == 'X'){
                     MX_BMSG((verbose < -2), "ENABLE XON\n");
                     unsigned char c[1] = {XON};
-                    write(fd, c, 1);
+                    if(write(fd, c, 1) != 1){;}
                 }
             }
         } else {
@@ -8360,7 +8360,7 @@ int64_t mbtrnpp_em710raw_update_buffer(int fd, byte *buf, size_t len, const byte
         mbtrnpp_em710raw_set_rts(fd, false);
     } else if(em_ser_flow == 'X'){
         unsigned char c[1] = {XOFF};
-        write(fd, c, 1);
+        if(write(fd, c, 1) != 1){;}
         MX_BPRINT((verbose < -2), "DISABLE XOFF (%lld bytes)\n", burst_bytes);
 
     }
@@ -8385,7 +8385,7 @@ int64_t mbtrnpp_em710raw_read_buffer(ser_buf_t *src, byte *dest, int64_t read_le
     if(src == NULL || src->fd < 0 || src->size <= 0 || dest == NULL || read_len <= 0){
         fprintf(stderr, "%s: ERR - invalid argument ser_buf %p\n",__func__, src);
         if(src != NULL){
-            fprintf(stderr,"fd %d size %lld dest %p readlen %lld\n", src->fd, src->size, dest, read_len);
+            fprintf(stderr,"fd %d size %"PRId64" dest %p readlen %"PRId64"\n", src->fd, src->size, dest, read_len);
         }
         return retval;
     }


### PR DESCRIPTION
sync with build file changes in libtrnav.
This primarily involves gnu make and sentry cmake/gnu make build scripts to fix issues (e.g. opt/rov linkage errors under linux) and integrate opt/rov (trnxpp) target at the top level.

Suppress gctp warnings (geolib build target only); the warnings are for future deprecation in the open C2X standard.
Until it is deprecated (becomes and error), it makes sense to disable the warning for that target, rather than do extensive modification to gctp source.

Also fixes (not suppresses) warnings in mbtrnav/qnx-utils (DataLogReader,TimeP) and mbtrnutils (mbtrnpp).

Excludes files used by MB-System build.
Tested on macOS Sonoma 14.7 and Ubuntu 22.04 LTS.
