### PR TITLE
mbio: expose Reson 7k3 SonarSettings (record 7000) via new mb_sonarsettings(), surfaced in mblist

### DIFF
--- a/src/man/man1/mblist.1
+++ b/src/man/man1/mblist.1
@@ -547,7 +547,7 @@ from the "NN"th column of a secondary data table file specified using \fB-Y\fP.
 .IP
 \fB .A\fP  Amplitude (backscatter) in dB (formats 56 & 57 \- Simrad multibeam only)
 .IP
-\fB .a\fP  Mean absorption coefficient in dB/km (formats 56 & 57 \- Simrad multibeam some versions only)
+\fB .a\fP  Mean absorption coefficient in dB/km (formats 56 & 57 \- Simrad multibeam some versions only; format 89 \- Reson 7k3)
 .IP
 \fB .B\fP  Normal incidence backscatter in dB (formats 56 & 57 \- Simrad multibeam only)
 .IP
@@ -568,7 +568,7 @@ from the "NN"th column of a secondary data table file specified using \fB-Y\fP.
 .IP
 \fB .g\fP  Stop of TVG ramp in samples (formats 56 & 57 \- Simrad multibeam only)
 .IP
-\fB .L\fP  Transmit pulse length (usec) (formats 56 & 57 \- Simrad multibeam only)
+\fB .L\fP  Transmit pulse length (usec) (formats 56 & 57 \- Simrad multibeam only; format 89 \- Reson 7k3)
 .IP
 \fB .l\fP  Transmit pulse length (sec)
 .IP
@@ -582,7 +582,7 @@ for example\fB .30p\fP will give the first 30 sidescan pixels of each beam.
 .IP
 \fB .R\fP  Range in samples (formats 56 & 57 \- Simrad multibeam only)
 .IP
-\fB .r\fP  Sampling rate in Hz (formats 56 & 57 \- Simrad multibeam only)
+\fB .r\fP  Sampling rate in Hz (formats 56 & 57 \- Simrad multibeam only; format 89 \- Reson 7k3)
 .IP
 \fB .S\fP  Number of raw sidescan pixels per ping (formats 56 & 57 \- Simrad multibeam only)
 .IP

--- a/src/mbio/mb_access.c
+++ b/src/mbio/mb_access.c
@@ -1660,6 +1660,59 @@ int mb_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *tr
   return (status);
 }
 /*--------------------------------------------------------------------*/
+int mb_sonarsettings(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *frequency,
+                     double *sample_rate, double *tx_pulse_width, double *power_selection, double *gain_selection,
+                     double *absorption, double *spreading, double *sound_velocity, double *beamwidth_tx,
+                     double *beamwidth_rx, int *error) {
+  if (verbose >= 2) {
+    fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
+    fprintf(stderr, "dbg2  Input arguments:\n");
+    fprintf(stderr, "dbg2       verbose:    %d\n", verbose);
+    fprintf(stderr, "dbg2       mb_ptr:     %p\n", (void *)mbio_ptr);
+    fprintf(stderr, "dbg2       store_ptr:  %p\n", (void *)store_ptr);
+  }
+
+  struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
+
+  /* call the appropriate mbsys_ extraction routine (NULL for formats that do not
+     record per-ping sonar settings; reson7k3 is the first to implement it) */
+  int status = MB_SUCCESS;
+  if (mb_io_ptr->mb_io_sonarsettings != NULL) {
+    status = (*mb_io_ptr->mb_io_sonarsettings)(verbose, mbio_ptr, store_ptr, kind, frequency, sample_rate,
+                                               tx_pulse_width, power_selection, gain_selection, absorption,
+                                               spreading, sound_velocity, beamwidth_tx, beamwidth_rx, error);
+  }
+  else {
+    status = MB_FAILURE;
+    *error = MB_ERROR_BAD_SYSTEM;
+  }
+
+  if (verbose >= 2) {
+    fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);
+    fprintf(stderr, "dbg2  Return values:\n");
+    fprintf(stderr, "dbg2       kind:       %d\n", *kind);
+  }
+  if (verbose >= 2 && *error == MB_ERROR_NO_ERROR) {
+    fprintf(stderr, "dbg2       frequency:       %f\n", *frequency);
+    fprintf(stderr, "dbg2       sample_rate:     %f\n", *sample_rate);
+    fprintf(stderr, "dbg2       tx_pulse_width:  %f\n", *tx_pulse_width);
+    fprintf(stderr, "dbg2       power_selection: %f\n", *power_selection);
+    fprintf(stderr, "dbg2       gain_selection:  %f\n", *gain_selection);
+    fprintf(stderr, "dbg2       absorption:      %f\n", *absorption);
+    fprintf(stderr, "dbg2       spreading:       %f\n", *spreading);
+    fprintf(stderr, "dbg2       sound_velocity:  %f\n", *sound_velocity);
+    fprintf(stderr, "dbg2       beamwidth_tx:    %f\n", *beamwidth_tx);
+    fprintf(stderr, "dbg2       beamwidth_rx:    %f\n", *beamwidth_rx);
+  }
+  if (verbose >= 2) {
+    fprintf(stderr, "dbg2       error:      %d\n", *error);
+    fprintf(stderr, "dbg2  Return status:\n");
+    fprintf(stderr, "dbg2       status:     %d\n", status);
+  }
+
+  return (status);
+}
+/*--------------------------------------------------------------------*/
   int mb_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error) {
   if (verbose >= 2) {

--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -503,6 +503,10 @@ int mb_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbe
 int mb_pulses(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *pulses, int *error);
 int mb_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
              double *receive_gain, int *error);
+int mb_sonarsettings(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *frequency,
+             double *sample_rate, double *tx_pulse_width, double *power_selection, double *gain_selection,
+             double *absorption, double *spreading, double *sound_velocity, double *beamwidth_tx,
+             double *beamwidth_rx, int *error);
 int mb_makess(int verbose, void *mbio_ptr, void *store_ptr, int pixel_size_set, double *pixel_size,
                          int swath_width_set, double *swath_width, int pixel_int, int *error);
 int mb_extract_rawssdimensions(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *sample_interval,

--- a/src/mbio/mb_io.h
+++ b/src/mbio/mb_io.h
@@ -794,6 +794,10 @@ struct mb_io_struct {
   int (*mb_io_pulses)(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *pulses, int *error);
   int (*mb_io_gains)(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                      double *receive_gain, int *error);
+  int (*mb_io_sonarsettings)(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *frequency,
+                     double *sample_rate, double *tx_pulse_width, double *power_selection, double *gain_selection,
+                     double *absorption, double *spreading, double *sound_velocity, double *beamwidth_tx,
+                     double *beamwidth_rx, int *error);
   int (*mb_io_extract_rawssdimensions)(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *sample_interval,
                                        int *num_samples_port, int *num_samples_stbd, int *error);
   int (*mb_io_extract_rawss)(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *sidescan_type,

--- a/src/mbio/mbr_reson7k3.c
+++ b/src/mbio/mbr_reson7k3.c
@@ -22386,6 +22386,7 @@ int mbr_register_reson7k3(int verbose, void *mbio_ptr, int *error) {
   mb_io_ptr->mb_io_ttimes = &mbsys_reson7k3_ttimes;
   mb_io_ptr->mb_io_detects = &mbsys_reson7k3_detects;
   mb_io_ptr->mb_io_gains = &mbsys_reson7k3_gains;
+  mb_io_ptr->mb_io_sonarsettings = &mbsys_reson7k3_sonarsettings;
   mb_io_ptr->mb_io_copyrecord = &mbsys_reson7k3_copy;
   mb_io_ptr->mb_io_makess = &mbsys_reson7k3_makess;
   mb_io_ptr->mb_io_extract_rawss = NULL;

--- a/src/mbio/mbsys_reson7k3.c
+++ b/src/mbio/mbsys_reson7k3.c
@@ -7342,6 +7342,86 @@ int mbsys_reson7k3_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind
   return (status);
 }
 /*--------------------------------------------------------------------*/
+int mbsys_reson7k3_sonarsettings(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *frequency,
+                        double *sample_rate, double *tx_pulse_width, double *power_selection, double *gain_selection,
+                        double *absorption, double *spreading, double *sound_velocity, double *beamwidth_tx,
+                        double *beamwidth_rx, int *error) {
+  if (verbose >= 2) {
+    fprintf(stderr, "\ndbg2  MBIO function <%s> called\n", __func__);
+    fprintf(stderr, "dbg2  Input arguments:\n");
+    fprintf(stderr, "dbg2       verbose:    %d\n", verbose);
+    fprintf(stderr, "dbg2       mb_ptr:     %p\n", (void *)mbio_ptr);
+    fprintf(stderr, "dbg2       store_ptr:  %p\n", (void *)store_ptr);
+  }
+
+  struct mbsys_reson7k3_struct *store = (struct mbsys_reson7k3_struct *)store_ptr;
+  s7k3_SonarSettings *SonarSettings = (s7k3_SonarSettings *)&store->SonarSettings;
+
+  /* get data kind */
+  *kind = store->kind;
+
+  int status = MB_SUCCESS;
+
+  /* extract the recorded Reson 7k Sonar Settings (record 7000) values — these are
+     values written into the file by the sonar; no proprietary gain model is applied */
+  if (*kind == MB_DATA_DATA) {
+    if (store->read_SonarSettings) {
+      *frequency = (double)SonarSettings->frequency;             /* Hz */
+      *sample_rate = (double)SonarSettings->sample_rate;         /* Hz */
+      *tx_pulse_width = (double)SonarSettings->tx_pulse_width;   /* seconds */
+      *power_selection = (double)SonarSettings->power_selection; /* dB re 1 uPa */
+      *gain_selection = (double)SonarSettings->gain_selection;   /* dB */
+      *absorption = (double)SonarSettings->absorption;           /* dB/km */
+      *spreading = (double)SonarSettings->spreading;             /* dB */
+      *sound_velocity = (double)SonarSettings->sound_velocity;   /* m/s */
+      *beamwidth_tx = (double)SonarSettings->beamwidth_vertical; /* radians (projector) */
+      *beamwidth_rx = (double)SonarSettings->rx_width;           /* radians (receiver) */
+
+      *error = MB_ERROR_NO_ERROR;
+      status = MB_SUCCESS;
+    }
+    else {
+      *error = MB_ERROR_UNINTELLIGIBLE;
+      status = MB_FAILURE;
+    }
+  }
+
+  /* deal with comment */
+  else if (*kind == MB_DATA_COMMENT) {
+    *error = MB_ERROR_COMMENT;
+    status = MB_FAILURE;
+  }
+
+  /* deal with other record type */
+  else {
+    *error = MB_ERROR_OTHER;
+    status = MB_FAILURE;
+  }
+
+  if (verbose >= 2) {
+    fprintf(stderr, "\ndbg2  MBIO function <%s> completed\n", __func__);
+    fprintf(stderr, "dbg2  Return values:\n");
+    fprintf(stderr, "dbg2       kind:           %d\n", *kind);
+    if (*error == MB_ERROR_NO_ERROR) {
+      fprintf(stderr, "dbg2       frequency:       %f\n", *frequency);
+      fprintf(stderr, "dbg2       sample_rate:     %f\n", *sample_rate);
+      fprintf(stderr, "dbg2       tx_pulse_width:  %f\n", *tx_pulse_width);
+      fprintf(stderr, "dbg2       power_selection: %f\n", *power_selection);
+      fprintf(stderr, "dbg2       gain_selection:  %f\n", *gain_selection);
+      fprintf(stderr, "dbg2       absorption:      %f\n", *absorption);
+      fprintf(stderr, "dbg2       spreading:       %f\n", *spreading);
+      fprintf(stderr, "dbg2       sound_velocity:  %f\n", *sound_velocity);
+      fprintf(stderr, "dbg2       beamwidth_tx:    %f\n", *beamwidth_tx);
+      fprintf(stderr, "dbg2       beamwidth_rx:    %f\n", *beamwidth_rx);
+    }
+    fprintf(stderr, "dbg2       error:          %d\n", *error);
+    fprintf(stderr, "dbg2  Return status:\n");
+    fprintf(stderr, "dbg2       status:         %d\n", status);
+  }
+
+  return (status);
+}
+/*--------------------------------------------------------------------*/
 int mbsys_reson7k3_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr,
                                     int *kind, double *transducer_depth,
                                     double *altitudev, int *error) {

--- a/src/mbio/mbsys_reson7k3.c
+++ b/src/mbio/mbsys_reson7k3.c
@@ -7362,7 +7362,7 @@ int mbsys_reson7k3_sonarsettings(int verbose, void *mbio_ptr, void *store_ptr, i
 
   int status = MB_SUCCESS;
 
-  /* extract the recorded Reson 7k Sonar Settings (record 7000) values — these are
+  /* extract the recorded Reson 7k Sonar Settings (record 7000) values - these are
      values written into the file by the sonar; no proprietary gain model is applied */
   if (*kind == MB_DATA_DATA) {
     if (store->read_SonarSettings) {

--- a/src/mbio/mbsys_reson7k3.h
+++ b/src/mbio/mbsys_reson7k3.h
@@ -3516,6 +3516,10 @@ int mbsys_reson7k3_ttimes(int verbose, void *mbio_ptr, void *store_ptr, int *kin
 int mbsys_reson7k3_detects(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int *nbeams, int *detects, int *error);
 int mbsys_reson7k3_gains(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transmit_gain, double *pulse_length,
                         double *receive_gain, int *error);
+int mbsys_reson7k3_sonarsettings(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *frequency,
+                        double *sample_rate, double *tx_pulse_width, double *power_selection, double *gain_selection,
+                        double *absorption, double *spreading, double *sound_velocity, double *beamwidth_tx,
+                        double *beamwidth_rx, int *error);
 int mbsys_reson7k3_extract_altitude(int verbose, void *mbio_ptr, void *store_ptr, int *kind, double *transducer_depth,
                                    double *altitude, int *error);
 int mbsys_reson7k3_extract_nav(int verbose, void *mbio_ptr, void *store_ptr, int *kind, int time_i[7], double *time_d,

--- a/src/utilities/mblist.cc
+++ b/src/utilities/mblist.cc
@@ -736,6 +736,24 @@ int mb_get_raw(int verbose, void *mbio_ptr, int *mode, int *ipulse_length, int *
                        start_sample, range, depression, bs, ss_pixels, error);
 
     break;
+  case MBF_RESON7K3:
+    {
+    /* Reson 7k3: pull the recorded 7000 Sonar Settings via the format-independent
+       mb_sonarsettings() accessor (these are values written by the sonar; no vendor
+       gain/TVG model is applied). Transmit power and receiver gain are also available
+       through the -O.T/.t (mb_gains) codes. */
+    double ss_frequency, ss_sample_rate, ss_tx_pulse_width, ss_power, ss_gain;
+    double ss_absorption, ss_spreading, ss_sound_velocity, ss_beamwidth_tx, ss_beamwidth_rx;
+    int ss_kind = MB_DATA_NONE;
+    if (mb_sonarsettings(verbose, mbio_ptr, mb_io_ptr->store_data, &ss_kind, &ss_frequency, &ss_sample_rate,
+                         &ss_tx_pulse_width, &ss_power, &ss_gain, &ss_absorption, &ss_spreading, &ss_sound_velocity,
+                         &ss_beamwidth_tx, &ss_beamwidth_rx, error) == MB_SUCCESS) {
+      *sample_rate = (int)(ss_sample_rate + 0.5);
+      *absorption = ss_absorption;
+      *ipulse_length = (int)(ss_tx_pulse_width * 1.0e6 + 0.5);  /* seconds -> usec (as for .L) */
+    }
+    }
+    break;
   }
 
   int status = MB_SUCCESS;


### PR DESCRIPTION
## Summary

The Reson 7k3 reader (`mbsys_reson7k3`) already parses the **7000 Sonar Settings** record, but the only settings reachable through the format-independent API are `transmit_gain` / `pulse_length` / `receive_gain` (via `mb_gains`). The rest of the recorded settings — **frequency, sample rate, transmit pulse width, power & gain selection, absorption, spreading, sound velocity, and tx/rx beamwidths** — are needed for backscatter processing (removing the time-varying gain, and applying transmission-loss / insonified-area corrections) but are currently locked in the system-specific struct.

This PR adds a small, **purely additive** accessor to surface those recorded values, and wires the most useful ones into `mblist`.

### API
`mb_sonarsettings()` mirrors the existing `mb_gains()`:
- new function pointer `mb_io_sonarsettings` in `struct mb_io` — **NULL by default**, so formats that don't implement it return `MB_ERROR_BAD_SYSTEM` and **no other format readers are touched**;
- generic wrapper `mb_sonarsettings()` in `mb_access.c` (prototype in `mb_define.h`);
- implementation `mbsys_reson7k3_sonarsettings()` returning the recorded 7000 values, registered in `mbr_reson7k3.c`.

### mblist
`mb_get_raw()` learns about format 89 (Reson 7k3) through `mb_sonarsettings()`, so the existing raw output codes now work for Reson 7k data:

| code | value |
|------|-------|
| `-O.a` | mean absorption (dB/km) |
| `-O.r` | sampling rate (Hz) |
| `-O.L` | transmit pulse length (µs) |

(transmit power and receiver gain are already available via `-O.T` / `-O.t` through `mb_gains`). Man page updated.

### Note on proprietary data
This only surfaces values **the sonar wrote into the file** (the 7000 record MB-System already parses). It applies **no vendor gain/TVG model** — there is nothing proprietary here.

### Testing
- `libmbio` and `mblist` build cleanly.
- Verified against real R/V *Hugh R. Sharp* **Reson 7125** data (format 89), e.g.:
  ```
  $ mblist -I surveyp.mb89 -O"T.a.r.L"
  2015/06/19/19/42/06.160208   44.00   34483    100
  ...
  ```
  (time, absorption dB/km, sample-rate Hz, pulse-length µs)

### Possible follow-ups
The accessor already returns frequency, spreading, sound velocity, and tx/rx beamwidths; these could be surfaced via additional `mblist` codes, and `mb_sonarsettings()` could be implemented for other systems that record equivalent settings (e.g. Kongsberg `.kmall`, Reson 7kr).