### PR TITLE
Fix src/mbgrd2gltf/CMakeLists.txt to force use of local Draco source files.

### DIFF
--- a/src/mbgrd2gltf/CMakeLists.txt
+++ b/src/mbgrd2gltf/CMakeLists.txt
@@ -27,7 +27,8 @@ message("In src/mbgrd2gltf")
 find_package(NetCDF REQUIRED)
 
 # Attempt to find an installed version of Draco
-find_package(Draco)
+# Commented out to force use of local Draco source files for compatibility
+# find_package(Draco)
 
 # Set the C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -35,6 +36,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set the draco directory
 set(DRACO_DIR "${CMAKE_CURRENT_SOURCE_DIR}/draco")
+
+# Initialize INCLUDE_DIRS
+set(INCLUDE_DIRS "")
 
 # Set the sources for the executable
 set(SOURCES bathymetry.cpp compression.cpp geometry.cpp main.cpp model.cpp options.cpp)
@@ -57,8 +61,10 @@ if(NOT TARGET Draco::Draco)
 		list(FILTER DRACO_SOURCES EXCLUDE REGEX ".*/.*test.*")
 
 		# Set the include directories and sources conditionally.
-		set(INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/draco)
+		set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/draco)
 		set(SOURCES ${SOURCES} ${DRACO_SOURCES})
+		# No external libraries needed since we're compiling the source
+		set(DRACO_LIBRARIES "")
 	else()
 		message("Using installed Draco, but Draco target not found, checking for libraries...")
 		find_library(DRACO_LIBRARY NAMES draco PATHS /usr/local/lib)
@@ -80,9 +86,11 @@ endif()
 add_executable(mbgrd2gltf ${SOURCES})
 
 # Set and link the include directories
-set(INCLUDE_DIRS ${INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/src/mbgrd2gltf ${CMAKE_SOURCE_DIR}/src/mbgrd2gltf/tinygltf)
 target_include_directories(mbgrd2gltf
 	PRIVATE ${NetCDF_INCLUDE_DIRS}
+	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tinygltf
+	PRIVATE ${DRACO_DIR}
 	PRIVATE ${INCLUDE_DIRS}
 )
 

--- a/src/mbgrd2gltf/model.cpp
+++ b/src/mbgrd2gltf/model.cpp
@@ -242,7 +242,7 @@ namespace mbgrd2gltf {
 
 			// Initialize the attribute with the correct type and number of components
 			// The attribute is of type POSITION and has 3 components (x, y, z)
-			pos_att.Init(draco::GeometryAttribute::POSITION, nullptr, 3, draco::DT_FLOAT32, false, sizeof(float) * 3, 0);
+			pos_att.Init(draco::GeometryAttribute::POSITION, nullptr, 3, draco::DT_FLOAT32, false, static_cast<int64_t>(12), static_cast<int64_t>(0));
 
 			// Add the attribute to the mesh
 			const uint32_t pos_att_id = pc.AddAttribute(pos_att, true, num_vertices);


### PR DESCRIPTION
This is in response to reported problems building on Ubuntu 22:
```
[ 71%] Linking CXX executable mbgrd2gltf
/usr/bin/ld: CMakeFiles/mbgrd2gltf.dir/model.cpp.o: in function
`mbgrd2gltf::model::dracoEncodeGeometry(std::vector<float,
std::allocator<float> > const&, std::vector<unsigned int,
std::allocator<unsigned int> > const&, mbgrd2gltf::Options const&,
std::vector<unsigned char, std::allocator<unsigned char> >&)':
model.cpp:(.text+0x2d5b9): undefined reference to
`draco::GeometryAttribute::Init(draco::GeometryAttribute::Type,
draco::DataBuffer*, unsigned char, draco::DataType, bool, long, long)'
collect2: error: ld returned 1 exit status
make[2]: *** [src/mbgrd2gltf/CMakeFiles/mbgrd2gltf.dir/build.make:187: src/
mbgrd2gltf/mbgrd2gltf] Error 1
make[1]: *** [CMakeFiles/Makefile2:3111: src/mbgrd2gltf/CMakeFiles/
mbgrd2gltf.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```
Also a do use explicit int64_t casts to avoid any linking issues.