### PR TITLE
Trndev: add converge info to position estimate vs nav plots

### DIFF
--- a/src/mbtrn/tools/mbtrnpp-plot/qp-trnu.conf.sh
+++ b/src/mbtrn/tools/mbtrnpp-plot/qp-trnu.conf.sh
@@ -287,8 +287,8 @@ QP_YTITLE["$QU_KEY"]="MLE Northing"
 #QP_Y2TITLE["$QU_KEY"]="Depth"
 #QP_Y2RANGE_MIN["$QU_KEY"]=6.5
 #QP_Y2RANGE_MAX["$QU_KEY"]=8.8
-QP_XSCALE["$QU_KEY"]=-1.0
-QP_YSCALE["$QU_KEY"]=-1.0
+#QP_XSCALE["$QU_KEY"]=-1.0
+#QP_YSCALE["$QU_KEY"]=-1.0
 QP_XOFS["$QU_KEY"]=${QU_EST_E_OFS}
 QP_YOFS["$QU_KEY"]=${QU_EST_W_OFS}
 QP_PLOT_STYLE["$QU_KEY"]="points" #lines
@@ -301,8 +301,13 @@ QP_USE_LINETYPES["$QU_KEY"]="N"
 QP_LINETYPE["$QU_KEY"]=1
 QP_INC_LINETYPE["$QU_KEY"]="Y"
 #QP_LINE_TYPES["$QU_KEY"]="${QU_LINE_TYPE_DFL}"
-QP_PLOT_SPECS["$QU_KEY"]="${QU_TRNU_PTDAT_CSV},${QU_GREEN},4,,1,5,x1y1,pt.xy"
-QP_PLOT_SPECS["$QU_KEY"]+="+${QU_TRNU_MLEDAT_CSV},${QU_ORANGE},4,,1,5,x1y2,mle.xy"
+QP_EXPR["$QU_KEY"]="Y"
+QP_SPECDEL["$QU_KEY"]="|"
+QP_PLOT_SPECS["$QU_KEY"]="${QU_TRNU_PTDAT_CSV},${QU_GREEN},4,,1,(\$5),x1y1,pt.xy"
+QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MLEDAT_CSV},${QU_BLUE},4,,1,(\$5),x1y2,mle.xy"
+# Note: older trnu logs may not include the convergence columns
+QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MLEDAT_CSV},${QU_ORANGE},4,,1,(\$7==1?\$5:1/0),x1y2,mle(cnv)"
+QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MLEDAT_CSV},${QU_MAGENTA},4,,1,(\$8==1?\$5:1/0),x1y2,mle(val)"
 
 QU_KEY=${QU_KEYS[4]}
 QP_OFILE_NAME["$QU_KEY"]="${QU_MLEX_OIMG_NAME}"
@@ -474,9 +479,10 @@ QP_INC_LINETYPE["$QU_KEY"]="Y"
 QP_EXPR["$QU_KEY"]="Y"
 QP_SPECDEL["$QU_KEY"]="|"
 QP_PLOT_SPECS["$QU_KEY"]="${QU_TRNU_PTDAT_CSV},${QU_GREEN},4,,1,(\$5),x1y1,pt.xy"
-QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MSEDAT_CSV},${QU_BLUE},4,,1,(\$5),x1y2,mse.xy"
-# Note: older trnu logs may not include the converged column (11)
-QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MSEDAT_CSV},${QU_ORANGE},4,,1,(\$11==1?\$5:1/0),x1y2,mse.xy"
+QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MSEDAT_CSV},${QU_BLUE},4,,1,(\$5),x1y2,mse"
+# Note: older trnu logs may not include the converge columns
+QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MSEDAT_CSV},${QU_ORANGE},4,,1,(\$11==1?\$5:1/0),x1y2,mse(cnv)"
+QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MSEDAT_CSV},${QU_MAGENTA},4,,1,(\$12==1?\$5:1/0),x1y2,mse(val)"
 
 QU_KEY=${QU_KEYS[8]}
 QP_OFILE_NAME["$QU_KEY"]="${QU_MSEX_OIMG_NAME}"
@@ -632,8 +638,8 @@ QP_YTITLE["$QU_KEY"]="PT Northing"
 #QP_Y2TITLE["$QU_KEY"]="Depth"
 #QP_Y2RANGE_MIN["$QU_KEY"]=6.5
 #QP_Y2RANGE_MAX["$QU_KEY"]=8.8
-QP_XSCALE["$QU_KEY"]=-1.0
-QP_YSCALE["$QU_KEY"]=-1.0
+#QP_XSCALE["$QU_KEY"]=-1.0
+#QP_YSCALE["$QU_KEY"]=-1.0
 QP_XOFS["$QU_KEY"]="${QU_EST_E_OFS}"
 QP_YOFS["$QU_KEY"]=${QU_EST_W_OFS}
 QP_PLOT_STYLE["$QU_KEY"]="points" #lines

--- a/src/mbtrn/tools/mbtrnpp-plot/qp-trnu.conf.sh
+++ b/src/mbtrn/tools/mbtrnpp-plot/qp-trnu.conf.sh
@@ -301,13 +301,16 @@ QP_USE_LINETYPES["$QU_KEY"]="N"
 QP_LINETYPE["$QU_KEY"]=1
 QP_INC_LINETYPE["$QU_KEY"]="Y"
 #QP_LINE_TYPES["$QU_KEY"]="${QU_LINE_TYPE_DFL}"
+# Use these for trnu logs with convergence fields in trn_mse_dat trn_mle_dat
 QP_EXPR["$QU_KEY"]="Y"
 QP_SPECDEL["$QU_KEY"]="|"
 QP_PLOT_SPECS["$QU_KEY"]="${QU_TRNU_PTDAT_CSV},${QU_GREEN},4,,1,(\$5),x1y1,pt.xy"
 QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MLEDAT_CSV},${QU_BLUE},4,,1,(\$5),x1y2,mle.xy"
-# Note: older trnu logs may not include the convergence columns
 QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MLEDAT_CSV},${QU_ORANGE},4,,1,(\$7==1?\$5:1/0),x1y2,mle(cnv)"
 QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MLEDAT_CSV},${QU_MAGENTA},4,,1,(\$8==1?\$5:1/0),x1y2,mle(val)"
+# Use these for trnu logs w/o convergence fields in trn_mse_dat trn_mle_dat
+#QP_PLOT_SPECS["$QU_KEY"]="${QU_TRNU_PTDAT_CSV},${QU_GREEN},4,,1,5,x1y1,pt.xy"
+#QP_PLOT_SPECS["$QU_KEY"]+="+${QU_TRNU_MLEDAT_CSV},${QU_BLUE},4,,1,5,x1y2,mle.xy"
 
 QU_KEY=${QU_KEYS[4]}
 QP_OFILE_NAME["$QU_KEY"]="${QU_MLEX_OIMG_NAME}"
@@ -476,13 +479,16 @@ QP_USE_LINETYPES["$QU_KEY"]="N"
 QP_LINETYPE["$QU_KEY"]=1
 QP_INC_LINETYPE["$QU_KEY"]="Y"
 #QP_LINE_TYPES["$QU_KEY"]="${QU_LINE_TYPE_DFL}"
+# Use these for trnu logs with convergence fields in trn_mse_dat trn_mle_dat
 QP_EXPR["$QU_KEY"]="Y"
 QP_SPECDEL["$QU_KEY"]="|"
 QP_PLOT_SPECS["$QU_KEY"]="${QU_TRNU_PTDAT_CSV},${QU_GREEN},4,,1,(\$5),x1y1,pt.xy"
 QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MSEDAT_CSV},${QU_BLUE},4,,1,(\$5),x1y2,mse"
-# Note: older trnu logs may not include the converge columns
 QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MSEDAT_CSV},${QU_ORANGE},4,,1,(\$11==1?\$5:1/0),x1y2,mse(cnv)"
 QP_PLOT_SPECS["$QU_KEY"]+="|${QU_TRNU_MSEDAT_CSV},${QU_MAGENTA},4,,1,(\$12==1?\$5:1/0),x1y2,mse(val)"
+# Use these for trnu logs w/o convergence fields in trn_mse_dat trn_mle_dat
+#QP_PLOT_SPECS["$QU_KEY"]="${QU_TRNU_PTDAT_CSV},${QU_GREEN},4,,1,5,x1y1,pt.xy"
+#QP_PLOT_SPECS["$QU_KEY"]+="+${QU_TRNU_MSEDAT_CSV},${QU_BLUE},4,,1,5,x1y2,mse"
 
 QU_KEY=${QU_KEYS[8]}
 QP_OFILE_NAME["$QU_KEY"]="${QU_MSEX_OIMG_NAME}"

--- a/src/mbtrnutils/mbtrnpp.c
+++ b/src/mbtrnutils/mbtrnpp.c
@@ -5636,14 +5636,16 @@ int mbtrnpp_trn_pub_olog(trn_update_t *update,
                      update->pt_dat->z);
 
         if(NULL!=update->mle_dat)
-            mlog_tprintf(log_id,"trn_mle_dat,%lf,%.4lf,%.4lf,%.4lf\n",
+            mlog_tprintf(log_id,"trn_mle_dat,%lf,%.4lf,%.4lf,%.4lf,%hd,%hd\n",
                          update->mle_dat->time,
                          update->mle_dat->x,
                          update->mle_dat->y,
-                         update->mle_dat->z);
+                         update->mle_dat->z,
+                         update->is_converged,
+                         update->is_valid);
 
         if(NULL!=update->mse_dat)
-            mlog_tprintf(log_id,"trn_mse_dat,%lf,%.4lf,%.4lf,%.4lf,%.4lf,%.4lf,%.4lf,%.4lf,%hd\n",
+            mlog_tprintf(log_id,"trn_mse_dat,%lf,%.4lf,%.4lf,%.4lf,%.4lf,%.4lf,%.4lf,%.4lf,%hd,%hd\n",
                          update->mse_dat->time,
                          update->mse_dat->x,
                          update->mse_dat->y,
@@ -5652,7 +5654,8 @@ int mbtrnpp_trn_pub_olog(trn_update_t *update,
                          update->mse_dat->covariance[2],
                          update->mse_dat->covariance[5],
                          update->mse_dat->covariance[1],
-                         update->is_converged);
+                         update->is_converged,
+                         update->is_valid);
 
         if(NULL!=update->mse_dat && NULL!=update->pt_dat && NULL!=update->mle_dat)
             mlog_tprintf(log_id,"trn_est,%lf,%.4lf,%.4lf,%.4lf,%.4lf,%.4lf,%.4lf,%.2lf,%.2lf,%.2lf\n",


### PR DESCRIPTION
Add convergence info (converged, valid) fields to trn_mse_dat and trn_mle_dat CSV log messages in trnu log.
In mbtrnpp-plot, Use convergence info in plots comparing MMSE and MLE position estimates to navigation (pose) data.

This will not work with logs that don't have the convergence data.
The plot configuration file (qp-trnu.conf.sh) includes the original code and annotations to use it instead if needed.

Example attached
[conv-plot-example.pdf](https://github.com/user-attachments/files/20630945/conv-plot-example.pdf)
