### PR TITLE
Bugfix: mbtrnpp shutdown

### DIFF
--- a/src/mbio/mb_fileio.c
+++ b/src/mbio/mb_fileio.c
@@ -171,7 +171,20 @@ int mb_fileio_get(int verbose, void *mbio_ptr, char *buffer, size_t *size, int *
       }
   }
   else if (mb_io_ptr->mbsp != NULL) {
-    mb_io_ptr->mb_io_input_read(verbose, mbio_ptr, size, buffer, error);
+      // mb_io_input_read may return zero or more bytes (possibly fewer than requested)
+      // If zero bytes are returned, error is set (!= MBERROR_NO_ERROR) if an error occurred
+      // otherwise returns -1 on error
+      if ((read_len = mb_io_ptr->mb_io_input_read(verbose, mbio_ptr, size, buffer, error)) <= 0) {
+          if(NULL != error && *error != MB_ERROR_NO_ERROR) {
+              status = MB_FAILURE;
+              // leave error set
+              // *error = MB_ERROR_EOF;
+              *size = read_len;
+          }
+      }
+      else {
+          *error = MB_ERROR_NO_ERROR;
+      }
   }
   else {
       fprintf(stderr,"mb_io file and socket pointers both NULL\n");

--- a/src/mbtrn/utils/frames7k.c
+++ b/src/mbtrn/utils/frames7k.c
@@ -634,6 +634,7 @@ static int s_app_main (app_cfg_t *cfg)
         retval=0;
         int read_retries = 5;
         long int seq_number = 0;
+        bool auto_str = false;
 
         while ( (forever || (count < cfg->cycles)) && !g_stop_flag) {
             int istat=0;
@@ -663,6 +664,9 @@ static int s_app_main (app_cfg_t *cfg)
                     nf->packet_size = R7K_NF_BYTES + drf->size;
                     nf->total_size  = drf->size;
                     nf->total_records  = 1;
+                    auto_str = true;
+                } else {
+                    auto_str = false;
                 }
 
 
@@ -681,7 +685,7 @@ static int s_app_main (app_cfg_t *cfg)
                 // show contents
                 if (show_frame) {
 
-                    MX_MSG("NF:\n");
+                    MX_PRINT("NF%s:\n",(auto_str ? " [auto] " : ""));
                     r7k_nf_show(nf,false,5);
 
                     MX_MSG("DRF:\n");

--- a/src/mbtrn/utils/frames7k.c
+++ b/src/mbtrn/utils/frames7k.c
@@ -634,7 +634,6 @@ static int s_app_main (app_cfg_t *cfg)
         retval=0;
         int read_retries = 5;
         long int seq_number = 0;
-        bool auto_str = false;
 
         while ( (forever || (count < cfg->cycles)) && !g_stop_flag) {
             int istat=0;
@@ -654,7 +653,10 @@ static int s_app_main (app_cfg_t *cfg)
                 r7k_nf_t *nf = (r7k_nf_t *)(frame_buf);
                 r7k_drf_t *drf = (r7k_drf_t *)(frame_buf+R7K_NF_BYTES);
 
+                bool auto_str = false;
                 if(cfg->mode == IMODE_FILE && !cfg->net_frames) {
+                    // file does not contain netframes
+                    // auto-generate netframe info
                     memset((void *)frame_buf,0,R7K_NF_BYTES);
 
                     nf->protocol_version = R7K_NF_PROTO_VER;
@@ -665,10 +667,7 @@ static int s_app_main (app_cfg_t *cfg)
                     nf->total_size  = drf->size;
                     nf->total_records  = 1;
                     auto_str = true;
-                } else {
-                    auto_str = false;
                 }
-
 
                 MX_LPRINT(FRAMES7K, 2, "r7kr_read_frame cycle[%d/%d] ret[%d] lost[%"PRIu32"]\n", count, cfg->cycles, istat, lost_bytes);
 

--- a/src/mbtrnutils/mbtrnpp.c
+++ b/src/mbtrnutils/mbtrnpp.c
@@ -3106,6 +3106,7 @@ static void s_sig_handler(int sig)
     {
         case SIGINT:
             // user interrupt (CTRL-C); set flag to end processing loop(s)
+            fprintf(stderr,"%s:%d - SIGINT received\n", __func__, __LINE__);
             g_interrupted = true;
             break;
         default:
@@ -4632,7 +4633,7 @@ int main(int argc, char **argv) {
 
                 MST_COUNTER_INC(app_stats->stats->events[MBTPP_EV_EMBGETALL]);
 
-                fprintf(stderr, "EOF (input socket) - clear status/error\n");
+                fprintf(stderr, "%s:%d - EOF (input socket) - clear status/error\n", __func__, __LINE__);
                 status = MB_SUCCESS;
                 error = MB_ERROR_NO_ERROR;
 
@@ -4640,7 +4641,7 @@ int main(int argc, char **argv) {
 
                 MST_COUNTER_INC(app_stats->stats->events[MBTPP_EV_EMBGETALL]);
 
-                fprintf(stderr, "EOF (input serial) - clear status/error\n");
+                fprintf(stderr, "%s:%d - EOF (input serial) - clear status/error\n", __func__, __LINE__);
                 status = MB_SUCCESS;
                 error = MB_ERROR_NO_ERROR;
 
@@ -4681,19 +4682,34 @@ int main(int argc, char **argv) {
 
     /* close the files */
       if (mbtrn_cfg->input_mode == INPUT_MODE_SOCKET) {
-          fprintf(stderr, "socket input mode - continue (probably shouldn't be here)\n");
-          mlog_tprintf(mbtrnpp_mlog_id,"e,invalid code path - socket input mode\n");
-          read_data = true;
+          if(g_interrupted) {
+              fprintf(stderr, "socket input mode - interrupt received\n");
+              mlog_tprintf(mbtrnpp_mlog_id,"e,interrupt received - socket input mode\n");
+          } else {
+              fprintf(stderr, "socket input mode - continue (probably shouldn't be here)\n");
+              mlog_tprintf(mbtrnpp_mlog_id,"e,invalid code path - socket input mode\n");
+              read_data = true;
+          }
 
           // empty the ring buffer
           ndata = 0;
+
+          // release mbio resources
+          status = mb_close(mbtrn_cfg->verbose, &imbio_ptr, &error);
       } else if (mbtrn_cfg->input_mode == INPUT_MODE_SERIAL) {
-          fprintf(stderr, "serial input mode - continue (probably shouldn't be here)\n");
-          mlog_tprintf(mbtrnpp_mlog_id,"e,invalid code path - serial input mode\n");
-          read_data = true;
+          if(g_interrupted) {
+              fprintf(stderr, "serial input mode - interrupt received\n");
+              mlog_tprintf(mbtrnpp_mlog_id,"e,interrupt received - socket input mode\n");
+          } else {
+              fprintf(stderr, "serial input mode - continue (probably shouldn't be here)\n");
+              mlog_tprintf(mbtrnpp_mlog_id,"e,invalid code path - socket input mode\n");
+              read_data = true;
+          }
 
           // empty the ring buffer
           ndata = 0;
+          // release mbio resources
+          status = mb_close(mbtrn_cfg->verbose, &imbio_ptr, &error);
       } else {
           status = mb_close(mbtrn_cfg->verbose, &imbio_ptr, &error);
 
@@ -4779,6 +4795,7 @@ int main(int argc, char **argv) {
 
     status = mbtrnpp_closelog(mbtrn_cfg->verbose, &logfp, &error);
   }
+  
 
   /* close output */
   if ( OUTPUT_FLAG_SET(OUTPUT_MB1_FILE_EN) ) {
@@ -4815,7 +4832,6 @@ int main(int argc, char **argv) {
   MEM_CHKINVALIDATE(mbtrn_cfg->trn_mission_id);
 
   /* check memory */
-  //if (mbtrn_cfg->verbose >= 4)
     status = mb_memory_list(mbtrn_cfg->verbose, &error);
 
   /* give the statistics */
@@ -6896,7 +6912,7 @@ int mbtrnpp_reson7kr_input_read(int verbose, void *mbio_ptr, size_t *size, char 
         // only reconnect if disconnected
         if ((NULL!=reader && reader->state==R7KR_INITIALIZED) || (me_errno==ME_ESOCK) || (me_errno==ME_EOF)  ) {
 
-            fprintf(stderr,"EOF (input socket) - clear status/error\n");
+            fprintf(stderr, "%s:%d - EOF (input serial) - clear status/error\n", __func__, __LINE__);
             status = MB_SUCCESS;
             *error = MB_ERROR_NO_ERROR;
 
@@ -9064,7 +9080,7 @@ int mbtrnpp_mb1r_input_read(int verbose, void *mbio_ptr, size_t *size, char *buf
             } else {
                 // read error
                 read_err = true;
-                MX_LPRINT(MBTRNPP, 3, "mb1r_read_frame failed rbytes[%zu]\n",(size_t)rbytes);
+                MX_LPRINT(MBTRNPP, 3, "mb1r_read_frame failed rbytes[%"PRId64"]\n",rbytes);
             }
 
         } else {
@@ -9119,7 +9135,7 @@ int mbtrnpp_mb1r_input_read(int verbose, void *mbio_ptr, size_t *size, char *buf
         // only reconnect if disconnected
         if ((NULL!=reader && reader->state==MB1R_INITIALIZED) || (me_errno==ME_ESOCK) || (me_errno==ME_EOF)  ) {
 
-            fprintf(stderr,"EOF (input socket) - clear status/error\n");
+            fprintf(stderr,"%s:%d - EOF (input socket) - clear status/error reader state %d me_error %d\n", __func__, __LINE__, reader->state, me_errno);
             status = MB_SUCCESS;
             *error = MB_ERROR_NO_ERROR;
 
@@ -9131,8 +9147,14 @@ int mbtrnpp_mb1r_input_read(int verbose, void *mbio_ptr, size_t *size, char *buf
             mlog_tprintf(mbtrnpp_mlog_id,"mbtrnpp: input socket status[%s]\n",mb1r_strstate(reader->state));
             MST_COUNTER_INC(app_stats->stats->events[MBTPP_EV_MB_DISN]);
 
-            // re-connect reader
+            if(g_interrupted) {
+                fprintf(stderr, "%s:%d - interrupted (SIGINT) returning MB_ERROR_EOF\n", __func__, __LINE__);
+                status   = MB_FAILURE;
+                *error   = MB_ERROR_EOF;
+                *size    = (size_t)0;
+            } else
             if (mb1r_reader_connect(reader,true)==0) {
+                // re-connect reader
                 read_frame = true;
                 read_err = false;
                 fprintf(stderr,"mbtrnpp: input socket re-connected status[%s]\n",mb1r_strstate(reader->state));


### PR DESCRIPTION
This change set addresses two issues related to mbtrnpp shutdown (e.g. by SIGINT):
- Using socket input for MB1 format, when SIGINT is raised (via CTRL-C), mbtrnpp would not exit. In that context, mbtrnpp would have to be backgrounded and killed manually to stop it. 
The mb1r input methods were not setting the return values needed to indicate that mb_get_all should exit. Logic is needed in mbtrnpp and mb_fileio; similar logic is used for other mbtrnpp real-time input types. Even with this fix, once mbtrnpp has connected to the MB1 input source, it will continue to pend until the MB1 input socket has closed; once it does, mbtrnpp will exit cleanly. This is due to a blocking read in the MB1 reader (mb1r). For now, I'd recommend we keep the blocking read, which is what we'd want during operation, and minimizes spinning during integration and test.

- Using socket (or serial) input for MB1 format, mbio memory was not being released on exit. Calling mb_close on exit in those contexts addresses the issue.

In addition, some debug output has been updated for clarity and content.

This changes set has been tested on MacOS Sonoma using the trnxpp MB1 server.