### PR TITLE
Fix MSVC/Windows build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,9 +102,87 @@ if (${srcdir} STREQUAL ${bindir})
 endif (${srcdir} STREQUAL ${bindir})
 
 add_compile_definitions(CMAKE_BUILD_SYSTEM=1)
+
+# Platform system libs commonly tacked onto utility executables. On POSIX:
+# libm (math) and pthread are external; on MSVC they're built into the CRT
+# and pthreads-win32 is already linked globally.
+if(WIN32)
+  set(MB_SYSLIBS "")
+else()
+  set(MB_SYSLIBS m pthread)
+endif()
 if (CMAKE_C_BYTE_ORDER STREQUAL "LITTLE_ENDIAN")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DBYTESWAPPED")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBYTESWAPPED")
+endif()
+
+# MSVC has no <unistd.h>; the substitute lives in src/mbio/unistd_w.h, pulled in
+# by src/mbio/mb_define.h (force-included below) under #ifdef _WIN32.
+if(MSVC)
+  # Most project libraries have no __declspec(dllexport) markers, so building
+  # them as SHARED produces a .dll with no .lib import library and downstream
+  # targets fail to link. Force auto-export of all symbols, which generates
+  # the import lib automatically. Equivalent to MinGW's --export-all-symbols.
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+  # src/mbio holds mb_define.h + unistd_w.h; make resolvable from every TU so the
+  # force-included mb_define.h can pull "unistd_w.h" regardless of the includer.
+  include_directories(${CMAKE_SOURCE_DIR}/src/mbio)
+  # mb_define.h also pulls src/mbaux/mb_xdr_win32.h (the shared Windows XDR shim)
+  # on every force-included TU, so that path must be global too.
+  include_directories(${CMAKE_SOURCE_DIR}/src/mbaux)
+
+  # Silence the most common POSIX-name warnings (open vs _open, etc.)
+  # NOMINMAX prevents Windows.h from defining min/max macros that clobber
+  # std::numeric_limits<>::max(), std::min(), etc.
+  add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE _CRT_SECURE_NO_WARNINGS NOMINMAX WIN32_LEAN_AND_MEAN NOGDI)
+  # Force-include mb_define.h on every translation unit. It carries the Windows
+  # POSIX compatibility shim under #ifdef _WIN32 (clock_gettime, strcasecmp,
+  # sockets, getopt, S_IS*, etc.) plus the <unistd.h> selector. Its XDR shim
+  # has identical XdrOp/XDR types to src/surf/xdr_win32.h, which is guarded with
+  # _MB_WIN_XDR_DEFINED so the two do not collide.
+  # /FI<file> = "include this header at the top of every translation unit".
+  add_compile_options(/FI${CMAKE_SOURCE_DIR}/src/mbio/mb_define.h)
+
+  # getopt (POSIX) — utilities pervasively call getopt; MSVC ships none.
+  if(GETOPT_INCLUDE_DIR)
+    include_directories(${GETOPT_INCLUDE_DIR})
+  endif()
+  if(GETOPT_LIBRARY)
+    link_libraries(${GETOPT_LIBRARY})
+  endif()
+
+  # NetCDF — GMT public headers (gmt_shore.h etc) include <netcdf.h>.
+  if(NetCDF_INCLUDE_DIR)
+    include_directories(${NetCDF_INCLUDE_DIR})
+  endif()
+
+  # GLib (needed by GMT public headers when HAVE_GLIB_GTHREAD set).
+  if(GLIB_INCLUDE_DIR)
+    include_directories(${GLIB_INCLUDE_DIR})
+  endif()
+  if(GLIB_CONFIG_DIR)
+    include_directories(${GLIB_CONFIG_DIR})
+  endif()
+  if(GLIB_LIBRARY)
+    link_libraries(${GLIB_LIBRARY})
+  endif()
+
+  # pthreads-win32 (path supplied via PTHREADINC / PTHREADLIB in ConfigUser.cmake).
+  # Wire include path + global link library so every target that uses pthread_*
+  # resolves it without per-target plumbing.
+  if(PTHREADINC)
+    include_directories(${PTHREADINC})
+    # PTW32_STATIC_LIB only when linking the static variant (pthreadVC2.lib here
+    # is the DLL import lib, so leave it dynamic).
+    add_compile_definitions(HAVE_STRUCT_TIMESPEC)
+  endif()
+  if(PTHREADLIB)
+    link_libraries(${PTHREADLIB})
+  endif()
+
+  # Winsock — htonl/ntohl and friends live in Ws2_32.lib on Windows.
+  link_libraries(Ws2_32)
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/src/bsio/mbbs_tm.c
+++ b/src/bsio/mbbs_tm.c
@@ -46,6 +46,11 @@
 #include "mbbs.h"
 #include "mbbs_defines.h"
 
+/* POSIX strtok_r — MSVC has strtok_s with the same signature. */
+#ifdef _WIN32
+#define strtok_r(str, delim, saveptr) strtok_s((str), (delim), (saveptr))
+#endif
+
 static int tm_monthdays[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31, 31};
 static int tm_callertz = TM_TZ_UNKNOWN;
 

--- a/src/gsf/CMakeLists.txt
+++ b/src/gsf/CMakeLists.txt
@@ -42,7 +42,7 @@ if(WIN32)
 endif()
 
 add_executable(dump_gsf dump_gsf.c gsf.h)
-target_link_libraries(dump_gsf PRIVATE mbgsf m)
+target_link_libraries(dump_gsf PRIVATE mbgsf ${MB_SYSLIBS})
 
 install(TARGETS mbgsf DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(TARGETS dump_gsf DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/gsf/dump_gsf.c
+++ b/src/gsf/dump_gsf.c
@@ -33,6 +33,9 @@
 #include "gsf.h"
 
 /* global external data required by this module */
+#if defined(_WIN32) && !defined(mbgsf_EXPORTS)
+__declspec(dllimport)
+#endif
 extern int gsfError;
 
 /* static global data for this module */

--- a/src/gsf/gsf.c
+++ b/src/gsf/gsf.c
@@ -209,6 +209,11 @@ static int      numOpenFiles;
 static GSF_FILE_TABLE gsfFileTable[GSF_MAX_OPEN_FILES];
 
 /* Global external data defined in this module */
+/* CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS only auto-exports functions, not data;
+   this variable needs an explicit dllexport to cross the mbgsf.dll boundary. */
+#if defined(_WIN32) && defined(mbgsf_EXPORTS)
+__declspec(dllexport)
+#endif
 int             gsfError;       /* used to report most recent error */
 
 /* Static functions used, but not exported from this source file */

--- a/src/gsf/gsf_enc.c
+++ b/src/gsf/gsf_enc.c
@@ -1,1 +1,10099 @@
-/******************************************************************** * * Module Name : GSF_ENC.C * * Author/Date : J. S. Byrne / 3 May 1994 * * Description : *  This source file contains the GSF functions for encoding a GSF byte *   stream from host data structures. * * Restrictions/Limitations : * 1) This library assumes the host computer uses the ASCII character set. * 2) This library assumes that the data types u_short and u_int are defined *    on the host machine, where a u_short is a 16 bit unsigned integer, and *    a u_int is a 32 bit unsigned integer. * 3) This library assumes that the type short is 16 bits, and that *    the type int is 32 bits. * * * Change Descriptions : * who          when      what * ---          ----      ---- * jsb          10-17-94  Added support for Reson SeaBat data * jsb          03-10-95  Modified ping record to store dynamic depth *                        corrector and tide corrector. * jsb          11-13-95  Added Unique id for EM1000 * jsb          12-22-95  Added nearest scaled integer rounding on latitude *                        longitude, roll, pitch, and heave. * hem          08-20-96  Added gsfEncodeSinglebeam; added EncodeSASSSpecific, *                        EncodeTypeIIISeaBeamSpecific, EncodeSeaMapSpecific, *                        EncodeEchotracSpecific, EncodeMGD77Specific, *                        EncodeBDBSpecific, & EncodeNOSHDBSpecific; changed *                        gsfEncodeComment so that it uses the length of the *                        comment specified in the record rather than using *                        strlen to find the length of the comment (to allow *                        nulls in the comment); * jsb          09-27-96  Added support for SeaBeam with amplitude data * jsb          03-24-97  Added support for gsfSeaBatIISpecific as a replacement *                        of gsfSeaBatSpecific for the Reson 900x series sonars. *                        Added gsfSeaBat8101Specific for the Reson 8101 series *                        sonar. * hem          07-23-97  Added code to gsfEncodeSwathBathySummary, *                        gsfEncodeSinglebeam, and *                        gsfEncodeSoundVelocityProfile to handle rounding *                        latitudes, longitudes, depths, etc. properly before *                        storage in the GSF file. * bac          10-27-97  Added EncodeSeaBeam2112Specific to support the Sea *                        Beam 2112/36 sonar. * dwc          1-9-98    Added EncodeElacMkIISpecific to support the Elac *                        Bottomchart MkII sonar. * jsb          09/28/98  Added gsfEncodeHVNavigationError. This change made *                        in response to CRs: GSF-98-001, and GSF-98-002. Also *                        added support for horizontal error ping array subrecord *                        in responce to CR: GSF-98-003. Removed the computation of *                        error_sum from gsfEncodeSwathBathymetryPing, now the library *                        will write horizontal and vertical depth estimates for each *                        ping if the array pointers are non-null. * jsb          12/29/98  Added support for Simrad em3000 series sonar systems. * wkm          3-30-99   Added EncodeCmpSassSpecific to deal with CMP SASS data. * wkm          8-02-99   Updated EncodeCmpSassSpecific to include lntens (heave) with CMP SASS data. * bac          10-24-00  Updated EncodeEM3Specific to include data fields from updated *                        EM series runtime parameter datagram. * bac          07-18-01  Added support for the Reson 8100 series of sonars.  Also removed the usage *                        of C++ reserved words "class" and "operator". * bac          10-12-01  Added a new attitude record definition.  The attitude record provides *                        a method for logging full time-series attitude measurements in the GSF *                        file, instead of attitude samples only at ping time.  Each attitude *                        record contains arrays of attitude measurements for time, roll, pitch, *                        heave and heading.  The number of measurements is user-definable, but *                        because of the way in which measurement times are stored, a single *                        attitude record should never contain more than sixty seconds worth of *                        data. * jsb          01-19-02  Added support for Simrad EM120, and removed references to unused variables. * bac          06-19-03  Added support for bathymetric receive beam time series intensity data (i.e., Simrad *                        "Seabed image" and Reson "snippets").  Included RWL updates of 12-19-02 for adding *                        sensor-specific singlebeam information to the MB sensor specific subrecords. * bac          12-28-04  Added support for Navisound singlebeam, EM3000D, EM3002, and EM3002D.  Fixed *                        encoding of 1-byte BRB intensity values.  Corrected the encode/decode of Reson *                        projector angle.  Added beam_spacing to the gsfReson8100Specific subrecord. * bac          06-28-06  Added support for EM121A data received via Kongsberg SIS, mapped to existing *                        EM3 series sensor specific data structure. Replaced references to long types *                        with int types, for compilation on 64-bit architectures. * dhg          10-24-06  Added support for GeoSwathPlus interferometric sonar * dhg          10-31-06  Added support for GeoSwathPlus "range_error" and "angle_error" * dhg          11-01-06  Corrected "model_number" and "frequency" for "GeoSwathPlusSpecific" record * mab          02-01-09  Updates to support Reson 7125. Added new subrecord IDs and subrecord definitions for Kongsberg *                        sonar systems where TWTT and angle are populated from raw range and beam angle datagram. Added *                        new subrecord definition for EM2000.  Bug fixes in gsfOpen and gsfPercent. * clb          02-25-11  Changed the EncodeBRBIntensity() function when bits_per_sample is 12 * clb          04-06-11  Changes made for DeltaT * clb          04-13-11  When encoding a ping, reject it if the number of beams <= 0 * clb          06-21-11  Added em12 to list of available sensors * clb          09-20-11  Added support for R2Sonic * jcd          02-17-12  fixed EncodeQualityFlagsArray to work with num_beams not evenly divisible by 4 * * Classification : Unclassified * * References : DoDBL Generic Sensor Format Sept. 30, 1993 * * Copyright 2019 Leidos, Inc. * There is no charge to use the library, and it may be accessed at: * https://www.leidos.com/products/ocean-marine#gsf * This library may be redistributed and/or modified under the terms of * the GNU Lesser General Public License version 2.1, as published by the * Free Software Foundation.  A copy of the LGPL 2.1 license is included with * the GSF distribution and is avaialbe at: http://opensource.org/licenses/LGPL-2.1. * * Leidos, Inc. configuration manages GSF, and provides GSF releases. Users are * strongly encouraged to communicate change requests and change proposals to Leidos, Inc. * * This library is distributed in the hope that it will be useful, but * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY * or FITNESS FOR A PARTICULAR PURPOSE. * ********************************************************************//* Standard C Library Includes */#include <string.h>#include <stdlib.h>/* Get network byte swap functions */#include <sys/types.h>#if !defined WIN32  && !defined WIN64#include <netinet/in.h>#else#include <winsock.h>#endif/* GSF library interface description */#include "gsf.h"#include "gsf_enc.h"/* Global external data defined in this module */extern int      gsfError;  /* Defined in gsf.c */int EncodeCompressedUnsignedShortArray (unsigned char *sptr, const unsigned short *array, int num_beams, int subrecordID);int EncodeCompressedArray (unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int subrecordID);/* Function prototypes for this file */static int      EncodeScaleFactors(unsigned char *sptr, const gsfScaleFactors *sf);static int      EncodeTwoByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);static int      EncodeSignedTwoByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);static int      EncodeByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);static int      EncodeFourByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);static int      EncodeSignedFourByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);static int      EncodeSignedByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);static int      EncodeBeamFlagsArray(unsigned char *sptr, const unsigned char *array, int num_beams);static int      EncodeQualityFlagsArray(unsigned char *sptr, const unsigned char *array, int num_beams);static int      EncodeFromUnsignedShortToByteArray(unsigned char *sptr, const unsigned short *array, int num_beams, const gsfScaleFactors *sf, int id);static int      EncodeBRBIntensity(unsigned char *sptr, const gsfBRBIntensity *idata, int num_beams, int sensor_id, int bytes_used);static int      EncodeSeabeamSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeEM12Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeEM100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeEM950Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeEM1000Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeEM121ASpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeEM121Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeEM3ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);static int      EncodeEM4ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);static int      EncodeKMALLImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);static int      EncodeReson7100ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);static int      EncodeResonTSeriesImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);static int      EncodeR2SonicImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);static int      EncodeCmpSassSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeSeaMapSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata, const GSF_FILE_TABLE *ft);static int      EncodeSeaBatSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeEchotracSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata);static int      EncodeMGD77Specific(unsigned char *sptr, const gsfSBSensorSpecific *sdata);static int      EncodeBDBSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata);static int      EncodeNOSHDBSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata);static int      EncodeSBAmpSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeSeaBatIISpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeSeaBat8101Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeSeaBeam2112Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeElacMkIISpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeEM3Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeEM3RawSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeReson7100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeReson8100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeResonTSeriesSpecific(unsigned char *sptr, gsfSensorSpecific *sdata);static int      EncodeSBEchotracSpecific(unsigned char *sptr, const t_gsfSBEchotracSpecific *sdata);static int      EncodeSBMGD77Specific(unsigned char *sptr, const t_gsfSBMGD77Specific *sdata);static int      EncodeSBBDBSpecific(unsigned char *sptr, const t_gsfSBBDBSpecific *sdata);static int      EncodeSBNOSHDBSpecific(unsigned char *sptr, const t_gsfSBNOSHDBSpecific *sdata);static int      EncodeSBNavisoundSpecific(unsigned char *sptr, const t_gsfSBNavisoundSpecific *sdata);static int      EncodeEM4Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeKMALLSpecific(unsigned char *sptr, const gsfSensorSpecific * sdata);static int      EncodeGeoSwathPlusSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeKlein5410BssSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeDeltaTSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeR2SonicSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeKlein5410BssImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);#if 1/* 3-30-99 wkm: obsolete */static int      EncodeTypeIIISeaBeamSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);static int      EncodeSASSSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);#endif/******************************************************************** * * Function Name : gsfEncodeHeader * * Description : This function encodes a GSF header into external byte *   stream form from the passed gsfHeader structure. * * Inputs : *    sptr = a pointer to the unsigned char buffer to write into. *    header = a pointer to the gsfHeader structure to read from. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/intgsfEncodeHeader(unsigned char *sptr, gsfHeader * header){    unsigned char  *p = sptr;    memset(header->version, 0, GSF_VERSION_SIZE);    strncpy(header->version, GSF_VERSION, (GSF_VERSION_SIZE-1));    header->version[GSF_VERSION_SIZE-1] = 0;    memcpy(p, header->version, GSF_VERSION_SIZE);    p += GSF_VERSION_SIZE;    return (p - sptr);}/******************************************************************** * * Function Name : gsfEncodeSwathBathySummary * * Description : This function encodes a GSF swath bathymetry summary record *   into external byte stream form from the passed gsfHeader structure. * * Inputs : *   sptr = a pointer to the unsigned char buffer to write into. *   sum = a pointer to the gsfSwathBathySummary structure to read from. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/intgsfEncodeSwathBathySummary(unsigned char *sptr, gsfSwathBathySummary *sum){    unsigned char  *p = sptr;    double          dtemp;    gsfuLong        ltemp;    /* First 8 bytes contain the time of the first ping in the file */    ltemp = htonl(sum->start_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    ltemp = htonl(sum->start_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next 8 bytes contain the time of the last ping in the file */    ltemp = htonl(sum->end_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    ltemp = htonl(sum->end_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the minimum latitude. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = sum->min_latitude * 1.0e7;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the minimum longitude. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = sum->min_longitude * 1.0e7;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the maximum latitude. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = sum->max_latitude * 1.0e7;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the maximum longitude. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = sum->max_longitude * 1.0e7;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the minimum depth. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = sum->min_depth * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the maximum depth. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = sum->max_depth * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeEchotracSpecific * * Description : This function encodes the Bathy 2000 and echotrac *  sensor specific data from the HSPS source files. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEchotracSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    /* First two byte integer contains the navigation error */    stemp = htons((gsfuShort) (sdata->gsfEchotracSpecific.navigation_error));    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the most probable position source navigation */    *p = (unsigned char) sdata->gsfEchotracSpecific.mpp_source;    p += 1;    /* Next byte contains the tide source */    *p = (unsigned char) sdata->gsfEchotracSpecific.tide_source;    p += 1;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeMGD77Specific * * Description : This function encodes the MGD77 fields * into an MGD77 record. The MGD77 Singlebeam is essentially * survey trackline data, and actual survey data can be retrieved * from the source. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeMGD77Specific(unsigned char *sptr, const gsfSBSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuLong        ltemp;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the time zone correction */    stemp = htons((gsfuShort) (sdata->gsfMGD77Specific.time_zone_corr));    memcpy(p, &stemp, 2);    p += 2;    /* The Next two byte integer contains how the navigation was obtained */    stemp = htons((gsfuShort) (sdata->gsfMGD77Specific.position_type_code));    memcpy(p, &stemp, 2);    p += 2;    /* The Next two byte integer contains on how the sound velocity       correction was made */    stemp = htons((gsfuShort) (sdata->gsfMGD77Specific.correction_code));    memcpy(p, &stemp, 2);    p += 2;    /* The Next two byte integer contains how the bathymetry was obtained */    stemp = htons((gsfuShort) (sdata->gsfMGD77Specific.bathy_type_code));    memcpy(p, &stemp, 2);    p += 2;    /* The Next two byte integer contains the quality code for Nav */    stemp = htons((gsfuShort) (sdata->gsfMGD77Specific.quality_code));    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the two way travel time */    dtemp = sdata->gsfMGD77Specific.travel_time * 10000;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeBDBSpecific * * Description : This function encodes the BDB fields * into a BDB record. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeBDBSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuLong        ltemp;    /* Next four byte integer contains the the document number */    ltemp = htonl((gsfuLong) (sdata->gsfBDBSpecific.doc_no));    memcpy(p, &ltemp, 4);    p += 4;    /* Next byte contains the evaluation flag */    *p = (unsigned char) sdata->gsfBDBSpecific.eval;    p += 1;    /* Next byte contains the classification flag */    *p = (unsigned char) sdata->gsfBDBSpecific.classification;    p += 1;    /* Next byte contains the track adjustment flag */    *p = (unsigned char) sdata->gsfBDBSpecific.track_adj_flag;    p += 1;    /* Next byte contains the source flag */    *p = (unsigned char) sdata->gsfBDBSpecific.source_flag;    p += 1;    /* Next byte contains the discrete point or track line flag */    *p = (unsigned char) sdata->gsfBDBSpecific.pt_or_track_ln;    p += 1;    /* Next byte contains the datum flag */    *p = (unsigned char) sdata->gsfBDBSpecific.datum_flag;    p += 1;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeNOSHDBSpecific * * Description : This function encodes the NOSHDB fields into a *               NOSHDB record. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeNOSHDBSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    /* First two byte integer contains the depth type code */    stemp = htons((gsfuShort) (sdata->gsfNOSHDBSpecific.type_code));    memcpy(p, &stemp, 2);    p += 2;    /* The Next two byte integer contains the cartographic code */    stemp = htons((gsfuShort) (sdata->gsfNOSHDBSpecific.carto_code));    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}/******************************************************************** * * Function Name : gsfEncodeSinglebeam * * Description : This function encodes a GSF single beam ping record *   in external byte stream form from a gsfSwathBathyPing structure. * * Inputs : *   sptr = a pointer to the unsigned char buffer to write into *   ping = a pointer to the gsfSwathBathPing record to read from * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *    GSF_UNRECOGNIZED_SENSOR_ID * ********************************************************************/intgsfEncodeSinglebeam(unsigned char *sptr, gsfSingleBeamPing * ping){    gsfuLong        ltemp;    gsfuShort       stemp;    int             sensor_size = 0;    double          dtemp;    unsigned char  *p = sptr;    unsigned char  *temp_ptr;    /* First 8 bytes contain the time */    ltemp = htonl(ping->ping_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    ltemp = htonl(ping->ping_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the longitude. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = ping->longitude * 1.0e7;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the latitude. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = ping->latitude * 1.0e7;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the tide corrector for this ping.     * Round this to the nearest whole centimeter.     */    dtemp = ping->tide_corrector * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the depth corrector.     * Round this to the nearest whole centimeter.     */    dtemp = ping->depth_corrector * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the ship heading, round this value to the     * nearest one hundredth of a degree.     */    stemp = htons((gsfuShort) ((ping->heading * 100.0) + 0.501));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the pitch. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = ping->pitch * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the roll. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = ping->roll * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the heave. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = ping->heave * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the depth. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = ping->depth * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the sound speed correction.     * Round the scaled quantity to the nearest whole integer.     */    dtemp = ping->sound_speed_correction * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the positioning system type */    stemp = htons((gsfuShort) (ping->positioning_system_type));    memcpy(p, &stemp, 2);    p += 2;    /* Next possible subrecord is the sensor specific subrecord. Save the    *  current pointer, and leave room for the four byte subrecord identifier.    */    temp_ptr = p;    p += 4;    switch (ping->sensor_id)    {        case (GSF_SINGLE_BEAM_SUBRECORD_ECHOTRAC_SPECIFIC):            sensor_size = EncodeEchotracSpecific(p, &ping->sensor_data);            break;        case (GSF_SINGLE_BEAM_SUBRECORD_BATHY2000_SPECIFIC):            sensor_size = EncodeEchotracSpecific(p, &ping->sensor_data);            break;        case (GSF_SINGLE_BEAM_SUBRECORD_MGD77_SPECIFIC):            sensor_size = EncodeMGD77Specific(p, &ping->sensor_data);            break;        case (GSF_SINGLE_BEAM_SUBRECORD_BDB_SPECIFIC):            sensor_size = EncodeBDBSpecific(p, &ping->sensor_data);            break;        case (GSF_SINGLE_BEAM_SUBRECORD_NOSHDB_SPECIFIC):            sensor_size = EncodeNOSHDBSpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_UNKNOWN):            sensor_size = 0;            break;          default:            gsfError = GSF_UNRECOGNIZED_SENSOR_ID;            return (-1);    }    /*  Identifier has sensor specific id in first byte, and size in the    *  remaining three bytes    */    ltemp = ping->sensor_id << 24;    ltemp |= (gsfuLong) sensor_size;    ltemp = htonl(ltemp);    memcpy(temp_ptr, &ltemp, 4);    p += sensor_size;    /* Return the number of bytes written into the buffer. */    return (p - sptr);}/******************************************************************** * * Function Name : gsfEncodeSwathBathymetryPing * * Description : This function encodes a GSF swath bathymetry ping record *   in external byte stream form from a gsfSwathBathyPing structure. * * Inputs : *    sptr = a pointer to the unsigned char buffer to write into *    ping = a pointer to the gsfSwathBathPing record to read from *    ft = a pointer to the gsfFileTable, where the scale factors are *         maintained. * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *   GSF_UNRECOGNIZED_SENSOR_ID *   GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER *   GSF_INVALID_NUM_BEAMS *   GSF_MB_PING_RECORD_ENCODE_FAILED *   GSF_RECORD_SIZE_ERROR * ********************************************************************/intgsfEncodeSwathBathymetryPing(unsigned char *sptr, gsfSwathBathyPing *ping, GSF_FILE_TABLE *ft){    gsfuLong        ltemp;    gsfuShort       stemp;    int             sensor_size = 0;    int             ret;    double          dtemp;    unsigned char  *p = sptr;    unsigned char  *temp_ptr;    /* First 8 bytes contain the time */    ltemp = htonl(ping->ping_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    ltemp = htonl(ping->ping_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the longitude. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = ping->longitude * 1.0e7;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the latitude. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = ping->latitude * 1.0e7;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the number of beams */    if (ping->number_beams <= 0)    {        gsfError = GSF_INVALID_NUM_BEAMS;        return(-1);    }    stemp = htons(ping->number_beams);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the center beam number, portmost    *  outer beam is beam number 1.    */    stemp = htons(ping->center_beam);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the ping flags field */    stemp = htons(ping->ping_flags);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer is a reserved field */    stemp = htons(ping->reserved);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the tide corrector for this ping.     * Round this to the nearest whole centimeter.     */    dtemp = ping->tide_corrector * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the depth corrector.     * Round this to the nearest whole centimeter.     */    dtemp = ping->depth_corrector * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the ship heading, round this value to the     * nearest one hundredth of a degree. (Heading is always a positive value)     */    stemp = htons((gsfuShort) ((ping->heading * 100.0) + 0.501));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the pitch. Round the scaled quantity     * to the nearest whole integer.     */    dtemp = ping->pitch * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the roll. Round the scaled quantity     * to the nearest whole integer.     */    dtemp = ping->roll * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the heave. Round the scaled quantity     * to the nearest whole integer.     */    dtemp = ping->heave * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the course, round this value to the     * nearest one hundredth of a degree. (Course is always a positive value)     */    stemp = htons((gsfuShort) ((ping->course * 100.0) + 0.501));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the speed. Round the scaled quantity     * to the nearest integer. (Speed is always a positive quantity)     */    stemp = htons((gsfuShort) ((ping->speed * 100.0) + 0.501));    memcpy(p, &stemp, 2);    p += 2;    if (ft->major_version_number > 2)    {        /* Next four byte integer contains the height. Round the scaled quantity         * to the nearest whole integer.         */        dtemp = ping->height * 1000.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfsLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* Next four byte integer contains the SEP. Round the scaled quantity         * to the nearest whole integer.         */        dtemp = ping->sep * 1000.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfsLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* Next four byte integer contains the GPS tide corrector for this ping.         * Round this to the nearest whole millimeter.         */        dtemp = ping->gps_tide_corrector * 1000.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfsLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* Next two bytes are spare space */        memset (p, 0, (size_t) 2);        p += 2;    }    /* The first possible subrecord is the scale factors.  The scale factor     * record is encoded for writing to the file once at the beginning of the     * file, and again whenever the scale factors change.     */    if ((memcmp(&ft->rec.mb_ping.scaleFactors, &ping->scaleFactors, sizeof(gsfScaleFactors))) ||        (ft->scales_read))    {        memcpy(&ft->rec.mb_ping.scaleFactors, &ping->scaleFactors, sizeof(gsfScaleFactors));        ret = EncodeScaleFactors(p, &ping->scaleFactors);        if (ret <= 0)        {            return(-1);        }        p += ret;        /* scales_read is set in gsfOpen if the file is opened create to ensure that scale factors         * are written with the first ping of each file. Clear scales_read here.         */        ft->scales_read = 0;    }    /* Next possible subrecord is the depth array.  For this array to be     * encoded there must be data, and a scale factor.     */    if (ping->depth != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY);        }        else        {            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY - 1].compressionFlag & 0xF0)            {                default:                case GSF_FIELD_SIZE_DEFAULT:                case GSF_FIELD_SIZE_TWO:                    ret = EncodeTwoByteArray(p, ping->depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY);                    break;                case GSF_FIELD_SIZE_FOUR:                    ret = EncodeFourByteArray(p, ping->depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY);                    break;            }        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the nominal depth array.  For this array     * to be encoded there must be data, and a scale factor.     */    if (ping->nominal_depth != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->nominal_depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY);        }        else        {            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY - 1].compressionFlag & 0xF0)            {                default:                case GSF_FIELD_SIZE_DEFAULT:                case GSF_FIELD_SIZE_TWO:                    ret = EncodeTwoByteArray(p, ping->nominal_depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY);                    break;                case GSF_FIELD_SIZE_FOUR:                    ret = EncodeFourByteArray(p, ping->nominal_depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY);                    break;            }        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the across track distance array.  For this    * array to be encoded there must be data, and a scale factor.    */    if (ping->across_track != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->across_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY);        }        else        {            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY - 1].compressionFlag & 0xF0)            {                default:                case GSF_FIELD_SIZE_DEFAULT:                case GSF_FIELD_SIZE_TWO:                    ret = EncodeSignedTwoByteArray(p, ping->across_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY);                    break;                case GSF_FIELD_SIZE_FOUR:                    ret = EncodeSignedFourByteArray(p, ping->across_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY);                    break;            }        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the along track distance array.  For this    * array to be encoded there must be data, and a scale factor.    */    if (ping->along_track != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->along_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY);        }        else        {            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY - 1].compressionFlag & 0xF0)            {                default:                case GSF_FIELD_SIZE_DEFAULT:                case GSF_FIELD_SIZE_TWO:                    ret = EncodeSignedTwoByteArray(p, ping->along_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY);                    break;                case GSF_FIELD_SIZE_FOUR:                    ret = EncodeSignedFourByteArray(p, ping->along_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY);                    break;            }        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the travel time array.  For this    * array to be encoded there must be data, and a scale factor.    */    if (ping->travel_time != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->travel_time, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY);        }        else        {            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY - 1].compressionFlag & 0xF0)            {                default:                case GSF_FIELD_SIZE_DEFAULT:                case GSF_FIELD_SIZE_TWO:                    ret = EncodeTwoByteArray(p, ping->travel_time, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY);                    break;                case GSF_FIELD_SIZE_FOUR:                    ret = EncodeFourByteArray(p, ping->travel_time, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY);                    break;            }        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the beam angle array. For this    * array to be encoded there must be data, and a scale factor.    */    if (ping->beam_angle != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->beam_angle, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_ARRAY);        }        else        {            ret = EncodeSignedTwoByteArray(p, ping->beam_angle, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the mean, calibrated amplitude array. For    * this array to be encoded there must be data, and a scale factor.    */    if (ping->mc_amplitude != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->mc_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY);        }        else        {            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY - 1].compressionFlag & 0xF0)            {                default:                case GSF_FIELD_SIZE_DEFAULT:                case GSF_FIELD_SIZE_ONE:                    ret = EncodeSignedByteArray(p, ping->mc_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY);                    break;                case GSF_FIELD_SIZE_TWO:                    ret = EncodeSignedTwoByteArray(p, ping->mc_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY);                    break;            }        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the mean, relative amplitude array.  For    * this array to be encoded there must be data, and a scale factor.    */    if (ping->mr_amplitude != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->mr_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY);        }        else        {            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY - 1].compressionFlag & 0xF0)            {                default:                case GSF_FIELD_SIZE_DEFAULT:                case GSF_FIELD_SIZE_ONE:                    ret = EncodeByteArray(p, ping->mr_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY);                    break;                case GSF_FIELD_SIZE_TWO:                    ret = EncodeTwoByteArray(p, ping->mr_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY);                    break;            }        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the echo width array. For this    * array to be encoded there must be data, and a scale factor.    */    if (ping->echo_width != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->echo_width, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY);        }        else        {            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY - 1].compressionFlag & 0xF0)            {                default:                case GSF_FIELD_SIZE_DEFAULT:                case GSF_FIELD_SIZE_ONE:                    ret = EncodeByteArray(p, ping->echo_width, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY);                    break;                case GSF_FIELD_SIZE_TWO:                    ret = EncodeTwoByteArray(p, ping->echo_width, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY);                    break;            }        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the quality factor array.  For this    * array to be encoded there must be data, and a scale factor.    */    if (ping->quality_factor != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_QUALITY_FACTOR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->quality_factor, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_QUALITY_FACTOR_ARRAY);        }        else        {            ret = EncodeByteArray(p, ping->quality_factor, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_QUALITY_FACTOR_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of ship heave at beam reception    * time. For this array to be encoded there must be data, and a scale factor.    */    if (ping->receive_heave != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_RECEIVE_HEAVE_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->receive_heave, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_RECEIVE_HEAVE_ARRAY);        }        else        {        ret = EncodeSignedByteArray(p, ping->receive_heave, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_RECEIVE_HEAVE_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of estimated depth errors.    * For this array to be encoded there must be data, and a scale factor.    * jsb 10/19/98 This subrecord is obsolete, it is replaced with vertical_error.    */    if (ping->depth_error != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DEPTH_ERROR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->depth_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DEPTH_ERROR_ARRAY);        }        else        {            ret = EncodeTwoByteArray(p, ping->depth_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DEPTH_ERROR_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of estimated across track errors.    * For this array to be encoded there must be data, and a scale factor.    * jsb 10/19/98 This subrecord is obsolete, it is replaced with horizontal_error.    */    if (ping->across_track_error != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ERROR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->across_track_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ERROR_ARRAY);        }        else        {            ret = EncodeTwoByteArray(p, ping->across_track_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ERROR_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of estimated along track errors.    * For this array to be encoded there must be data, and a scale factor.    * jsb 10/19/98 This subrecord is obsolete, it is replaced with horizontal_error.    */    if (ping->along_track_error != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ERROR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->along_track_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ERROR_ARRAY);        }        else        {            ret = EncodeTwoByteArray(p, ping->along_track_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ERROR_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of beam status flags */    if (ping->beam_flags != (unsigned char *) NULL)    {        ret = EncodeBeamFlagsArray(p, ping->beam_flags, ping->number_beams);        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the beam quality flags provided by the     * Reson SeaBat system.  There are two bits per beam.     */    if (ping->quality_flags != (unsigned char *) NULL)    {        ret = EncodeQualityFlagsArray(p, ping->quality_flags, ping->number_beams);        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of signal to noise ratios.    * For this array to be encoded there must be new data, and a scale factor.    */    if (ping->signal_to_noise != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_SIGNAL_TO_NOISE_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->signal_to_noise, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SIGNAL_TO_NOISE_ARRAY);        }        else        {            ret = EncodeByteArray(p, ping->signal_to_noise, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SIGNAL_TO_NOISE_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the beam angle forward array. For this    * array to be encoded there must be data, and a scale factor.    */    if (ping->beam_angle_forward != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_FORWARD_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->beam_angle_forward, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_FORWARD_ARRAY);        }        else        {            ret = EncodeTwoByteArray(p, ping->beam_angle_forward, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_FORWARD_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of estimated vertical errors.    * For this array to be encoded there must be data, and a scale factor.    */    if (ping->vertical_error != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_VERTICAL_ERROR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->vertical_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_VERTICAL_ERROR_ARRAY);        }        else        {            ret = EncodeTwoByteArray(p, ping->vertical_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_VERTICAL_ERROR_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of estimated horizontal errors.    * For this array to be encoded there must be data, and a scale factor.    */    if (ping->horizontal_error != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_HORIZONTAL_ERROR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->horizontal_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_HORIZONTAL_ERROR_ARRAY);        }        else        {            ret = EncodeTwoByteArray(p, ping->horizontal_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_HORIZONTAL_ERROR_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of transmit sector numbers. */    if (ping->sector_number != (unsigned short *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_SECTOR_NUMBER_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedUnsignedShortArray (p, ping->sector_number, ping->number_beams, GSF_SWATH_BATHY_SUBRECORD_SECTOR_NUMBER_ARRAY);        }        else        {            /* By default this array is coded as a one byte value */            ret = EncodeFromUnsignedShortToByteArray(p, ping->sector_number, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SECTOR_NUMBER_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of beam detection information values. */    if (ping->detection_info != (unsigned short *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DETECTION_INFO_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedUnsignedShortArray (p, ping->detection_info, ping->number_beams, GSF_SWATH_BATHY_SUBRECORD_DETECTION_INFO_ARRAY);        }        else        {            /* By default this array is coded as a one byte value */            ret = EncodeFromUnsignedShortToByteArray(p, ping->detection_info, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DETECTION_INFO_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of beam detection information values. */    if (ping->incident_beam_adj != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_INCIDENT_BEAM_ADJ_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->incident_beam_adj, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_INCIDENT_BEAM_ADJ_ARRAY);        }        else        {            ret = EncodeSignedByteArray(p, ping->incident_beam_adj, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_INCIDENT_BEAM_ADJ_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the array of data cleaning information received from the system. */    if (ping->system_cleaning != (unsigned short *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_SYSTEM_CLEANING_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedUnsignedShortArray (p, ping->system_cleaning, ping->number_beams, GSF_SWATH_BATHY_SUBRECORD_SYSTEM_CLEANING_ARRAY);        }        else        {            /* By default this array is coded as a one byte value */            ret = EncodeFromUnsignedShortToByteArray(p, ping->system_cleaning, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SYSTEM_CLEANING_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* The next possible subrecord is the array of correction values used to correct the travel time array for Doppler for FM signals */    if (ping->doppler_corr != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DOPPLER_CORRECTION_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->doppler_corr, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DOPPLER_CORRECTION_ARRAY);        }        else        {            ret = EncodeSignedByteArray(p, ping->doppler_corr, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DOPPLER_CORRECTION_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* The next possible subrecord is the array of vertical uncertainties provided by the sonar */    if (ping->sonar_vert_uncert != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_SONAR_VERT_UNCERT_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->sonar_vert_uncert, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SONAR_VERT_UNCERT_ARRAY);        }        else        {            ret = EncodeTwoByteArray(p, ping->sonar_vert_uncert, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SONAR_VERT_UNCERT_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* The next possible subrecord is the array of vertical uncertainties provided by the sonar */    if (ping->sonar_horz_uncert != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_SONAR_HORZ_UNCERT_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->sonar_horz_uncert, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SONAR_HORZ_UNCERT_ARRAY);        }        else        {            ret = EncodeTwoByteArray(p, ping->sonar_horz_uncert, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SONAR_HORZ_UNCERT_ARRAY);        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the detction window length array. For this    * array to be encoded there must be data, and a scale factor.    */    if (ping->detection_window != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->detection_window, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY);        }        else        {            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY - 1].compressionFlag & 0xF0)            {                case GSF_FIELD_SIZE_ONE:                    ret = EncodeByteArray(p, ping->detection_window, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY);                    break;                default:                case GSF_FIELD_SIZE_DEFAULT:                case GSF_FIELD_SIZE_TWO:                    ret = EncodeTwoByteArray(p, ping->detection_window, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY);                    break;                case GSF_FIELD_SIZE_FOUR:                    ret = EncodeFourByteArray(p, ping->detection_window, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY);                    break;            }        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the mean absolute coefficient array. For this    * array to be encoded there must be data, and a scale factor.    */    if (ping->mean_abs_coeff != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->mean_abs_coeff, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY);        }        else        {            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY - 1].compressionFlag & 0xF0)            {                case GSF_FIELD_SIZE_ONE:                    ret = EncodeByteArray(p, ping->mean_abs_coeff, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY);                    break;                default:                case GSF_FIELD_SIZE_DEFAULT:                case GSF_FIELD_SIZE_TWO:                    ret = EncodeTwoByteArray(p, ping->mean_abs_coeff, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY);                    break;                case GSF_FIELD_SIZE_FOUR:                    ret = EncodeFourByteArray(p, ping->mean_abs_coeff, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY);                    break;            }        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }        if (ping->TVG_dB != (double *) NULL)    {        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)        {            ret = EncodeCompressedArray (p, ping->TVG_dB, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY);        }        else        {            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY - 1].compressionFlag & 0xF0)            {                case GSF_FIELD_SIZE_ONE:                    ret = EncodeByteArray(p, ping->TVG_dB, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY);                    break;                default:                case GSF_FIELD_SIZE_DEFAULT:                case GSF_FIELD_SIZE_TWO:                    ret = EncodeTwoByteArray(p, ping->TVG_dB, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY);                    break;                case GSF_FIELD_SIZE_FOUR:                    ret = EncodeFourByteArray(p, ping->TVG_dB, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY);                    break;            }        }        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Next possible subrecord is the sensor specific subrecord. Save the    *  current pointer, and leave room for the four byte subrecord identifier.    */    temp_ptr = p;    p += 4;    switch (ping->sensor_id)    {        case (GSF_SWATH_BATHY_SUBRECORD_UNKNOWN):            sensor_size = 0;            break;        case (GSF_SWATH_BATHY_SUBRECORD_SEABEAM_SPECIFIC):            sensor_size = EncodeSeabeamSpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_EM100_SPECIFIC):            sensor_size = EncodeEM100Specific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_EM12_SPECIFIC):            sensor_size = EncodeEM12Specific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_EM950_SPECIFIC):            sensor_size = EncodeEM950Specific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_EM121A_SPECIFIC):            sensor_size = EncodeEM121ASpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_EM121_SPECIFIC):            sensor_size = EncodeEM121Specific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_SASS_SPECIFIC):            sensor_size = EncodeSASSSpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_SEAMAP_SPECIFIC):            sensor_size = EncodeSeaMapSpecific(p, &ping->sensor_data, ft);            break;        case (GSF_SWATH_BATHY_SUBRECORD_SEABAT_SPECIFIC):            sensor_size = EncodeSeaBatSpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_EM1000_SPECIFIC):            sensor_size = EncodeEM1000Specific(p, &ping->sensor_data);            break;            #if 1            /* 3-30-99 wkm: obsolete */        case (GSF_SWATH_BATHY_SUBRECORD_TYPEIII_SEABEAM_SPECIFIC):            sensor_size = EncodeTypeIIISeaBeamSpecific(p, &ping->sensor_data);            break;            #endif        case (GSF_SWATH_BATHY_SUBRECORD_SB_AMP_SPECIFIC):            sensor_size = EncodeSBAmpSpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_SEABAT_II_SPECIFIC):            sensor_size = EncodeSeaBatIISpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_SEABAT_8101_SPECIFIC):            sensor_size = EncodeSeaBat8101Specific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_SEABEAM_2112_SPECIFIC):            sensor_size = EncodeSeaBeam2112Specific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_ELAC_MKII_SPECIFIC):            sensor_size = EncodeElacMkIISpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_CMP_SASS_SPECIFIC):            sensor_size = EncodeCmpSassSpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_EM2000_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3000_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM1002_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM300_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM120_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3002_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3000D_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3002D_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM121A_SIS_SPECIFIC):            sensor_size = EncodeEM3Specific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_EM2000_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3000_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM1002_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM300_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM120_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3002_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3000D_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3002D_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM121A_SIS_RAW_SPECIFIC):            sensor_size = EncodeEM3RawSpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8101_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8111_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8124_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8125_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8150_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8160_SPECIFIC):            sensor_size = EncodeReson8100Specific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_RESON_7125_SPECIFIC):            sensor_size = EncodeReson7100Specific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_RESON_TSERIES_SPECIFIC):            sensor_size = EncodeResonTSeriesSpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SB_SUBRECORD_ECHOTRAC_SPECIFIC):            sensor_size = EncodeSBEchotracSpecific(p, &ping->sensor_data.gsfSBEchotracSpecific);            break;        case (GSF_SWATH_BATHY_SB_SUBRECORD_BATHY2000_SPECIFIC):            sensor_size = EncodeSBEchotracSpecific(p, &ping->sensor_data.gsfSBEchotracSpecific);            break;        case (GSF_SWATH_BATHY_SB_SUBRECORD_MGD77_SPECIFIC):            sensor_size = EncodeSBMGD77Specific(p, &ping->sensor_data.gsfSBMGD77Specific);            break;        case (GSF_SWATH_BATHY_SB_SUBRECORD_BDB_SPECIFIC):            sensor_size = EncodeSBBDBSpecific(p, &ping->sensor_data.gsfSBBDBSpecific);            break;        case (GSF_SWATH_BATHY_SB_SUBRECORD_NOSHDB_SPECIFIC):            sensor_size = EncodeSBNOSHDBSpecific(p, &ping->sensor_data.gsfSBNOSHDBSpecific);            break;        case (GSF_SWATH_BATHY_SB_SUBRECORD_PDD_SPECIFIC):            sensor_size = EncodeSBEchotracSpecific(p, &ping->sensor_data.gsfSBPDDSpecific);            break;        case (GSF_SWATH_BATHY_SB_SUBRECORD_NAVISOUND_SPECIFIC):            sensor_size = EncodeSBNavisoundSpecific(p, &ping->sensor_data.gsfSBNavisoundSpecific);            break;        case (GSF_SWATH_BATHY_SUBRECORD_EM710_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM302_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM122_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM2040_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_ME70BO_SPECIFIC):            sensor_size = EncodeEM4Specific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_KMALL_SPECIFIC):            sensor_size = EncodeKMALLSpecific(p,&ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_GEOSWATH_PLUS_SPECIFIC):            sensor_size = EncodeGeoSwathPlusSpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_KLEIN_5410_BSS_SPECIFIC):            sensor_size = EncodeKlein5410BssSpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_DELTA_T_SPECIFIC):            sensor_size = EncodeDeltaTSpecific(p, &ping->sensor_data);            break;        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2020_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2022_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2024_SPECIFIC):            sensor_size = EncodeR2SonicSpecific(p, &ping->sensor_data);            break;        default:            gsfError = GSF_UNRECOGNIZED_SENSOR_ID;            return (-1);    }   /*  Identifier has sensor specific id in first byte, and size in the    *  remaining three bytes    */    ltemp = ping->sensor_id << 24;    ltemp |= (gsfuLong) sensor_size;    ltemp = htonl(ltemp);    memcpy(temp_ptr, &ltemp, 4);    p += sensor_size;    /* Next possible subrecord is the array of intensity series */    if (ping->brb_inten != (gsfBRBIntensity *) NULL)    {        ret = EncodeBRBIntensity(p, ping->brb_inten, ping->number_beams, ping->sensor_id, p-sptr-12);  /* 12 = GSF_FILL_SIZE_CHECKSUM */        if (ret <= 0)        {            return (-1);        }        p += ret;    }    /* Return the number of byte written into the buffer */    return (p - sptr);}/******************************************************************** * * Function Name : EncodeScaleFactors * * Description : This function encodes the ping scale factor subrecord *  from internal form into external byte stream stream form. * * Inputs : *   sptr = a pointer to the unsigned char buffer to write into *   sf = a pointer to the GSF scale factors used to scale the data * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *   GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER * ********************************************************************/static intEncodeScaleFactors(unsigned char *sptr, const gsfScaleFactors *sf){    unsigned char  *p = sptr;    gsfuLong        ltemp, subID;    double          dtemp;    unsigned int    subrecordID;    int             sf_counter;    unsigned int    itemp;    /* First byte contains the subrecord identifier */    ltemp = GSF_SWATH_BATHY_SUBRECORD_SCALE_FACTORS << 24;    /* Next four bytes contain the size of the subrecord, need to    * compute this value:    *  4 byte number of scale factors    * 12 bytes per number of scale factors    */    ltemp |= 4 + (12 * sf->numArraySubrecords);    subID = htonl(ltemp);    memcpy(p, &subID, 4);    p += 4;    /* Next four byte integer contains the number of scale factors */    ltemp = htonl((gsfuShort) (sf->numArraySubrecords));    memcpy(p, &ltemp, 4);    p += 4;    /* Loop to encode each scale factor which has been defined.    * The loop counter i indexes through the known subrecord ids    */    sf_counter = 0;    for (subrecordID = 1; subrecordID <= GSF_MAX_PING_ARRAY_SUBRECORDS; subrecordID++)    {        itemp = (int) (sf->scaleTable[subrecordID - 1].multiplier + 0.001);        if ((itemp >= MIN_GSF_SF_MULT_VALUE) && (itemp <= MAX_GSF_SF_MULT_VALUE))        {            /* First four byte integer has the id in the first byte, the             *  compression flags in the second byte, and the two lower             *  order bytes are reserved             */            ltemp = ((gsfuLong) subrecordID) << 24;     /* ID = loop counter */            ltemp |= (((gsfuLong) (sf->scaleTable[subrecordID - 1].compressionFlag)) << 16);            ltemp = htonl(ltemp);            memcpy(p, &ltemp, 4);            p += 4;            /* encode the scale factor multiplier */            dtemp = sf->scaleTable[subrecordID - 1].multiplier;            ltemp = htonl((gsfsLong) dtemp);            memcpy(p, &ltemp, 4);            p += 4;            /* encode the scale factor offset */            ltemp = htonl((gsfsLong) (sf->scaleTable[subrecordID - 1].offset));            memcpy(p, &ltemp, 4);            p += 4;            sf_counter++;        }    }    /* Make sure that we encoded the expected number of array subrecords. If not return an error condition */    if (sf_counter != sf->numArraySubrecords)    {        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;        return (-1);    }    return (p - sptr);}/******************************************************************** * * Function Name : EncodeTwoByteArray * * Description : This function encodes a two byte beam array subrecord *  from internal form to external byte stream form. * * Inputs : *    sptr = a pointer to the unsigned char buffer to write to *    array = a pointer to the array of doubles from which to read *    num_beams = the integer number of beams (number of doubles in the array) *    sf = a pointer to the GSF scale factors used to scale the data *    id = the array subrecord id * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER *    GSF_INVALID_NUM_BEAMS * ********************************************************************/static intEncodeTwoByteArray(unsigned char *sptr, const double *array, int num_beams,    const gsfScaleFactors *sf, int id){    unsigned char  *ptr = sptr;    gsfuLong        ltemp;    gsfuShort       stemp;    double          dtemp;    int             i;    /* Make sure we have a multiplier for this array */    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)    {        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;        return (-1);    }    if (num_beams <= 0)    {        gsfError = GSF_INVALID_NUM_BEAMS;        return(-1);    }    /* subrecord identifier has array id in first byte, and size in the    *  remaining three bytes    */    ltemp = id << 24;    ltemp |= num_beams * 2;    ltemp = htonl(ltemp);    memcpy(ptr, &ltemp, 4);    ptr += 4;    for (i = 0; i < num_beams; i++)    {        dtemp = (array[i] + sf->scaleTable[id - 1].offset) * sf->scaleTable[id - 1].multiplier;        /* Make sure we round to the nearest whole integer */        if (dtemp >= 0.0)        {            dtemp += 0.501;        }        else        {            dtemp -= 0.501;        }        stemp = (gsfuShort) dtemp;        stemp = htons(stemp);        memcpy(ptr, &stemp, 2);        ptr += 2;    }    return (ptr - sptr);}/******************************************************************** * * Function Name : EncodeSignedTwoByteArray * * Description : This function encodes a two byte beam array subrecord *  from internal form to external byte stream form. * * Inputs : *    sptr = a pointer to the unsigned char buffer to write to *    array = a pointer to the array of doubles from which to read *    num_beams = the integer number of beams (number of doubles in the array) *    sf = a pointer to the GSF scale factors used to scale the data *    id = the array subrecord id * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER *    GSF_INVALID_NUM_BEAMS * ********************************************************************/static intEncodeSignedTwoByteArray(unsigned char *sptr, const double *array, int num_beams,    const gsfScaleFactors *sf, int id){    unsigned char  *ptr = sptr;    gsfuLong        ltemp;    gsfsShort       stemp;    double          dtemp;    int             i;    /* Make sure we have a multiplier for this array */    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)    {        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;        return (-1);    }    if (num_beams <= 0)    {        gsfError = GSF_INVALID_NUM_BEAMS;        return(-1);    }    /* subrecord identifier has array id in first byte, and size in the    *  remaining three bytes    */    ltemp = id << 24;    ltemp |= num_beams * 2;    ltemp = htonl(ltemp);    memcpy(ptr, &ltemp, 4);    ptr += 4;    for (i = 0; i < num_beams; i++)    {        dtemp = (array[i] + sf->scaleTable[id - 1].offset) *            sf->scaleTable[id - 1].multiplier;        /* Make sure we round to the nearest whole integer */        if (dtemp >= 0.0)        {            dtemp += 0.501;        }        else        {            dtemp -= 0.501;        }        stemp = (gsfsShort) dtemp;        stemp = htons(stemp);        memcpy(ptr, &stemp, 2);        ptr += 2;    }    return (ptr - sptr);}/******************************************************************** * * Function Name : EncodeFourByteArray * * Description : This function encodes a four byte beam array subrecord *  from internal form to external byte stream form. * * Inputs : *    sptr = a pointer to the unsigned char buffer to write to *    array = a pointer to the array of doubles from which to read *    num_beams = the integer number of beams (number of doubles in the array) *    sf = a pointer to the GSF scale factors used to scale the data *    id = the array subrecord id * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER *    GSF_INVALID_NUM_BEAMS * ********************************************************************/static intEncodeFourByteArray(unsigned char *sptr, const double *array, int num_beams,    const gsfScaleFactors *sf, int id){    unsigned char  *ptr = sptr;    gsfuLong        ltemp;    double          dtemp;    int             i;    /* Make sure we have a multiplier for this array */    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)    {        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;        return (-1);    }    if (num_beams <= 0)    {        gsfError = GSF_INVALID_NUM_BEAMS;        return(-1);    }    /* subrecord identifier has array id in first byte, and size in the    *  remaining three bytes    */    ltemp = id << 24;    ltemp |= num_beams * 4;    ltemp = htonl(ltemp);    memcpy(ptr, &ltemp, 4);    ptr += 4;    for (i = 0; i < num_beams; i++)    {        dtemp = (array[i] + sf->scaleTable[id - 1].offset) * sf->scaleTable[id - 1].multiplier;        /* Make sure we round to the nearest whole integer */        if (dtemp >= 0.0)        {            dtemp += 0.501;        }        else        {            dtemp -= 0.501;        }        ltemp = (gsfuLong) dtemp;        ltemp = htonl(ltemp);        memcpy(ptr, &ltemp, 4);        ptr += 4;    }    return (ptr - sptr);}/******************************************************************** * * Function Name : EncodeSignedFourByteArray * * Description : This function encodes a two byte beam array subrecord *  from internal form to external byte stream form. * * Inputs : *    sptr = a pointer to the unsigned char buffer to write to *    array = a pointer to the array of doubles from which to read *    num_beams = the integer number of beams (number of doubles in the array) *    sf = a pointer to the GSF scale factors used to scale the data *    id = the array subrecord id * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER *    GSF_INVALID_NUM_BEAMS * ********************************************************************/static intEncodeSignedFourByteArray(unsigned char *sptr, const double *array, int num_beams,    const gsfScaleFactors *sf, int id){    unsigned char  *ptr = sptr;    gsfuLong        ltemp;    gsfsLong        stemp;    double          dtemp;    int             i;    /* Make sure we have a multiplier for this array */    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)    {        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;        return (-1);    }    if (num_beams <= 0)    {        gsfError = GSF_INVALID_NUM_BEAMS;        return(-1);    }    /* subrecord identifier has array id in first byte, and size in the    *  remaining three bytes    */    ltemp = id << 24;    ltemp |= num_beams * 4;    ltemp = htonl(ltemp);    memcpy(ptr, &ltemp, 4);    ptr += 4;    for (i = 0; i < num_beams; i++)    {        dtemp = (array[i] + sf->scaleTable[id - 1].offset) *            sf->scaleTable[id - 1].multiplier;        /* Make sure we round to the nearest whole integer */        if (dtemp >= 0.0)        {            dtemp += 0.501;        }        else        {            dtemp -= 0.501;        }        stemp = (gsfsLong) dtemp;        stemp = htonl(stemp);        memcpy(ptr, &stemp, 4);        ptr += 4;    }    return (ptr - sptr);}/******************************************************************** * * Function Name : EncodeByteArray * * Description : This function encodes a byte beam array subrecord *  from internal form to external byte stream form. * * Inputs : *    sptr = a pointer to the unsigned char buffer to write to *    array = a pointer to the array of doubles from which to read *    num_beams = the integer number of beams (number of doubles in the array) *    sf = a pointer to the GSF scale factors used to scale the data *    id = the array subrecord id * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER *    GSF_INVALID_NUM_BEAMS * ********************************************************************/static intEncodeByteArray(unsigned char *sptr, const double *array, int num_beams,    const gsfScaleFactors * sf, int id){    unsigned char  *ptr = sptr;    unsigned char   ctemp;    gsfuLong        ltemp;    double          dtemp;    int             i;    /* Make sure we have a multiplier for this array */    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)    {        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;        return (-1);    }    if (num_beams <= 0)    {        gsfError = GSF_INVALID_NUM_BEAMS;        return(-1);    }    /* subrecord identifier has array id in first byte, and size in the    *  remaining three bytes    */    ltemp = id << 24;    ltemp |= num_beams;    ltemp = htonl(ltemp);    memcpy(ptr, &ltemp, 4);    ptr += 4;    for (i = 0; i < num_beams; i++)    {        dtemp = (array[i] + sf->scaleTable[id - 1].offset) *            sf->scaleTable[id - 1].multiplier;        /* Make sure we round to the nearest whole integer */        if (dtemp >= 0.0)        {            dtemp += 0.501;        }        else        {            dtemp -= 0.501;        }        ctemp = (unsigned char) dtemp;        memcpy(ptr, &ctemp, 1);        ptr++;    }    return (ptr - sptr);}/******************************************************************** * * Function Name : EncodeSignedByteArray * * Description : This function encodes a byte beam array subrecord *  from internal form to external byte stream form. * * Inputs : *    sptr = a pointer to the unsigned char buffer to write to *    array = a pointer to the array of doubles from which to read *    num_beams = the integer number of beams (number of doubles in the array) *    sf = a pointer to the GSF scale factors used to scale the data *    id = the array subrecord id * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER *    GSF_INVALID_NUM_BEAMS * ********************************************************************/static intEncodeSignedByteArray (unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors * sf, int id){    unsigned char  *ptr = sptr;    char   ctemp;    gsfuLong        ltemp;    double          dtemp;    int             i;    /* Make sure we have a multiplier for this array */    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)    {        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;        return (-1);    }    if (num_beams <= 0)    {        gsfError = GSF_INVALID_NUM_BEAMS;        return(-1);    }    /* subrecord identifier has array id in first byte, and size in the    *  remaining three bytes    */    ltemp = id << 24;    ltemp |= num_beams;    ltemp = htonl(ltemp);    memcpy(ptr, &ltemp, 4);    ptr += 4;    for (i = 0; i < num_beams; i++)    {        dtemp = (array[i] + sf->scaleTable[id - 1].offset) * sf->scaleTable[id - 1].multiplier;        ctemp = (char) dtemp;        memcpy(ptr, &ctemp, 1);        ptr++;    }    return (ptr - sptr);}/******************************************************************** * * Function Name : EncodeFromUnsignedShortToByteArray * * Description : This function encodes data from an unsigned short integer *  beam array into a subrecord packed as one byte values on the byte stream. *  Note that this function deliberately packs the unsigned short value *  from each element of the array into a single byte on the stream. *  Thus, the encoded dynamic range is 0 - 255. * * Inputs : *    sptr = a pointer to the unsigned char buffer to write to *    array = a pointer to the array of ints from which to read *    num_beams = the integer number of beams (number of doubles in the array) *    sf = a pointer to the GSF scale factors used to scale the data *    id = the array subrecord id * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER *    GSF_INVALID_NUM_BEAMS * ********************************************************************/static intEncodeFromUnsignedShortToByteArray(unsigned char *sptr, const unsigned short *array, int num_beams, const gsfScaleFactors *sf, int id){    unsigned char  *ptr = sptr;    gsfuLong        ltemp;    double          dtemp;    int             i;    /* Make sure we have a multiplier for this array */    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)    {        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;        return (-1);    }    if (num_beams <= 0)    {        gsfError = GSF_INVALID_NUM_BEAMS;        return(-1);    }    /* subrecord identifier has array id in first byte, and size in the     *  remaining three bytes     */    ltemp = id << 24;    ltemp |= num_beams;    ltemp = htonl(ltemp);    memcpy(ptr, &ltemp, 4);    ptr += 4;    for (i = 0; i < num_beams; i++)    {        dtemp = (array[i] + sf->scaleTable[id - 1].offset) * sf->scaleTable[id - 1].multiplier;        *ptr = (unsigned char)dtemp;        ptr++;    }    return (ptr - sptr);}/******************************************************************** * * Function Name : EncodeBeamFlagsArray * * Description : This function encodes the array of beam flags from internal *  form to external byte stream form. * * Inputs : *    sptr = a pointer to the unsigned char buffer to write to *    array = a pointer to the unsigned char buffer to read from *    num_beams = an integer containing the number of beams (elements in array) * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *     GSF_INVALID_NUM_BEAMS * ********************************************************************/static intEncodeBeamFlagsArray(unsigned char *sptr, const unsigned char *array, int num_beams){    unsigned char  *ptr = sptr;    gsfuLong        ltemp;    int             i;    if (num_beams <= 0)    {        gsfError = GSF_INVALID_NUM_BEAMS;        return(-1);    }    /* subrecord identifier has array id in first byte, and size in the    *  remaining three bytes    */    ltemp = GSF_SWATH_BATHY_SUBRECORD_BEAM_FLAGS_ARRAY << 24;    ltemp |= num_beams;    ltemp = htonl(ltemp);    memcpy(ptr, &ltemp, 4);    ptr += 4;    for (i = 0; i < num_beams; i++)    {        *ptr = array[i];        ptr++;    }    return (ptr - sptr);}/******************************************************************** * * Function Name : EncodeQualityFlagsArray * * Description : This function encodes the array of beam detection *  quality flags for Reson SeaBat data from internal form to external *  byte stream form. This field only has two bits so it packed as two *  bits per beam. * * Inputs : *    sptr = a pointer to the unsigned char buffer to write to *    array = a pointer to the unsigned char buffer to read from *    num_beams = an integer containing the number of beams (elements in array) * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *     GSF_INVALID_NUM_BEAMS * ********************************************************************/static intEncodeQualityFlagsArray(unsigned char *sptr, const unsigned char *array, int num_beams){    unsigned char  *ptr = sptr;    gsfuLong        ltemp;    int             i;    int             shift;    if (num_beams <= 0)    {        gsfError = GSF_INVALID_NUM_BEAMS;        return(-1);    }    /* Leave four bytes free for the subrecord id and size */    ptr += 4;    /* Pack the array values */    shift = 6;    *ptr = 0;    for (i = 0; i < num_beams; i++)    {        *ptr |= array[i] << shift;        if (shift == 0)        {            ptr++;            *ptr = 0;            shift = 6;        }        else        {            shift -= 2;        }    }    /*  If shift doesn't get reset to 6 then we have a number of beams that is not evenly divisible by 4.  The problem is that        we actually encoded part of another byte but we didn't increment the ptr.  */    if (shift != 6) ptr++;    /* subrecord identifier has array id in first byte, and size in the    *  remaining three bytes    */    ltemp = GSF_SWATH_BATHY_SUBRECORD_QUALITY_FLAGS_ARRAY << 24;    ltemp |= (ptr - sptr - 4);    ltemp = htonl(ltemp);    memcpy(sptr, &ltemp, 4);    return (ptr - sptr);}/******************************************************************** * * Function Name : EncodeSeabeamSpecific * * Description : This function encodes the sensor specific data from *  a SeaBeam system into external byte stream form. * * Inputs : *   sptr = a pointer to an unsigned char to write into *   sdata = a pointer to a union of GSF sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSeabeamSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    gsfuShort       stemp;    stemp = htons((gsfuShort) sdata->gsfSeaBeamSpecific.EclipseTime);    memcpy(sptr, &stemp, 2);    return (2);}/******************************************************************** * * Function Name : EncodeEM12Specific * * Description : This function encodes the sensor specific data from *   a EM12 system into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEM12Specific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the ping number */    stemp = htons((gsfuShort) (sdata->gsfEM12Specific.ping_number));    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the resolution */    *p = (unsigned char)  sdata->gsfEM12Specific.resolution;    p += 1;    /* Next byte contains the ping quality factor*/    *p = (unsigned char)  sdata->gsfEM12Specific.ping_quality;    p += 1;    /* Next two byte integer contains the sound velocity * 10 */    dtemp = (sdata->gsfEM12Specific.sound_velocity * 10.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the operational mode */    *p = (unsigned char)  sdata->gsfEM12Specific.mode;    p += 1;    /* The next 32 bytes are spare space for future growth */    memset(p, 0, 32);    p += 32;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeEm100Specific * * Description : This function encodes the EM100 sensor specific information *  into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEM100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the ship pitch */    dtemp = sdata->gsfEM100Specific.ship_pitch * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the transducer pitch */    dtemp = sdata->gsfEM100Specific.transducer_pitch * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the sonar mode (from the em100 amplitude datagram) */    *p = (unsigned char) sdata->gsfEM100Specific.mode;    p += 1;    /* Next byte contains the power (from the em100 amplitude datagram) */    *p = (unsigned char)  sdata->gsfEM100Specific.power;    p += 1;    /* Next byte contains the attenuation (from the em100 amplitude datagram) */    *p = (unsigned char)  sdata->gsfEM100Specific.attenuation;    p += 1;    /* Next byte contains the tvg (from the em100 amplitude datagram) */    *p = (unsigned char)  sdata->gsfEM100Specific.tvg;    p += 1;    /* Next byte contains the pulse length from the em100 amplitude datagram) */    *p = (unsigned char)  sdata->gsfEM100Specific.pulse_length;    p += 1;    /* Next two byte integer contains the counter from the em100    * amplitude datagram    */    stemp = htons((gsfuShort) (sdata->gsfEM100Specific.counter));    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeEm950Specific * * Description :  This function encodes the EM950 sensor specific information *  into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEM950Specific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the ping number */    stemp = htons((gsfuShort) (sdata->gsfEM950Specific.ping_number));    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the sonar mode of operation */    *p = (unsigned char) sdata->gsfEM950Specific.mode;    p += 1;    /* Next byte contains the ping quality factor*/    *p = (unsigned char) sdata->gsfEM950Specific.ping_quality;    p += 1;    /* Next two byte integer contains the transducer pitch */    dtemp = sdata->gsfEM950Specific.ship_pitch * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the transducer pitch */    dtemp = sdata->gsfEM950Specific.transducer_pitch * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sea surface sound speed * 10     */    dtemp = (sdata->gsfEM950Specific.surface_velocity * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeEm1000Specific * * Description :  This function encodes the EM1000 sensor specific information *  into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEM1000Specific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the ping number */    stemp = htons((gsfuShort) (sdata->gsfEM1000Specific.ping_number));    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the sonar mode of operation */    *p = (unsigned char) sdata->gsfEM1000Specific.mode;    p += 1;    /* Next byte contains the ping quality factor*/    *p = (unsigned char) sdata->gsfEM1000Specific.ping_quality;    p += 1;    /* Next two byte integer contains the transducer pitch */    dtemp = sdata->gsfEM1000Specific.ship_pitch * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the transducer pitch */    dtemp = sdata->gsfEM1000Specific.transducer_pitch * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sea surface sound speed * 10 */    dtemp = (sdata->gsfEM1000Specific.surface_velocity * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeEm121ASpecific * * Description : This function encodes the EM121A sensor specific *  information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEM121ASpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the ping number */    stemp = htons((gsfuShort) (sdata->gsfEM121ASpecific.ping_number));    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the sonar mode of operation */    *p = (unsigned char) sdata->gsfEM121ASpecific.mode;    p += 1;    /* Next byte contains the number of valid beams */    *p = (unsigned char) sdata->gsfEM121ASpecific.valid_beams;    p += 1;    /* Next byte contains the transmit pulse length */    *p = (unsigned char) sdata->gsfEM121ASpecific.pulse_length;    p += 1;    /* Next byte contains the sonar beam width */    *p = (unsigned char) sdata->gsfEM121ASpecific.beam_width;    p += 1;    /* Next byte contains the transmit power level */    *p = (unsigned char) sdata->gsfEM121ASpecific.tx_power;    p += 1;    /* Next byte contains the number of transmit channels NOT working */    *p = (unsigned char) sdata->gsfEM121ASpecific.tx_status;    p += 1;    /* Next byte contains the number of receive channels NOT working */    *p = (unsigned char) sdata->gsfEM121ASpecific.rx_status;    p += 1;    /* Next two byte integer contains the sea surface sound speed * 10     */    dtemp = (sdata->gsfEM121ASpecific.surface_velocity * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeEm121Specific * * Description : This function encodes the EM121 sensor specific *  information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEM121Specific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the ping number */    stemp = htons((gsfuShort) (sdata->gsfEM121Specific.ping_number));    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the sonar mode of operation */    *p = (unsigned char) sdata->gsfEM121Specific.mode;    p += 1;    /* Next byte contains the number of valid beams */    *p = (unsigned char) sdata->gsfEM121Specific.valid_beams;    p += 1;    /* Next byte contains the transmit pulse length */    *p = (unsigned char) sdata->gsfEM121Specific.pulse_length;    p += 1;    /* Next byte contains the sonar beam width */    *p = (unsigned char) sdata->gsfEM121Specific.beam_width;    p += 1;    /* Next byte contains the transmit power level */    *p = (unsigned char) sdata->gsfEM121Specific.tx_power;    p += 1;    /* Next byte contains the number of transmit channels NOT working */    *p = (unsigned char) sdata->gsfEM121Specific.tx_status;    p += 1;    /* Next byte contains the number of receive channels NOT working */    *p = (unsigned char) sdata->gsfEM121Specific.rx_status;    p += 1;    /* Next two byte integer contains the sea surface sound speed * 10     */    dtemp = (sdata->gsfEM121Specific.surface_velocity * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeCmpSassSpecific * * Description : This function encodes the Compressed SASS *               specific data record to external byte stream format. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeCmpSassSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double      dtemp;    dtemp = (sdata->gsfCmpSassSpecific.lfreq * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    dtemp = (sdata->gsfCmpSassSpecific.lntens * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}#if 1/* 3-30-99 wkm: obsolete *//******************************************************************** * * Function Name : EncodeSASSSpecific * * Description : This function encodes the Typeiii SASS *               specific data record to external byte stream format. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSASSSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    /* First two byte integer contains the leftmost beam */    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.leftmost_beam));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the rightmost beam */    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.rightmost_beam));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the total number of beams */    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.total_beams));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the navigation mode */    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.nav_mode));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the ping number */    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.ping_number));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the mission number */    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.mission_number));    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeTypeIIISeaBeamSpecific * * Description : This function encodes the Type III Seabeam specific *               data record to external byte stream format. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeTypeIIISeaBeamSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    /* First two byte integer contains the leftmost beam */    stemp = htons((gsfuShort) (sdata->gsfTypeIIISeaBeamSpecific.leftmost_beam));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the rightmost beam */    stemp = htons((gsfuShort)(sdata->gsfTypeIIISeaBeamSpecific.rightmost_beam));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the total number of beams */    stemp = htons((gsfuShort)(sdata->gsfTypeIIISeaBeamSpecific.total_beams));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the navigation mode */    stemp = htons((gsfuShort)(sdata->gsfTypeIIISeaBeamSpecific.nav_mode));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the ping number */    stemp = htons((gsfuShort)(sdata->gsfTypeIIISeaBeamSpecific.ping_number));    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the mission number */    stemp = htons((gsfuShort)(sdata->gsfTypeIIISeaBeamSpecific.mission_number));    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}#endif/******************************************************************** * * Function Name : EncodeSeaMapSpecific * * Description : not implimented yet * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSeaMapSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata, const GSF_FILE_TABLE *ft){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    dtemp = (sdata->gsfSeamapSpecific.portTransmitter[0] * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    dtemp = (sdata->gsfSeamapSpecific.portTransmitter[1] * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    dtemp = (sdata->gsfSeamapSpecific.stbdTransmitter[0] * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    dtemp = (sdata->gsfSeamapSpecific.stbdTransmitter[1] * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    dtemp = (sdata->gsfSeamapSpecific.portGain * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    dtemp = (sdata->gsfSeamapSpecific.stbdGain * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    dtemp = (sdata->gsfSeamapSpecific.portPulseLength * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    dtemp = (sdata->gsfSeamapSpecific.stbdPulseLength * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    dtemp = (sdata->gsfSeamapSpecific.pressureDepth * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    /* JSB 11/08/2007; looks like the pointer increment for this field in the encode processing has been missing     *  since this code block was first written in GSFv1.03     */    if ((ft->major_version_number > 2) || ((ft->major_version_number == 2) && (ft->minor_version_number > 7)))    {        p += 2;    }    dtemp = (sdata->gsfSeamapSpecific.altitude * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    dtemp = (sdata->gsfSeamapSpecific.temperature * 10.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeSeaBatSpecific * * Description : This function encodes the Reson SeaBat sensor specific *  information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSeaBatSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the ping number */    stemp = htons((gsfuShort) sdata->gsfSeaBatSpecific.ping_number);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sea surface sound speed * 10 */    dtemp = sdata->gsfSeaBatSpecific.surface_velocity * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the sonar mode of operation */    *p = (unsigned char) sdata->gsfSeaBatSpecific.mode;    p += 1;    /* Next byte contains the sonar mode setting for this ping */    *p = (unsigned char) sdata->gsfSeaBatSpecific.sonar_range;    p += 1;    /* Next byte contains the sonar transmit power for this ping */    *p = (unsigned char) sdata->gsfSeaBatSpecific.transmit_power;    p += 1;    /* Next byte contains the sonar receive gain for this setting */    *p = (unsigned char) sdata->gsfSeaBatSpecific.receive_gain;    p += 1;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeSBAmpSpecific * * Description : This function encodes the Sea Beam with amplitude *  sensor specific information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSBAmpSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuLong        ltemp;    gsfuShort       stemp;    /* First byte contains the hour from the Eclipse */    *p = (unsigned char) sdata->gsfSBAmpSpecific.hour;    p += 1;    /* Next byte contains the minute from the Eclipse */    *p = (unsigned char) sdata->gsfSBAmpSpecific.minute;    p += 1;    /* Next byte contains the second from the Eclipse */    *p = (unsigned char) sdata->gsfSBAmpSpecific.second;    p += 1;    /* Next byte the hundredths of seconds from the Eclipse */    *p = (unsigned char) sdata->gsfSBAmpSpecific.hundredths;    p += 1;    /* Next four byte integer contains the block number */    ltemp = htonl((gsfuLong) sdata->gsfSBAmpSpecific.block_number);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the average gate depth */    stemp = htons((gsfuShort) sdata->gsfSBAmpSpecific.avg_gate_depth);    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeSeaBatIISpecific * * Description : This function encodes the Reson SeaBat II sensor specific *  information into external byte stream form.  The SeaBat II sensor *  specific data structure was defined to replace the gsfSeaBatSpecific *  data structure as of GSF version 1.04 * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSeaBatIISpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the ping number */    stemp = htons((gsfuShort) sdata->gsfSeaBatIISpecific.ping_number);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sea surface sound speed * 10 */    dtemp = sdata->gsfSeaBatIISpecific.surface_velocity * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sonar mode of operation */    stemp = htons((gsfuShort) sdata->gsfSeaBatIISpecific.mode);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sonar range setting */    stemp = htons((gsfuShort) sdata->gsfSeaBatIISpecific.sonar_range);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the power setting */    stemp = htons((gsfuShort) sdata->gsfSeaBatIISpecific.transmit_power);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the gain setting */    stemp = htons((gsfuShort) sdata->gsfSeaBatIISpecific.receive_gain);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the fore/aft beam width */    *p = (unsigned char) ((sdata->gsfSeaBatIISpecific.fore_aft_bw * 10.0) + 0.5);    p += 1;    /* Next byte contains the athwartships beam width */    *p = (unsigned char) ((sdata->gsfSeaBatIISpecific.athwart_bw * 10.0) + 0.5);    p += 1;    /* Next four bytes are reserved as spare space. */    *p = (unsigned char) (sdata->gsfSeaBatIISpecific.spare[0]);    p += 1;    *p = (unsigned char) (sdata->gsfSeaBatIISpecific.spare[1]);    p += 1;    *p = (unsigned char) (sdata->gsfSeaBatIISpecific.spare[2]);    p += 1;    *p = (unsigned char) (sdata->gsfSeaBatIISpecific.spare[3]);    p += 1;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeSeaBat8101Specific * * Description : This function encodes the Reson SeaBat 8101 sensor specific *  information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSeaBat8101Specific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the ping number */    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.ping_number);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sea surface sound speed * 10 */    dtemp = sdata->gsfSeaBat8101Specific.surface_velocity * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sonar mode of operation */    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.mode);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sonar range setting */    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.range);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the power setting */    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.power);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the gain setting */    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.gain);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the pulse width, in microseconds */    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.pulse_width);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the tvg spreading coefficient * 4 */    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.tvg_spreading);    p += 1;    /* Next byte contains the tvg absorption coefficient */    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.tvg_absorption);    p += 1;    /* Next byte contains the fore/aft beam width */    *p = (unsigned char) ((sdata->gsfSeaBat8101Specific.fore_aft_bw * 10.0) + 0.5);    p += 1;    /* Next byte contains the athwartships beam width */    *p = (unsigned char) ((sdata->gsfSeaBat8101Specific.athwart_bw * 10.0) + 0.5);    p += 1;    /* Next two byte integer is reserved for future use, to store the range filter min */    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.range_filt_min);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer is reserved for future use, to store the range filter max */    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.range_filt_max);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer is reserved for future use, to store the depth filter min */    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.depth_filt_min);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer is reserved for future use, to store the depth filter max */    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.depth_filt_max);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte is reserved for future use, to store the projector type */    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.projector);    p += 1;    /* Next four bytes are reserved as spare space. */    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.spare[0]);    p += 1;    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.spare[1]);    p += 1;    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.spare[2]);    p += 1;    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.spare[3]);    p += 1;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeSeaBeam2112Specific * * Description : This function encodes the Sea Beam 2112/36 sensor specific *  information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSeaBeam2112Specific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First byte contains the sonar mode of operation */    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.mode);    p += 1;    /* Next two byte integer contains the surface sound velocity * 100 - 130000 */    dtemp = (sdata->gsfSeaBeam2112Specific.surface_velocity * 100.0) - 130000;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the SSV source */    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.ssv_source);    p += 1;    /* Next byte contains the ping gain */    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.ping_gain);    p += 1;    /* Next byte contains the ping pulse width */    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.pulse_width);    p += 1;    /* Next byte contains the transmitter attenuation */    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.transmitter_attenuation);    p += 1;    /* Next byte contains the number of algorithms */    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.number_algorithms);    p += 1;    /* Next 4 bytes contain the algorithm order */    memcpy (p, (unsigned char *) (sdata->gsfSeaBeam2112Specific.algorithm_order), 4);    p += 4;    /* Next two bytes are reserved as spare space. */    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.spare[0]);    p += 1;    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.spare[1]);    p += 1;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeElacMkIISpecific * * Description : This function encodes the Elac Bottomchart MkII sensor specific *  information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeElacMkIISpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    /* First byte contains the sonar mode of operation */    *p = (unsigned char) (sdata->gsfElacMkIISpecific.mode);    p += 1;    /* Next two byte integer contains the ping counter */    stemp = htons((gsfuShort) sdata->gsfElacMkIISpecific.ping_num);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the surface sound velocity in m/s */    stemp = htons((gsfuShort) sdata->gsfElacMkIISpecific.sound_vel);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the pulse length in 0.01 ms */    stemp = htons((gsfuShort) sdata->gsfElacMkIISpecific.pulse_length);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the starboard receiver gain in dB */    *p = (unsigned char) (sdata->gsfElacMkIISpecific.receiver_gain_stbd);    p += 1;    /* Next byte contains the port receiver gain in dB */    *p = (unsigned char) (sdata->gsfElacMkIISpecific.receiver_gain_port);    p += 1;    /* Next two byte integer is reserved for future use */    stemp = htons((gsfuShort) sdata->gsfElacMkIISpecific.reserved);    memcpy(p, &stemp, 2);    p += 2;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeEM3Specific * * Description : This function encodes the Simrad EM3000 series sensor *  specific information into external byte stream form. * * Inputs : *   sptr = a pointer to an unsigned char buffer to write into *   sdata = a pointer to a union of sensor specific data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEM3Specific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;    double          dtemp;    int             run_time_id;    /* Next two bytes contain the EM model number */    stemp = htons((gsfuShort) sdata->gsfEM3Specific.model_number);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the ping number */    stemp = htons((gsfuShort) sdata->gsfEM3Specific.ping_number);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the system 1 or 2 serial number */    stemp = htons((gsfuShort) sdata->gsfEM3Specific.serial_number);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the sourface sound speed */    dtemp = sdata->gsfEM3Specific.surface_velocity * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the transmit depth */    dtemp = sdata->gsfEM3Specific.transducer_depth * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the maximum number of beams possible */    stemp = htons((gsfuShort) sdata->gsfEM3Specific.valid_beams);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the sample rate */    stemp = htons((gsfuShort) sdata->gsfEM3Specific.sample_rate);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the depth difference between sonar heads in the EM3000D */    dtemp = sdata->gsfEM3Specific.depth_difference * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the transducer depth offset multiplier */    *p = (unsigned char) (sdata->gsfEM3Specific.offset_multiplier);    p += 1;    /* Encode and write the run-time paremeters if any of them have changed. */    run_time_id = 1;    /* JSB 3/31/99 Commented out the following code block.  For now we will encode all of the     *  run-time parameter fields in the sensor specific sub-record for each ping, whether the     *  values have been updated or not.  In a future release, we plan to support encoding this     *  portion of the subrecord only when the values have been updated.  This can be done by     *  using the model in place for the scale factors record.  We will need to support a     *  "scales_read" flag for write after read access, and direct access back to the ping record     *  with the updated run-time params prior to a direct access read.     *     * run_time_id = 0;     * if (memcmp(&sdata->gsfEM3Specific.run_time[0], &ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[0], sizeof(gsfEM3RunTime)))     * {     *     memcpy (&ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[0], &sdata->gsfEM3Specific.run_time[0], sizeof(gsfEM3RunTime));     *     run_time_id |= 0x00000001;     * }     *     * If this is an em 3000 series dual head installation, then we'll need to save both sets of run time parameters when either set     *  has been updated.     *     * if ((sdata->gsfEM3Specific.model_number == 3002) ||     *    (sdata->gsfEM3Specific.model_number == 3003) ||     *    (sdata->gsfEM3Specific.model_number == 3004) ||     *    (sdata->gsfEM3Specific.model_number == 3005) ||     *    (sdata->gsfEM3Specific.model_number == 3006) ||     *    (sdata->gsfEM3Specific.model_number == 3007) ||     *    (sdata->gsfEM3Specific.model_number == 3008))     * {     *     if ((memcmp(&sdata->gsfEM3Specific.run_time[0], &ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[0], sizeof(gsfEM3RunTime))) ||     *         (memcmp(&sdata->gsfEM3Specific.run_time[1], &ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[1], sizeof(gsfEM3RunTime))))     *     {     *         memcpy (&ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[0], &sdata->gsfEM3Specific.run_time[0], sizeof(gsfEM3RunTime));     *         memcpy (&ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[1], &sdata->gsfEM3Specific.run_time[1], sizeof(gsfEM3RunTime));     *         run_time_id |= 0x00000001;     *         run_time_id |= 0x00000002;     *     }     * }     */    /* The next four byte value specifies the existence of the run-time data structure */    ltemp = htonl(run_time_id);    memcpy(p, &ltemp, 4);    p += 4;    /* If the first bit is set, then this subrecord contains a new set of run-time parameters     *  for a single head system, otherwise the run-time parameters have not changed.     */    if (run_time_id & 0x00000001)    {        /* The next two byte value contains the em model number */        stemp = htons(sdata->gsfEM3Specific.run_time[0].model_number);        memcpy(p, &stemp, 2);        p += 2;        /* First 8 bytes contain the time */        ltemp = htonl(sdata->gsfEM3Specific.run_time[0].dg_time.tv_sec);        memcpy(p, &ltemp, 4);        p += 4;        ltemp = htonl(sdata->gsfEM3Specific.run_time[0].dg_time.tv_nsec);        memcpy(p, &ltemp, 4);        p += 4;        /* The next two byte value contains the sequential ping number */        stemp = htons(sdata->gsfEM3Specific.run_time[0].ping_number);        memcpy(p, &stemp, 2);        p += 2;        /* The next two byte value contains the sonar head serial number */        stemp = htons(sdata->gsfEM3Specific.run_time[0].serial_number);        memcpy(p, &stemp, 2);        p += 2;        /* The next four byte value contains the system status */        ltemp = htonl(sdata->gsfEM3Specific.run_time[0].system_status);        memcpy(p, &ltemp, 4);        p += 4;        /* The next one byte value contains the mode identifier */        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].mode;        p += 1;        /* The next one byte value contains the filter identifier */        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].filter_id;        p += 1;        /* The next two byte value contains the minimum depth */        dtemp = sdata->gsfEM3Specific.run_time[0].min_depth;        stemp = htons((gsfuShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* The next two byte value contains the maximum depth */        dtemp = sdata->gsfEM3Specific.run_time[0].max_depth;        stemp = htons((gsfuShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* The next two byte value contains the absorption coefficient */        dtemp = sdata->gsfEM3Specific.run_time[0].absorption * 100.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        stemp = htons((gsfuShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* The next two byte value contains the transmit pulse length */        dtemp = sdata->gsfEM3Specific.run_time[0].pulse_length;        stemp = htons((gsfuShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* The next two byte value contains the transmit beam width */        dtemp = sdata->gsfEM3Specific.run_time[0].transmit_beam_width * 10.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        stemp = htons((gsfuShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* The next one byte value contains the transmit power reduction */        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].power_reduction;        p += 1;        /* The next one byte value contains the receive beam width */        *p = (unsigned char) (sdata->gsfEM3Specific.run_time[0].receive_beam_width * 10.0 + 0.501);        p += 1;        /* The next one byte value contains the receive band width in Hz. This value is         *  provided by the sonar with a precision of 50 hz.         */        *p = (unsigned char) (sdata->gsfEM3Specific.run_time[0].receive_bandwidth / 50.0 + 0.501);        p += 1;        /* The next one byte value contains the receive gain */        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].receive_gain;        p += 1;        /* The next one byte value contains the TVG law cross-over angle */        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].cross_over_angle;        p += 1;        /* The next one byte value contains the source of the surface sound speed value */        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].ssv_source;        p += 1;        /* The next two byte value contains the maximum port swath width */        stemp = htons(sdata->gsfEM3Specific.run_time[0].port_swath_width);        memcpy(p, &stemp, 2);        p += 2;        /* The next one byte value contains the beam spacing value */        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].beam_spacing;        p += 1;        /* The next one byte value contains the port coverage sector */        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].port_coverage_sector;        p += 1;        /* The next one byte value contains the yaw and pitch stabilization mode */        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].stabilization;        p += 1;        /* The next one byte value contains the starboard coverage sector */        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].stbd_coverage_sector;        p += 1;        /* The next two byte value contains the maximum starboard swath width */        stemp = htons(sdata->gsfEM3Specific.run_time[0].stbd_swath_width);        memcpy(p, &stemp, 2);        p += 2;        /* The next one byte value contains the HiLo frequency absorption coefficient ratio */        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].hilo_freq_absorp_ratio;        p += 1;        /* The next four bytes are reserved for future use */        memset(p, 0, 4);        p += 4;        /* If the second bit is set then this subrecord contains a second set of new run-time         *  for an em3000d series sonar system.         */        if (run_time_id & 0x00000002)        {            /* The next two byte value contains the em model number */            stemp = htons(sdata->gsfEM3Specific.run_time[1].model_number);            memcpy(p, &stemp, 2);            p += 2;            /* First 8 bytes contain the time */            ltemp = htonl(sdata->gsfEM3Specific.run_time[1].dg_time.tv_sec);            memcpy(p, &ltemp, 4);            p += 4;            ltemp = htonl(sdata->gsfEM3Specific.run_time[1].dg_time.tv_nsec);            memcpy(p, &ltemp, 4);            p += 4;            /* The next two byte value contains the sequential ping number */            stemp = htons(sdata->gsfEM3Specific.run_time[1].ping_number);            memcpy(p, &stemp, 2);            p += 2;            /* The next two byte value contains the sonar head serial number */            stemp = htons(sdata->gsfEM3Specific.run_time[1].serial_number);            memcpy(p, &stemp, 2);            p += 2;            /* The next four byte value contains the system status */            ltemp = htonl(sdata->gsfEM3Specific.run_time[1].system_status);            memcpy(p, &ltemp, 4);            p += 4;            /* The next one byte value contains the mode identifier */            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].mode;            p += 1;            /* The next one byte value contains the filter identifier */            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].filter_id;            p += 1;            /* The next two byte value contains the minimum depth */            dtemp = sdata->gsfEM3Specific.run_time[1].min_depth;            stemp = htons((gsfuShort) dtemp);            memcpy(p, &stemp, 2);            p += 2;            /* The next two byte value contains the maximum depth */            dtemp = sdata->gsfEM3Specific.run_time[1].max_depth;            stemp = htons((gsfuShort) dtemp);            memcpy(p, &stemp, 2);            p += 2;            /* The next two byte value contains the absorption coefficient */            dtemp = sdata->gsfEM3Specific.run_time[1].absorption * 100.0;            if (dtemp < 0.0)            {                dtemp -= 0.501;            }            else            {                dtemp += 0.501;            }            stemp = htons((gsfuShort) dtemp);            memcpy(p, &stemp, 2);            p += 2;            /* The next two byte value contains the transmit pulse length */            dtemp = sdata->gsfEM3Specific.run_time[1].pulse_length;            stemp = htons((gsfuShort) dtemp);            memcpy(p, &stemp, 2);            p += 2;            /* The next two byte value contains the transmit beam width */            dtemp = sdata->gsfEM3Specific.run_time[1].transmit_beam_width * 10.0;            if (dtemp < 0.0)            {                dtemp -= 0.501;            }            else            {                dtemp += 0.501;            }            stemp = htons((gsfuShort) dtemp);            memcpy(p, &stemp, 2);            p += 2;            /* The next one byte value contains the transmit power reduction */            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].power_reduction;            p += 1;            /* The next one byte value contains the receive beam width */            *p = (unsigned char) (sdata->gsfEM3Specific.run_time[1].receive_beam_width * 10.0 + 0.501);            p += 1;            /* The next one byte value contains the receive band width in Hz. This value is             *  provided by the sonar with a precision of 50 hz.             */            *p = (unsigned char) (sdata->gsfEM3Specific.run_time[1].receive_bandwidth / 50.0 + 0.501);            p += 1;            /* The next one byte value contains the receive gain */            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].receive_gain;            p += 1;            /* The next one byte value contains the TVG law cross-over angle */            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].cross_over_angle;            p += 1;            /* The next one byte value contains the source of the surface sound speed value */            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].ssv_source;            p += 1;            /* The next two byte value contains the maximum port swath width */            stemp = htons(sdata->gsfEM3Specific.run_time[1].port_swath_width);            memcpy(p, &stemp, 2);            p += 2;            /* The next one byte value contains the beam spacing value */            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].beam_spacing;            p += 1;            /* The next one byte value contains the port coverage sector */            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].port_coverage_sector;            p += 1;            /* The next one byte value contains the yaw and pitch stabilization mode */            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].stabilization;            p += 1;            /* The next one byte value contains the starboard coverage sector */            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].stbd_coverage_sector;            p += 1;            /* The next two byte value contains the maximum starboard swath width */            stemp = htons(sdata->gsfEM3Specific.run_time[1].stbd_swath_width);            memcpy(p, &stemp, 2);            p += 2;            /* The next one byte value contains the HiLo frequency absorption coefficient ratio */            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].hilo_freq_absorp_ratio;            p += 1;            /* The next four bytes are reserved for future use */            memset(p, 0, 4);            p += 4;         }    }    return (p - sptr);}/******************************************************************** * * Function Name : EncodeEM3RawSpecific * * Description : This function encodes the Kongsberg EM710/EM302/EM122/EM2040 *  sensor specific information into external byte stream form. * * Inputs : *   sptr = a pointer to an unsigned char buffer to write into *   sdata = a pointer to a union of sensor specific data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEM3RawSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;    double          dtemp;    int             i;    /* The next two bytes contain the model number */    stemp = htons (sdata->gsfEM3RawSpecific.model_number);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contain the ping counter */    stemp = htons (sdata->gsfEM3RawSpecific.ping_counter);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contain the serial number */    stemp = htons (sdata->gsfEM3RawSpecific.serial_number);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contain the surface velocity */    dtemp = sdata->gsfEM3RawSpecific.surface_velocity * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next four bytes contain the transmit transducer depth */    dtemp = sdata->gsfEM3RawSpecific.transducer_depth * 20000.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next two bytes contain the number of valid detections for this ping */    stemp = htons (sdata->gsfEM3RawSpecific.valid_detections);    memcpy(p, &stemp, 2);    p += 2;    /* The next four bytes contains the integer portion of the sampling frequency in Hz */    ltemp = htonl((gsfuLong) sdata->gsfEM3RawSpecific.sampling_frequency);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contain the fractional portion of the sampling frequency in Hz scaled by 4.0e9 */    dtemp = sdata->gsfEM3RawSpecific.sampling_frequency - ((gsfuLong) sdata->gsfEM3RawSpecific.sampling_frequency);    dtemp *= 4.0e9;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contains the "ROV depth" */    dtemp = sdata->gsfEM3RawSpecific.vehicle_depth * 1000.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two bytes contain the depth difference between sonar heads in the EM3000D */    dtemp = sdata->gsfEM3RawSpecific.depth_difference * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the transducer depth offset multiplier */    *p = (unsigned char) (sdata->gsfEM3RawSpecific.offset_multiplier);    p += 1;    /* The next 16 bytes are spare space for future use */    memset (p, 0, (size_t) 16);    p += 16;    /* The next two bytes contains the number of transmit sectors */    stemp = htons (sdata->gsfEM3RawSpecific.transmit_sectors);    memcpy(p, &stemp, 2);    p += 2;    /* Now loop over the transmit sectors to encode the sector specific information */    for (i = 0; i < sdata->gsfEM3RawSpecific.transmit_sectors; i++)    {        /* Next two bytes contains the tilt angle */        dtemp = sdata->gsfEM3RawSpecific.sector[i].tilt_angle * 100.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        stemp = htons((gsfsShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* Next two bytes contains the focus range */        dtemp = sdata->gsfEM3RawSpecific.sector[i].focus_range * 10.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        stemp = htons((gsfuShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* Next four bytes contains the signal length */        dtemp = sdata->gsfEM3RawSpecific.sector[i].signal_length * 1.0e6;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* Next four bytes contains the transmit delay */        dtemp = sdata->gsfEM3RawSpecific.sector[i].transmit_delay * 1.0e6;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* Next four bytes contains the center frequency */        dtemp = sdata->gsfEM3RawSpecific.sector[i].center_frequency * 1.0e3;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* Next byte contains the signal wave form identifier */        *p = (unsigned char) sdata->gsfEM3RawSpecific.sector[i].waveform_id;        p += 1;        /* Next byte contains the transmit sector number */        *p = (unsigned char) sdata->gsfEM3RawSpecific.sector[i].sector_number;        p += 1;        /* Next four bytes contains the signal bandwidth */        dtemp = sdata->gsfEM3RawSpecific.sector[i].signal_bandwidth * 1.0e3;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* The next 16 bytes are spare space for future use */        memset (p, 0, (size_t) 16);        p += 16;    }    /* The next 16 bytes are spare space for future use */    memset (p, 0, (size_t) 16);    p += 16;    /* Encode and write the run-time parameters.     *     * The next two byte value contains the em model number     */    stemp = htons(sdata->gsfEM3RawSpecific.run_time.model_number);    memcpy(p, &stemp, 2);    p += 2;    /* First 8 bytes contain the time */    ltemp = htonl(sdata->gsfEM3RawSpecific.run_time.dg_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    ltemp = htonl(sdata->gsfEM3RawSpecific.run_time.dg_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* The next two byte value contains the sequential ping number */    stemp = htons(sdata->gsfEM3RawSpecific.run_time.ping_counter);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the sonar head serial number */    stemp = htons(sdata->gsfEM3RawSpecific.run_time.serial_number);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the operator station status */    *p = sdata->gsfEM3RawSpecific.run_time.operator_station_status;    p += 1;    /* Next byte contains the processing unit status */    *p = sdata->gsfEM3RawSpecific.run_time.processing_unit_status;    p += 1;    /* Next byte contains the BSP status */    *p = sdata->gsfEM3RawSpecific.run_time.bsp_status;    p += 1;    /* Next byte contains the sonar head or transceiver status */    *p = sdata->gsfEM3RawSpecific.run_time.head_transceiver_status;    p += 1;    /* The next one byte value contains the mode identifier */    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.mode;    p += 1;    /* The next one byte value contains the filter identifier */    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.filter_id;    p += 1;    /* The next two byte value contains the minimum depth */    dtemp = sdata->gsfEM3RawSpecific.run_time.min_depth;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the maximum depth */    dtemp = sdata->gsfEM3RawSpecific.run_time.max_depth;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the absorption coefficient */    dtemp = sdata->gsfEM3RawSpecific.run_time.absorption * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the transmit pulse length in micro seconds */    dtemp = sdata->gsfEM3RawSpecific.run_time.tx_pulse_length;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the transmit beam width */    dtemp = sdata->gsfEM3RawSpecific.run_time.tx_beam_width * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next one byte value contains the transmit power reduction */    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.tx_power_re_max;    p += 1;    /* The next one byte value contains the receive beam width */    *p = (unsigned char) ((sdata->gsfEM3RawSpecific.run_time.rx_beam_width * 10.0) + 0.501);    p += 1;    /* The next one byte value contains the receive band width in Hz. This value is     *  provided by the sonar with a precision of 50 hz.     */    *p = (unsigned char) ((sdata->gsfEM3RawSpecific.run_time.rx_bandwidth / 50.0) + 0.501);    p += 1;    /* The next one byte value contains the receive gain */    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.rx_fixed_gain;    p += 1;    /* The next one byte value contains the TVG law cross-over angle */    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.tvg_cross_over_angle;    p += 1;    /* The next one byte value contains the source of the surface sound speed value */    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.ssv_source;    p += 1;    /* The next two byte value contains the maximum port swath width */    stemp = htons(sdata->gsfEM3RawSpecific.run_time.max_port_swath_width);    memcpy(p, &stemp, 2);    p += 2;    /* The next one byte value contains the beam spacing value */    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.beam_spacing;    p += 1;    /* The next one byte value contains the port coverage in degrees */    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.max_port_coverage;    p += 1;    /* The next one byte value contains the yaw and pitch stabilization mode */    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.stabilization;    p += 1;    /* The next one byte value contains the starboard coverage in degrees */    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.max_stbd_coverage;    p += 1;    /* The next two byte value contains the maximum starboard swath width */    stemp = htons(sdata->gsfEM3RawSpecific.run_time.max_stbd_swath_width);    memcpy(p, &stemp, 2);    p += 2;    /* The contents of the next two byte value depends on the sonar model number */    switch (sdata->gsfEM3RawSpecific.run_time.model_number)    {        case 1002:            /* The next two byte value contains the Durotong speed. This field is valid only for the EM1002 */            dtemp = sdata->gsfEM3RawSpecific.run_time.durotong_speed * 10.0;            if (dtemp < 0.0)            {                dtemp -= 0.501;            }            else            {                dtemp += 0.501;            }            stemp = htons((gsfuShort) dtemp);            memcpy(p, &stemp, 2);            p += 2;            break;        case 300:        case 120:        case 3000:        case 3020:            /* The next two byte value contains the transmit along track tilt in degrees.             * JSB: As of 3/1/09, still don't have final datagram documentation from KM             * to know whether the tx_along_tilt field is EM4 specific or if it will be supported             * on EM3 systems.             */            dtemp = sdata->gsfEM3RawSpecific.run_time.tx_along_tilt * 100.0;            if (dtemp < 0.0)            {                dtemp -= 0.501;            }            else            {                dtemp += 0.501;            }            stemp = htons((gsfsShort) dtemp);            memcpy(p, &stemp, 2);            p += 2;            break;        default:            /* Then next two byte value is spare */            p += 2;            break;    }    /* The contents of the next one byte value depends on the sonar model number */    switch (sdata->gsfEM3RawSpecific.run_time.model_number)    {        default:            /* The next one byte value contains the HiLo frequency absorption coefficient ratio             * JSB: As of 3/1/09, still don't have final datagram documentation from KM             * to know whether the filter ID 2 field is EM4 specific or if it will be supported             * on EM3 systems.             */            *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.hi_low_absorption_ratio;            p += 1;            break;    }    /* The next 16 bytes of space on the byte stream are spare space for future use. */    memset (p, 0, (size_t) 16);    p += 16;    /* Encode and write the PU status fields. */    /* The next one byte value contains the processor unit CPU load */    *p = (unsigned char) sdata->gsfEM3RawSpecific.pu_status.pu_cpu_load;    p += 1;    /* The next two bytes contain a bit mask detailing valid/invalid status of sensor inputs */    stemp = htons(sdata->gsfEM3RawSpecific.pu_status.sensor_status);    memcpy(p, &stemp, 2);    p += 2;    /* The next one byte value contains the achieved port coverage */    *p = (unsigned char) sdata->gsfEM3RawSpecific.pu_status.achieved_port_coverage;    p += 1;    /* The next one byte value contains the achieved starboard coverage */    *p = (unsigned char) sdata->gsfEM3RawSpecific.pu_status.achieved_stbd_coverage;    p += 1;    /* The next two bytes contain the yaw stabilization */    dtemp = sdata->gsfEM3RawSpecific.pu_status.yaw_stabilization * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next 16 bytes are reserved for future use */    memset (p, 0, (size_t) 16);    p += 16;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeEM4Specific * * Description : This function encodes the Kongsberg EM710/EM302/EM122/EM2040/ME70BO *  sensor specific information into external byte stream form. * * Inputs : *   sptr = a pointer to an unsigned char buffer to write into *   sdata = a pointer to a union of sensor specific data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEM4Specific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;    double          dtemp;    int             i;    /* The next two bytes contain the model number */    stemp = htons (sdata->gsfEM4Specific.model_number);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contain the ping counter */    stemp = htons (sdata->gsfEM4Specific.ping_counter);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contain the serial number */    stemp = htons (sdata->gsfEM4Specific.serial_number);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contain the surface velocity */    dtemp = sdata->gsfEM4Specific.surface_velocity * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next four bytes contain the transmit transducer depth */    dtemp = sdata->gsfEM4Specific.transducer_depth * 20000.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next two bytes contain the number of valid detections for this ping */    stemp = htons (sdata->gsfEM4Specific.valid_detections);    memcpy(p, &stemp, 2);    p += 2;    /* The next four bytes contains the integer portion of the sampling frequency in Hz */    ltemp = htonl((gsfuLong) sdata->gsfEM4Specific.sampling_frequency);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contain the fractional portion of the sampling frequency in Hz scaled by 4.0e9 */    dtemp = sdata->gsfEM4Specific.sampling_frequency - ((gsfuLong) sdata->gsfEM4Specific.sampling_frequency);    dtemp *= 4.0e9;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contains the scale factor value for the FM Doppler frequency correction */    ltemp = htonl((gsfuLong) sdata->gsfEM4Specific.doppler_corr_scale);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contains the "ROV depth" from the 0x66 datagram */    dtemp = sdata->gsfEM4Specific.vehicle_depth * 1000.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next 16 bytes are spare space for future use */    memset (p, 0, (size_t) 16);    p += 16;    /* The next two bytes contains the number of transmit sectors */    stemp = htons (sdata->gsfEM4Specific.transmit_sectors);    memcpy(p, &stemp, 2);    p += 2;    /* Now loop over the transmit sectors to encode the sector specific information */    for (i = 0; i < sdata->gsfEM4Specific.transmit_sectors; i++)    {        /* Next two bytes contains the tilt angle */        dtemp = sdata->gsfEM4Specific.sector[i].tilt_angle * 100.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        stemp = htons((gsfsShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* Next two bytes contains the focus range */        dtemp = sdata->gsfEM4Specific.sector[i].focus_range * 10.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        stemp = htons((gsfuShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* Next four bytes contains the signal length */        dtemp = sdata->gsfEM4Specific.sector[i].signal_length * 1.0e6;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* Next four bytes contains the transmit delay */        dtemp = sdata->gsfEM4Specific.sector[i].transmit_delay * 1.0e6;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* Next four bytes contains the center frequency */        dtemp = sdata->gsfEM4Specific.sector[i].center_frequency * 1.0e3;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* Next two bytes contains the mean absorption */        dtemp = sdata->gsfEM4Specific.sector[i].mean_absorption * 100.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        stemp = htons((gsfuShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* Next byte contains the signal wave form identifier */        *p = (unsigned char) sdata->gsfEM4Specific.sector[i].waveform_id;        p += 1;        /* Next byte contains the transmit sector number */        *p = (unsigned char) sdata->gsfEM4Specific.sector[i].sector_number;        p += 1;        /* Next four bytes contains the signal bandwidth */        dtemp = sdata->gsfEM4Specific.sector[i].signal_bandwidth * 1.0e3;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* The next 16 bytes are spare space for future use */        memset (p, 0, (size_t) 16);        p += 16;    }    /* The next 16 bytes are spare space for future use */    memset (p, 0, (size_t) 16);    p += 16;    /* Encode and write the run-time parameters.     *     * The next two byte value contains the em model number     */    stemp = htons(sdata->gsfEM4Specific.run_time.model_number);    memcpy(p, &stemp, 2);    p += 2;    /* First 8 bytes contain the time */    ltemp = htonl(sdata->gsfEM4Specific.run_time.dg_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    ltemp = htonl(sdata->gsfEM4Specific.run_time.dg_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* The next two byte value contains the sequential ping number */    stemp = htons(sdata->gsfEM4Specific.run_time.ping_counter);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the sonar head serial number */    stemp = htons(sdata->gsfEM4Specific.run_time.serial_number);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the operator station status */    *p = sdata->gsfEM4Specific.run_time.operator_station_status;    p += 1;    /* Next byte contains the processing unit status */    *p = sdata->gsfEM4Specific.run_time.processing_unit_status;    p += 1;    /* Next byte contains the BSP status */    *p = sdata->gsfEM4Specific.run_time.bsp_status;    p += 1;    /* Next byte contains the sonar head or transceiver status */    *p = sdata->gsfEM4Specific.run_time.head_transceiver_status;    p += 1;    /* The next one byte value contains the mode identifier */    *p = (unsigned char) sdata->gsfEM4Specific.run_time.mode;    p += 1;    /* The next one byte value contains the filter identifier */    *p = (unsigned char) sdata->gsfEM4Specific.run_time.filter_id;    p += 1;    /* The next two byte value contains the minimum depth */    dtemp = sdata->gsfEM4Specific.run_time.min_depth;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the maximum depth */    dtemp = sdata->gsfEM4Specific.run_time.max_depth;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the absorption coefficient */    dtemp = sdata->gsfEM4Specific.run_time.absorption * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the transmit pulse length in micro seconds */    dtemp = sdata->gsfEM4Specific.run_time.tx_pulse_length;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the transmit beam width */    dtemp = sdata->gsfEM4Specific.run_time.tx_beam_width * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next one byte value contains the transmit power reduction */    *p = (unsigned char) sdata->gsfEM4Specific.run_time.tx_power_re_max;    p += 1;    /* The next one byte value contains the receive beam width */    *p = (unsigned char) ((sdata->gsfEM4Specific.run_time.rx_beam_width * 10.0) + 0.501);    p += 1;    /* The next one byte value contains the receive band width in Hz. This value is     *  provided by the sonar with a precision of 50 hz.     */    *p = (unsigned char) ((sdata->gsfEM4Specific.run_time.rx_bandwidth / 50.0) + 0.501);    p += 1;    /* The next one byte value contains the receive gain */    *p = (unsigned char) sdata->gsfEM4Specific.run_time.rx_fixed_gain;    p += 1;    /* The next one byte value contains the TVG law cross-over angle */    *p = (unsigned char) sdata->gsfEM4Specific.run_time.tvg_cross_over_angle;    p += 1;    /* The next one byte value contains the source of the surface sound speed value */    *p = (unsigned char) sdata->gsfEM4Specific.run_time.ssv_source;    p += 1;    /* The next two byte value contains the maximum port swath width */    stemp = htons(sdata->gsfEM4Specific.run_time.max_port_swath_width);    memcpy(p, &stemp, 2);    p += 2;    /* The next one byte value contains the beam spacing value */    *p = (unsigned char) sdata->gsfEM4Specific.run_time.beam_spacing;    p += 1;    /* The next one byte value contains the port coverage in degrees */    *p = (unsigned char) sdata->gsfEM4Specific.run_time.max_port_coverage;    p += 1;    /* The next one byte value contains the yaw and pitch stabilization mode */    *p = (unsigned char) sdata->gsfEM4Specific.run_time.stabilization;    p += 1;    /* The next one byte value contains the starboard coverage in degrees */    *p = (unsigned char) sdata->gsfEM4Specific.run_time.max_stbd_coverage;    p += 1;    /* The next two byte value contains the maximum starboard swath width */    stemp = htons(sdata->gsfEM4Specific.run_time.max_stbd_swath_width);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the transmit along track tilt in degrees */    dtemp = sdata->gsfEM4Specific.run_time.tx_along_tilt * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next one byte value contains the filter ID 2, with the value for the penetration filter */    *p = (unsigned char) sdata->gsfEM4Specific.run_time.filter_id_2;    p += 1;    /* The next 16 bytes of space on the byte stream are spare space for future use. */    memset (p, 0, (size_t) 16);    p += 16;    /* Encode and write the PU status fields. */    /* The next one byte value contains the processor unit CPU load */    *p = (unsigned char) sdata->gsfEM4Specific.pu_status.pu_cpu_load;    p += 1;    /* The next two bytes contain a bit mask detailing valid/invalid status of sensor inputs */    stemp = htons(sdata->gsfEM4Specific.pu_status.sensor_status);    memcpy(p, &stemp, 2);    p += 2;    /* The next one byte value contains the achieved port coverage */    *p = (unsigned char) sdata->gsfEM4Specific.pu_status.achieved_port_coverage;    p += 1;    /* The next one byte value contains the achieved starboard coverage */    *p = (unsigned char) sdata->gsfEM4Specific.pu_status.achieved_stbd_coverage;    p += 1;    /* The next two bytes contain the yaw stabilization */    dtemp = sdata->gsfEM4Specific.pu_status.yaw_stabilization * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next 16 bytes are reserved for future use */    memset (p, 0, (size_t) 16);    p += 16;    return (p - sptr);}/********************************************************************** Function Name : EncodeKMALLSpecific** Description : This function encodes the Kongsberg kmall*  sensor specific information into external byte stream form.** Inputs :*    sptr = a pointer to an unsigned char buffer to write into*    sdata = a pointer to a union of sensor specific data.*    ft = a pointer to the gsf file table, this is used to determine*        is the run-time parameters should be written with this record.** Returns : This function returns the number of bytes encoded.** Error Conditions : none*********************************************************************/static intEncodeKMALLSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfsShort       sstemp;    gsfuLong        ltemp;    gsfuLong        ltemp_i;    gsfsLong        sltemp;    double          dtemp;    int             i = 0;    /* First byte contains a GSF sensor specific version number for this subrecord. This	 *  field, (gsfKMALLVersion) is a placeholder to support potential future growth.	 */    *p = 0;	p += 1;    /* Next byte contains an integer ID describing the MB datagram. */    *p = (unsigned char) sdata->gsfKMALLSpecific.dgmType;	p += 1;	/* Next byte contains an integer ID describing KMALL datagram version . */    *p = (unsigned char) sdata->gsfKMALLSpecific.dgmVersion;	p += 1;    /* The next byte contains the system id. */    *p = (unsigned char) sdata->gsfKMALLSpecific.systemID;    p += 1;	/* The next two bytes contain the echo sounder model */    stemp = htons((gsfuShort)sdata->gsfKMALLSpecific.echoSounderID);    memcpy(p, &stemp, 2);    p += 2;    /* The next eight bytes are spare */    memset(p, 0, (size_t) 8);    p += 8;    /* Next section is from the cmnPart */	/* The next two bytes contain the size of the CmnPart */    stemp = htons((gsfuShort)sdata->gsfKMALLSpecific.numBytesCmnPart);    memcpy(p, &stemp, 2);    p += 2;    /* The two bytes contain the ping counter */    stemp = htons((gsfuShort)sdata->gsfKMALLSpecific.pingCnt);    memcpy(p, &stemp, 2);    p += 2;    /* The next byte contains the number of recieve fans per ping */    *p = (unsigned char) sdata->gsfKMALLSpecific.rxFansPerPing;    p += 1;    /* The next byte contains the recieve fan index */    *p = (unsigned char) sdata->gsfKMALLSpecific.rxFanIndex;    p += 1;    /* The next byte contains the number of swaths per ping */    *p = (unsigned char) sdata->gsfKMALLSpecific.swathsPerPing;    p += 1;    /* The next byte contains the along ship index of this swath */    *p = (unsigned char) sdata->gsfKMALLSpecific.swathAlongPosition;    p += 1;    /* The next byte contains the transmitter index */    *p = (unsigned char) sdata->gsfKMALLSpecific.txTransducerInd;    p += 1;    /* The next byte contains the reciever index */    *p = (unsigned char) sdata->gsfKMALLSpecific.rxTransducerInd;    p += 1;    /* The next byte contains the number of recieve transducers */    *p = (unsigned char) sdata->gsfKMALLSpecific.numRxTransducers;    p += 1;    /* The next byte contains the algorithm type */    *p = (unsigned char) sdata->gsfKMALLSpecific.algorithmType;    p += 1;    /* The next sixteen bytes are spare */    memset(p, 0, (size_t) 16);    p += 16;    /* Next section is from the pingInfo */    /* The next two bytes contain the size of the ping info structure */    stemp = htons((gsfuShort) sdata->gsfKMALLSpecific.numBytesInfoData);    memcpy(p, &stemp, 2);    p += 2;    /* The next four bytes contains the ping rate, saved with a precision of 0.00001. */    dtemp = sdata->gsfKMALLSpecific.pingRate_Hz * 1.0e5;    dtemp += 0.501;	ltemp = htonl((gsfuLong) dtemp);    memcpy(p,&ltemp,4);    p += 4;    /* The next byte contains the beam spacing mode */    *p = (unsigned char) sdata->gsfKMALLSpecific.beamSpacing;    p += 1;    /* The next byte contains the depth mode */    *p = (unsigned char) sdata->gsfKMALLSpecific.depthMode;    p += 1;    /* The next byte contains the depth mode */    *p = (unsigned char) sdata->gsfKMALLSpecific.subDepthMode;    p += 1;    /* The next byte contains the distance between swaths */    *p = (unsigned char) sdata->gsfKMALLSpecific.distanceBtwSwath;    p += 1;    /* The next byte contains the detection mode */    *p = (unsigned char) sdata->gsfKMALLSpecific.detectionMode;    p += 1;    /* The next byte contains the pulse type */    *p = (unsigned char) sdata->gsfKMALLSpecific.pulseForm;    p += 1;    /* The four bytes contains the frequency mode */    dtemp = sdata->gsfKMALLSpecific.frequencyMode_Hz;	if (sdata->gsfKMALLSpecific.frequencyMode_Hz > 10000.0)    {        dtemp += 0.501;    }	ltemp = htonl((gsfsLong) dtemp);    memcpy(p,&ltemp,4);    p += 4;    /* The four bytes contains the lowest center frequency of all sectors for this swath */    dtemp = sdata->gsfKMALLSpecific.freqRangeLowLim_Hz * 1.0e3;	dtemp += 0.501;	ltemp = htonl((gsfuLong) dtemp);    memcpy(p,&ltemp,4);    p += 4;    /* The four bytes contains the highest center frequency of all sectors for this swath */    dtemp = sdata->gsfKMALLSpecific.freqRangeHighLim_Hz * 1.0e3;	dtemp += 0.501;	ltemp = htonl((gsfuLong) dtemp);    memcpy(p,&ltemp,4);    p += 4;    /* The four bytes contains the total signal length of the sector with the longest Tx pulse */    dtemp = (sdata->gsfKMALLSpecific.maxTotalTxPulseLength_sec * 1.0e6) + 0.501;	ltemp = htonl((gsfuLong) dtemp);    memcpy(p,&ltemp,4);    p += 4;    /* The four bytes contains the effective signal length (-3 dB) of the sector with the longest tx pulse */    dtemp = (sdata->gsfKMALLSpecific.maxEffTxPulseLength_sec * 1.0e6) + 0.501;	ltemp = htonl((gsfuLong) dtemp);    memcpy(p,&ltemp,4);    p += 4;    /* The four bytes contains the effective bandwidth (-3 dB) of the sector with the highest bandwith */    dtemp = (sdata->gsfKMALLSpecific.maxEffTxBandWidth_Hz * 1.0e3) + 0.501;	ltemp = htonl((gsfuLong) dtemp);    memcpy(p,&ltemp,4);    p += 4;    /* The four bytes contains the average absorption coefficient in dB/km */    dtemp = (sdata->gsfKMALLSpecific.absCoeff_dBPerkm * 1.0e3) + 0.501;	ltemp = htonl((gsfuLong) dtemp);    memcpy(p,&ltemp,4);    p += 4;    /* The two bytes contains the swath coverage to the port side in degrees */    dtemp = (sdata->gsfKMALLSpecific.portSectorEdge_deg * 1.0e2);	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sstemp = htons((gsfsShort) dtemp);    memcpy(p,&sstemp,2);    p += 2;    /* The two bytes contains the swath coverage to the starboard side in degrees */    dtemp = (sdata->gsfKMALLSpecific.starbSectorEdge_deg * 1.0e2);	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sstemp = htons((gsfsShort) dtemp);    memcpy(p,&sstemp,2);    p += 2;    /* The two bytes contains the swath coverage actually achieved to the port side in degrees */    dtemp = (sdata->gsfKMALLSpecific.portMeanCov_deg * 1.0e2);	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sstemp = htons((gsfsShort) dtemp);    memcpy(p,&sstemp,2);    p += 2;    /* The two bytes contains the swath coverage actually achieved to the starboard side in degrees */    dtemp = (sdata->gsfKMALLSpecific.starbMeanCov_deg * 1.0e2);	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sstemp = htons((gsfsShort) dtemp);    memcpy(p,&sstemp,2);    p += 2;    /* The two bytes contains the swath coverage actually achieved to the port side in degrees */    dtemp = (sdata->gsfKMALLSpecific.portMeanCov_deg * 1.0e2);	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sstemp = htons((gsfsShort) dtemp);    memcpy(p,&sstemp,2);    p += 2;    /* The two bytes contains the swath coverage actually achieved to the starboard side in degrees */    dtemp = (sdata->gsfKMALLSpecific.starbMeanCov_deg * 1.0e2);	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sstemp = htons((gsfsShort) dtemp);    memcpy(p,&sstemp,2);    p += 2;    /* The two bytes contains the swath coverage actually achieved to the port side, output from sonar as two byte value in whole meters */    dtemp = (sdata->gsfKMALLSpecific.portMeanCov_m);	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sstemp = htons((gsfsShort) dtemp);    memcpy(p,&sstemp,2);    p += 2;    /* The two bytes contains the swath coverage actually achieved to the starboard, output from sonar as two byte value in whole meters */    dtemp = (sdata->gsfKMALLSpecific.starbMeanCov_m);	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sstemp = htons((gsfsShort) dtemp);    memcpy(p,&sstemp,2);    p += 2;    /* The next byte contains the mode and stabilization settings */    *p = (unsigned char) sdata->gsfKMALLSpecific.modeAndStabilisation;    p += 1;    /* The next byte contains a first group of operator selectable filter settings */    *p = (unsigned char) sdata->gsfKMALLSpecific.runtimeFilter1;    p += 1;    /* The next byte contains a second group of operator selectable filter settings */    stemp = htons((gsfuShort) sdata->gsfKMALLSpecific.runtimeFilter2);    memcpy(p, &stemp, 2);    p += 2;    /* The next four bytes contains the pipe tracking status */    ltemp = (gsfuLong) sdata->gsfKMALLSpecific.pipeTrackingStatus;	ltemp = htonl(ltemp);    memcpy(p,&ltemp,4);    p += 4;    /* The next two bytes contain the transmit array size used */    dtemp = sdata->gsfKMALLSpecific.transmitArraySizeUsed_deg * 1.0e3;	dtemp += 0.501;	stemp = htons((gsfuShort) dtemp);    memcpy(p,&stemp,2);    p += 2;    /* The next two bytes contain the receive array size used */    dtemp = sdata->gsfKMALLSpecific.receiveArraySizeUsed_deg * 1.0e3;	dtemp += 0.501;	stemp = htons((gsfuShort) dtemp);    memcpy(p,&stemp,2);    p += 2;    /* The next two bytes contain the transmit power */    dtemp = sdata->gsfKMALLSpecific.transmitPower_dB * 1.0e2;	dtemp += 0.501;	sstemp = htons((gsfsShort) dtemp);    memcpy(p,&sstemp,2);    p += 2;    /* The next two bytes contain the source level ramp up time remaining */	stemp = htons((gsfuShort) sdata->gsfKMALLSpecific.SLrampUpTimeRemaining);    memcpy(p,&stemp,2);    p += 2;    /* The next four bytes contains the yaw angle applied */    dtemp = sdata->gsfKMALLSpecific.yawAngle_deg * 1.0e6;	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sltemp = htonl((gsfsLong) dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next two bytes contain the number of transmit sectors */	stemp = htons((gsfuShort) sdata->gsfKMALLSpecific.numTxSectors);    memcpy(p,&stemp,2);    p += 2;    /* The next two bytes contain the number of bytes per transmit sector */	stemp = htons((gsfuShort) sdata->gsfKMALLSpecific.numBytesPerTxSector);    memcpy(p,&stemp,2);    p += 2;    /* The next four bytes contains the heading of the vessel at the midpoint of the first Tx pulse */    dtemp = sdata->gsfKMALLSpecific.headingVessel_deg * 1.0e6;	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sltemp = htonl((gsfsLong) dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next four bytes contains the sound speed at transmit transducer depth at time of first tx pulse */    dtemp = sdata->gsfKMALLSpecific.soundSpeedAtTxDepth_mPerSec * 1.0e6;	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sltemp = htonl((gsfsLong) dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next four bytes contains the Tx transducer depth below the waterline at the time of the first tx pulse */    dtemp = sdata->gsfKMALLSpecific.txTransducerDepth_m * 1.0e6;	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sltemp = htonl((gsfsLong) dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next four bytes contains the distance between the water line and the vessel reference point in meters at the time of first tx pulse */    dtemp = sdata->gsfKMALLSpecific.z_waterLevelReRefPoint_m * 1.0e6;	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sltemp = htonl((gsfsLong) dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next four bytes contains the X distance between .all reference point and the .kmall reference point */    dtemp = sdata->gsfKMALLSpecific.x_kmallToall_m * 1.0e6;	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sltemp = htonl((gsfsLong) dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next four bytes contains the Y distance between .all reference point and the .kmall reference point */    dtemp = sdata->gsfKMALLSpecific.y_kmallToall_m * 1.0e6;	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sltemp = htonl((gsfsLong) dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next byte contains the method of position determination */    *p = (unsigned char) sdata->gsfKMALLSpecific.latLongInfo;    p += 1;    /* The next byte contains the status of the active positioning sensor */    *p = (unsigned char) sdata->gsfKMALLSpecific.posSensorStatus;    p += 1;    /* The next byte contains the status of the active attitude sensor */    *p = (unsigned char) sdata->gsfKMALLSpecific.attitudeSensorStatus;    p += 1;    /* The next four bytes contains the latitude of the RP at the time of the first pulse */    dtemp = sdata->gsfKMALLSpecific.latitude_deg * 1.0e7;	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sltemp = htonl((gsfsLong) dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next four bytes contains the longitude of the RP at the time of the first pulse */    dtemp = sdata->gsfKMALLSpecific.longitude_deg * 1.0e7;	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sltemp = htonl((gsfsLong) dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next four bytes contains the ellipsoidal height of the RP at the time of the first pulse */    dtemp = sdata->gsfKMALLSpecific.ellipsoidHeightReRefPoint_m * 1.0e3;	if (dtemp < 0.0)	{		dtemp -= 0.501;	}	else	{		dtemp += 0.501;	}	sltemp = htonl((gsfsLong) dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next thirty two bytes are spare */    memset(p, 0, (size_t) 32);    p += 32;    /* Now loop over the transmit sectors to encode the sector specific information */    for(i = 0; i < sdata->gsfKMALLSpecific.numTxSectors; ++i)    {        /* The next byte contains the sector number */        *p = (unsigned char) sdata->gsfKMALLSpecific.sector[i].txSectorNumb;        p += 1;        /* The next byte contains the array number */        *p = (unsigned char) sdata->gsfKMALLSpecific.sector[i].txArrNumber;        p += 1;        /* The next byte contains the subarray number */        *p = (unsigned char) sdata->gsfKMALLSpecific.sector[i].txSubArray;        p += 1;        /* The next four bytes contain the sector delay */        dtemp = sdata->gsfKMALLSpecific.sector[i].sectorTransmitDelay_sec * 1.0e6;        if(dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong)dtemp);        memcpy(p,&ltemp,4);        p += 4;        /* The next four bytes contain the tilt angle */        dtemp = sdata->gsfKMALLSpecific.sector[i].tiltAngleReTx_deg * 1.0e6;        if(dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        sltemp = htonl((gsfsLong)dtemp);        memcpy(p,&sltemp,4);        p += 4;        /* The next four bytes contain the nominal source level */        dtemp = sdata->gsfKMALLSpecific.sector[i].txNominalSourceLevel_dB * 1.0e6;        if(dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        sltemp = htonl((gsfsLong)dtemp);        memcpy(p,&sltemp,4);        p += 4;        /* The next four bytes contain the focus range */        dtemp = sdata->gsfKMALLSpecific.sector[i].txFocusRange_m * 1.0e3;        if(dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong)dtemp);        memcpy(p,&ltemp,4);        p += 4;        /* The next four bytes contain the center frequency */        dtemp = sdata->gsfKMALLSpecific.sector[i].centreFreq_Hz * 1.0e3;        if(dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong)dtemp);        memcpy(p,&ltemp,4);        p += 4;        /* The next four bytes contain the signal bandwidth */        dtemp = sdata->gsfKMALLSpecific.sector[i].signalBandWidth_Hz * 1.0e3;        if(dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong)dtemp);        memcpy(p,&ltemp,4);        p += 4;        /* The next four bytes contain the signal length */        dtemp = sdata->gsfKMALLSpecific.sector[i].totalSignalLength_sec * 1.0e6;        if(dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong)dtemp);        memcpy(p,&ltemp,4);        p += 4;        /* The next byte contains the pulse shading */        *p = (unsigned char) sdata->gsfKMALLSpecific.sector[i].pulseShading;        p += 1;        /* The next byte contains the signal waveform */        *p = (unsigned char) sdata->gsfKMALLSpecific.sector[i].signalWaveForm;        p += 1;        /* The next four bytes contain the high voltage level */        dtemp = sdata->gsfKMALLSpecific.sector[i].highVoltageLevel_dB * 1.0e6;        if(dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        sltemp = htonl((gsfsLong)dtemp);        memcpy(p,&sltemp,4);        p += 4;        /* The next four bytes contain the sector tracking correction level */        dtemp = sdata->gsfKMALLSpecific.sector[i].sectorTrackiongCorr_dB * 1.0e6;        if(dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        sltemp = htonl((gsfsLong)dtemp);        memcpy(p,&sltemp,4);        p += 4;        /* The next four bytes contain the effective signal length in seconds */        dtemp = sdata->gsfKMALLSpecific.sector[i].effectiveSignalLength_sec * 1.0e6;        if(dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        sltemp = htonl((gsfsLong)dtemp);        memcpy(p,&sltemp,4);        p += 4;        /* The next 8 bytes are our spare for later use */        memset(p,0,(size_t)8);        p += 8;    }    /* Next section is the rxInfo data */    /* The next two bytes contain the number of bytes in the RxInfo structure */    stemp = htons(sdata->gsfKMALLSpecific.numBytesRxInfo);    memcpy(p,&stemp,2);    p += 2;    /* The next two bytes contain the number of soundings, extra detections excluded */    stemp = htons(sdata->gsfKMALLSpecific.numSoundingsMaxMain);    memcpy(p,&stemp,2);    p += 2;    /* The next two bytes contain the number of valid soundings, extra detections excluded */    stemp = htons(sdata->gsfKMALLSpecific.numSoundingsValidMain);    memcpy(p,&stemp,2);    p += 2;    /* The next two bytes contain the number of bytes per element of the EMdgmMrZ_sounding_def */    stemp = htons(sdata->gsfKMALLSpecific.numBytesPerSounding);    memcpy(p,&stemp,2);    p += 2;    /* The next four bytes contain the integer portion of the water column sample rate */    ltemp_i = (gsfuLong) sdata->gsfKMALLSpecific.WCSampleRate;    ltemp = htonl((gsfuLong)ltemp_i);    memcpy(p,&ltemp,4);    p += 4;    /* The next four bytes contain the fractional portion of the water column sample rate */    dtemp = (sdata->gsfKMALLSpecific.WCSampleRate - (double) ltemp_i) * 1.0e9;    if(dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }	ltemp = htonl((gsfuLong)dtemp);    memcpy(p,&ltemp,4);    p += 4;    /* The next four bytes contain the integer portion of the seabed image sample rate */    ltemp_i = (gsfuLong) sdata->gsfKMALLSpecific.seabedImageSampleRate;    ltemp = htonl((gsfuLong)ltemp_i);    memcpy(p,&ltemp,4);    p += 4;    /* The next four bytes contain the fractional portion of the seabed image sample rate */    dtemp = (sdata->gsfKMALLSpecific.seabedImageSampleRate - (double) ltemp_i) * 1.0e9;    if(dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }	ltemp = htonl((gsfuLong)dtemp);    memcpy(p,&ltemp,4);    p += 4;    /* The next four bytes contain the backscatter level at normal incidence */    dtemp = sdata->gsfKMALLSpecific.BSnormal_dB * 1.0e6;    if(dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    sltemp = htonl((gsfsLong)dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next four bytes contain the backscatter level at oblique incidence */    dtemp = sdata->gsfKMALLSpecific.BSoblique_dB * 1.0e6;    if(dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    sltemp = htonl((gsfsLong)dtemp);    memcpy(p,&sltemp,4);    p += 4;    /* The next two bytes contain the sum of alarm flags for extra detections */    stemp = htons(sdata->gsfKMALLSpecific.extraDetectionAlarmFlag);    memcpy(p,&stemp,2);    p += 2;    /* The next two bytes contain the number of extra detections */    stemp = htons(sdata->gsfKMALLSpecific.numExtraDetections);    memcpy(p,&stemp,2);    p += 2;    /* The next two bytes contain the number of extra detection classes */    stemp = htons(sdata->gsfKMALLSpecific.numExtraDetectionClasses);    memcpy(p,&stemp,2);    p += 2;    /* The next two bytes contain the number of bytes per extra detection class */    stemp = htons(sdata->gsfKMALLSpecific.numBytesPerClass);    memcpy(p,&stemp,2);    p += 2;    /* The next 32 bytes are our spare for later use */    memset(p,0,(size_t)32);    p += 32;    /* Now loop over the extra detection classes */    for(i = 0; i < sdata->gsfKMALLSpecific.numExtraDetectionClasses; ++i)    {        /* The next 2 bytes contain the number of extra detections of this class */        stemp = htons(sdata->gsfKMALLSpecific.extraDetClassInfo[i].numExtraDetInClass);        memcpy(p,&stemp,2);        p += 2;        /* The next byte contains the alarm flag */        *p = (unsigned char) sdata->gsfKMALLSpecific.extraDetClassInfo[i].alarmFlag;        p += 1;        /* The next 32 bytes are our spare for later use */        memset(p,0,(size_t)32);        p += 32;    }    /* The next 32 bytes are our spare for later use */    memset(p,0,(size_t)32);    p += 32;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeGeoSwathPlusSpecific * * Description : This function encodes the GeoAcoustic GS+ *  sensor specific information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeGeoSwathPlusSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;    double          dtemp;    /* First 2 bytes contain the data source (0 = CBF, 1 = RDF) */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.data_source);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the ping side (0 port, 1 = stbd)  */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.side);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the model number  */    stemp = htons(sdata->gsfGeoSwathPlusSpecific.model_number);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the frequency (Hz) */    dtemp = (sdata->gsfGeoSwathPlusSpecific.frequency / 10.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the echosounder type */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.echosounder_type);    memcpy(p, &stemp, 2);    p += 2;    /* Next 4 bytes contain the ping number */    ltemp = htonl(sdata->gsfGeoSwathPlusSpecific.ping_number);    memcpy(p, &ltemp, 4);    p += 4;    /* Next 2 bytes contain the num_nav_samples */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_nav_samples);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the num_attitude_samples */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_attitude_samples);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the num_heading_samples */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_heading_samples);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the num_miniSVS_samples */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_miniSVS_samples);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the num_echosounder_samples */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_echosounder_samples);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the num_raa_samples (range-angle-amplitude) */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_raa_samples);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the mean SV (m/s) */    dtemp = (sdata->gsfGeoSwathPlusSpecific.mean_sv * 20.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the surface velocity (m/s)  */    dtemp = (sdata->gsfGeoSwathPlusSpecific.surface_velocity * 20.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the number of valid beams  */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.valid_beams);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the sample rate (Hz) */    dtemp = (sdata->gsfGeoSwathPlusSpecific.sample_rate / 10.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the pulse length (usec) */    dtemp = sdata->gsfGeoSwathPlusSpecific.pulse_length;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the ping length (m) */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.ping_length);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the transmit power (dB) */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.transmit_power);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the sidescan gain channel (0 - 3) */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.sidescan_gain_channel);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the stabilization flag (0 or 1) */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.stabilization);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the GPS quality */    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.gps_quality);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the range uncertainty. */    dtemp = (sdata->gsfGeoSwathPlusSpecific.range_uncertainty * 1000.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the angle uncertainty. */    dtemp = (sdata->gsfGeoSwathPlusSpecific.angle_uncertainty * 100.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next 32 bytes are spare, but are preserved for the future */    memcpy (p, &sdata->gsfGeoSwathPlusSpecific.spare, sizeof (unsigned char) * 32);    p += 32;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeKlein5410BssSpecific * * Description : This function encodes the Klein 5410 Bathy Sidescan *  sensor specific information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeKlein5410BssSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;    double          dtemp;    /* First 2 bytes contain the data source (0 = SDF) */    stemp = htons((gsfuShort) sdata->gsfKlein5410BssSpecific.data_source);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the ping side (0 port, 1 = stbd)  */    stemp = htons((gsfuShort) sdata->gsfKlein5410BssSpecific.side);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the sonar model number  */    stemp = htons((gsfuShort) sdata->gsfKlein5410BssSpecific.model_number);    memcpy(p, &stemp, 2);    p += 2;    /* Next four bytes contain the system frequency */    dtemp = sdata->gsfKlein5410BssSpecific.acoustic_frequency * 1.0e03;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contain the sampling frequency */    dtemp = sdata->gsfKlein5410BssSpecific.sampling_frequency * 1.0e03;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contain the ping number */    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.ping_number);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contain the total number of samples in the ping */    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.num_samples);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contain the number of valid range, angle, amplitude    samples in the ping */    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.num_raa_samples);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contain the error flags */    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.error_flags);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contain the range */    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.range);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contain the reading from the towfish pressure sensor in Volts */    dtemp = sdata->gsfKlein5410BssSpecific.fish_depth * 1.0e03;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contain the towfish altitude in m */    dtemp = sdata->gsfKlein5410BssSpecific.fish_altitude * 1.0e03;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four bytes contain the speed of sound at the transducer face in m/sec */    dtemp = sdata->gsfKlein5410BssSpecific.sound_speed * 1.0e03;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next 2 bytes contain the transmit pulse waveform number */    stemp = htons((gsfuShort) sdata->gsfKlein5410BssSpecific.tx_waveform);    memcpy(p, &stemp, 2);    p += 2;    /* Next 2 bytes contain the altimeter status: 0 = passive, 1 = active  */    stemp = htons((gsfuShort) sdata->gsfKlein5410BssSpecific.altimeter);    memcpy(p, &stemp, 2);    p += 2;    /* Next four bytes contain the raw data configuration */    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.raw_data_config);    memcpy(p, &ltemp, 4);    p += 4;    /* Next 32 bytes are spare, but are reserved for the future */    memcpy (p, &sdata->gsfKlein5410BssSpecific.spare, sizeof (unsigned char) * 32);    p += 32;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeReson8100Specific * * Description : This function encodes the Reson 8100 sensor specific *  information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeReson8100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;    double          dtemp;    /* First two byte integer contains the sonar latency */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.latency);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the ping number */    ltemp = htonl((gsfuLong) sdata->gsfReson8100Specific.ping_number);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the sonar id */    ltemp = htonl((gsfuLong) sdata->gsfReson8100Specific.sonar_id);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the sonar model */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.sonar_model);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sonar frequency */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.frequency);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sea surface sound speed * 10 */    dtemp = sdata->gsfReson8100Specific.surface_velocity * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sample rate */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.sample_rate);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the ping rate */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.ping_rate);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sonar mode of operation */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.mode);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sonar range setting */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.range);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the power setting */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.power);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the gain setting */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.gain);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the pulse width, in microseconds */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.pulse_width);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the tvg spreading coefficient * 4 */    *p = (unsigned char) (sdata->gsfReson8100Specific.tvg_spreading);    p += 1;    /* Next byte contains the tvg absorption coefficient */    *p = (unsigned char) (sdata->gsfReson8100Specific.tvg_absorption);    p += 1;    /* Next byte contains the fore/aft beam width */    *p = (unsigned char) ((sdata->gsfReson8100Specific.fore_aft_bw * 10.0) + 0.501);    p += 1;    /* Next byte contains the athwartships beam width */    *p = (unsigned char) ((sdata->gsfReson8100Specific.athwart_bw * 10.0) + 0.501);    p += 1;    /* Next byte contains the projector type */    *p = (unsigned char) (sdata->gsfReson8100Specific.projector_type);    p += 1;    /* Next two byte integer contains the projector angle, in deg * 100 */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.projector_angle);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the range filter min */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.range_filt_min);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the range filter max */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.range_filt_max);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the depth filter min */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.depth_filt_min);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the depth filter max */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.depth_filt_max);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the filters active flags */    *p = (unsigned char) (sdata->gsfReson8100Specific.filters_active);    p += 1;    /* Next two byte integer contains the temperature at the sonar head */    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.temperature);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the across track angular beam spacing * 10000 */    dtemp = sdata->gsfReson8100Specific.beam_spacing * 10000.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes are reserved as spare space. */    *p = (unsigned char) (sdata->gsfReson8100Specific.spare[0]);    p += 1;    *p = (unsigned char) (sdata->gsfReson8100Specific.spare[1]);    p += 1;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeReson7100Specific * * Description : This function encodes the Reson 7100 sensor specific *   information into external byte stream form. * * Inputs : *   sptr = a pointer to an unsigned char buffer to write into *   sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeReson7100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;    double          dtemp;    /* First two bytes contains the data format definition version number */    stemp = htons((gsfuShort) sdata->gsfReson7100Specific.protocol_version);    memcpy(p, &stemp, 2);    p += 2;    /* The next four bytes contains the sonar device ID */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.device_id);    memcpy(p, &ltemp, 4);    p += 4;    /* The next 16 bytes are spare space for future growth */    memset(p, 0, 16);    p += 16;    /* The next four byte integer contains the high order four bytes of the sonar serial number */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.major_serial_number);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four byte integer contains the low order four bytes of the sonar id */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.minor_serial_number);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the ping number */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.ping_number);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the multi_ping_sequence */    stemp = htons((gsfuShort) sdata->gsfReson7100Specific.multi_ping_seq);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the sonar frequency in Hz * 1,000.0 */    dtemp = (sdata->gsfReson7100Specific.frequency * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the sample rate in Hz * 10,000.0 */    dtemp = (sdata->gsfReson7100Specific.sample_rate * 1.0e4) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the receiver bandwidth, in Hz * 10,000.0 */    dtemp = (sdata->gsfReson7100Specific.receiver_bandwdth * 1.0e4) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the pulse length, in seconds * 10,000,000.0 */    dtemp = (sdata->gsfReson7100Specific.tx_pulse_width * 1.0e7) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the pulse type id */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.tx_pulse_type_id);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the pulse envelope id */    ltemp = htonl((gsfuShort) sdata->gsfReson7100Specific.tx_pulse_envlp_id);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the pulse envelope parameter */    dtemp = (sdata->gsfReson7100Specific.tx_pulse_envlp_param * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains additional pulse information */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.tx_pulse_reserved);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the maximum ping rate in pings/second * 1,000,000.0 */    dtemp = (sdata->gsfReson7100Specific.max_ping_rate * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the ping period in seconds since last ping * 1,000,000.0 */    dtemp = (sdata->gsfReson7100Specific.ping_period * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the sonar range setting in meters * 100.0 */    dtemp = (sdata->gsfReson7100Specific.range * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the power setting * 100.0 */    dtemp = (sdata->gsfReson7100Specific.power * 1.0e2);    if (dtemp < 0.0)    {        dtemp = dtemp - 0.501;    }    else    {        dtemp = dtemp + 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the gain setting * 100.0 */    dtemp = (sdata->gsfReson7100Specific.gain * 1.0e2);    if (dtemp < 0.0)    {        dtemp = dtemp - 0.501;    }    else    {        dtemp = dtemp + 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the control flags */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.control_flags);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the projector type */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.projector_id);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the projector steering angle, in deg * 1000.0 */    dtemp = (sdata->gsfReson7100Specific.projector_steer_angl_vert * 1.0e3);    if (dtemp < 0.0)    {        dtemp = dtemp - 0.501;    }    else    {        dtemp = dtemp + 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the projector steering angle, in deg * 1000.0 */    dtemp = (sdata->gsfReson7100Specific.projector_steer_angl_horz * 1.0e3);    if (dtemp < 0.0)    {        dtemp = dtemp - 0.501;    }    else    {        dtemp = dtemp + 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the fore/aft beam width in degrees * 100.0 */    dtemp = (sdata->gsfReson7100Specific.projector_beam_wdth_vert * 1.0e2) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the athwartships beam width in degrees * 100.0 */    dtemp = (sdata->gsfReson7100Specific.projector_beam_wdth_horz * 1.0e2) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the projector beam focal point in meters * 100.0 */    dtemp = (sdata->gsfReson7100Specific.projector_beam_focal_pt * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the projector beam weighting window type */    ltemp = htonl ((gsfuLong) sdata->gsfReson7100Specific.projector_beam_weighting_window_type);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the projector beam weighting window parameter */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.projector_beam_weighting_window_param);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the transmit flags */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.transmit_flags);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the hydrophone type */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.hydrophone_id);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the receive beam weighting window type */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.receiving_beam_weighting_window_type);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the receive beam weighting window param */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.receiving_beam_weighting_window_param);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the receive flags */    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.receive_flags);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte value contains the receive beam width in degrees * 100.0 */    dtemp = (sdata->gsfReson7100Specific.receive_beam_width * 1.0e2) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte value contains the range filter min in meters * 10 */    dtemp = (sdata->gsfReson7100Specific.range_filt_min * 1.0e1) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte value contains the range filter max in meters * 10 */    dtemp = (sdata->gsfReson7100Specific.range_filt_max * 1.0e1) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte value contains the depth filter min in meters * 10 */    dtemp = (sdata->gsfReson7100Specific.depth_filt_min * 1.0e1) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte value contains the depth filter max in meters * 10 */    dtemp = (sdata->gsfReson7100Specific.depth_filt_max * 1.0e1) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte value contains the absorption in dB/kilometer * 1,000.0 */    dtemp = (sdata->gsfReson7100Specific.absorption * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the sound velocity * 10 */    dtemp = (sdata->gsfReson7100Specific.sound_velocity * 1.0e1) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the spreading loss in dB * 1,000.0 */    dtemp = (sdata->gsfReson7100Specific.spreading * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;     /* The next byte contains the inverted beam angle flag*/    *p = sdata->gsfReson7100Specific.raw_data_from_7027;    p += 1;    /* The next 15 bytes are spare space for future growth */    memset(p, 0, 15);    p += 15;    /* The next byte contains the sv source */    *p = sdata->gsfReson7100Specific.sv_source;    p += 1;    /* The next byte contains the layer compensation flag */    *p = sdata->gsfReson7100Specific.layer_comp_flag;    p += 1;    /* The next 8 bytes are spare space for future growth */    memset(p, 0, 8);    p += 8;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeResonTSeriesSpecific * * Description : This function encodes the Reson T series *   sensor-specific information into external byte stream form. * * Inputs : *   sptr = a pointer to an unsigned char buffer to write into. *   sdata = a pointer to a union of sensor specific data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeResonTSeriesSpecific(unsigned char *sptr, gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;	gsfsLong        sltemp;    double          dtemp;    /* First two bytes contains the data format definition version number */    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.protocol_version);    memcpy(p, &stemp, 2);    p += 2;    /* The next four bytes contains the sonar device ID */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.device_id);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contain the number of devices */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.number_devices);    memcpy(p, &ltemp, 4);    p += 4;    /* The next 2 bytes contain the system enumerator */    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.system_enumerator);    memcpy(p, &stemp, 2);    p += 2;    /* The next 10 bytes are spare space for future growth */    memset(p, 0, 10);    p += 10;    /* The next four byte integer contains the high order four bytes of the sonar serial number */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.major_serial_number);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four byte integer contains the low order four bytes of the sonar id */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.minor_serial_number);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the ping number */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.ping_number);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the multi_ping_sequence */    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.multi_ping_seq);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the sonar frequency in Hz * 1,000.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.frequency * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the sample rate in Hz * 10,000.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.sample_rate * 1.0e4) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the receiver bandwidth, in Hz * 10,000.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.receiver_bandwdth * 1.0e4) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the pulse length, in seconds * 10,000,000.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.tx_pulse_width * 1.0e7) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the pulse type id */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.tx_pulse_type_id);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the pulse envelope id */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.tx_pulse_envlp_id);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the pulse envelope parameter */    dtemp = (sdata->gsfResonTSeriesSpecific.tx_pulse_envlp_param * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the multi_ping_sequence */    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.tx_pulse_mode);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains additional pulse information */    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.tx_pulse_reserved);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the maximum ping rate in pings/second * 1,000,000.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.max_ping_rate * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the ping period in seconds since last ping * 1,000,000.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.ping_period * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the sonar range setting in meters * 100.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.range * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the power setting * 100.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.power * 1.0e2);    if (dtemp < 0.0)    {        dtemp = dtemp - 0.501;    }    else    {        dtemp = dtemp + 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the gain setting * 100.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.gain * 1.0e2);    if (dtemp < 0.0)    {        dtemp = dtemp - 0.501;    }    else    {        dtemp = dtemp + 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the control flags */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.control_flags);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the projector type */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.projector_id);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the projector steering angle, in deg * 1000.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.projector_steer_angl_vert * 1.0e3);    if (dtemp < 0.0)    {        dtemp = dtemp - 0.501;    }    else    {        dtemp = dtemp + 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the projector steering angle, in deg * 1000.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.projector_steer_angl_horz * 1.0e3);    if (dtemp < 0.0)    {        dtemp = dtemp - 0.501;    }    else    {        dtemp = dtemp + 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the fore/aft beam width in degrees * 100.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.projector_beam_wdth_vert * 1.0e2) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the athwartships beam width in degrees * 100.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.projector_beam_wdth_horz * 1.0e2) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the projector beam focal point in meters * 100.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.projector_beam_focal_pt * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the projector beam weighting window type */    ltemp = htonl ((gsfuLong) sdata->gsfResonTSeriesSpecific.projector_beam_weighting_window_type);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the projector beam weighting window parameter */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.projector_beam_weighting_window_param);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the transmit flags */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.transmit_flags);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the hydrophone type */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.hydrophone_id);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the receive beam weighting window type */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.receiving_beam_weighting_window_type);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the receive beam weighting window param */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.receiving_beam_weighting_window_param);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the receive flags */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.receive_flags);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte value contains the receive beam width in degrees * 100.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.receive_beam_width * 1.0e2) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte value contains the range filter min in meters * 10 */    dtemp = (sdata->gsfResonTSeriesSpecific.range_filt_min * 1.0e1) + 0.501;    sltemp = htonl((gsfsLong) dtemp);    memcpy(p, &sltemp, 4);    p += 4;    /* Next four byte value contains the range filter max in meters * 10 */    dtemp = (sdata->gsfResonTSeriesSpecific.range_filt_max * 1.0e1) + 0.501;    sltemp = htonl((gsfsLong) dtemp);    memcpy(p, &sltemp, 4);    p += 4;    /* Next four byte value contains the depth filter min in meters * 10 */    if (sdata->gsfResonTSeriesSpecific.depth_filt_min < 0.0) {        dtemp = (sdata->gsfResonTSeriesSpecific.depth_filt_min * 1.0e1) - 0.501;    } else {        dtemp = (sdata->gsfResonTSeriesSpecific.depth_filt_min * 1.0e1) + 0.501;    }    sltemp = htonl((gsfsLong) dtemp);    memcpy(p, &sltemp, 4);    p += 4;    /* Next four byte value contains the depth filter max in meters * 10 */    dtemp = (sdata->gsfResonTSeriesSpecific.depth_filt_max * 1.0e1) + 0.501;    sltemp = htonl((gsfsLong) dtemp);    memcpy(p, &sltemp, 4);    p += 4;    /* Next four byte value contains the absorption in dB/kilometer * 1,000.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.absorption * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the sound velocity * 10 */    dtemp = (sdata->gsfResonTSeriesSpecific.sound_velocity * 1.0e1) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next byte contains the sv source */    *p = sdata->gsfResonTSeriesSpecific.sv_source;    p += 1;    /* Next four byte integer contains the spreading loss in dB * 1,000.0 */    dtemp = (sdata->gsfResonTSeriesSpecific.spreading * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the beam spacing mode */    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.beam_spacing_mode);    memcpy(p, &stemp, 2);    p += 2;    /* Next two byte integer contains the sonar source mode */    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.sonar_source_mode);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the coverage mode */    *p = sdata->gsfResonTSeriesSpecific.coverage_mode;    p += 1;    /* Next four byte integer contains the coverage angle in degrees * 100 */    dtemp = (sdata->gsfResonTSeriesSpecific.coverage_angle * 1.0e2);    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the horizontal receiver steering angle in degrees * 100 */    dtemp = (sdata->gsfResonTSeriesSpecific.horizontal_receiver_steering_angle * 1.0e2);    if (dtemp < 0.0)    {        dtemp = dtemp - 0.501;    }    else    {        dtemp = dtemp + 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next 3 bytes are spare space for future growth */    memset(p, 0, 3);    p += 3;    /* Next four byte integer contains the uncertainty type */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.uncertainty_type);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains transmitter steering angle*/    dtemp = (sdata->gsfResonTSeriesSpecific.transmitter_steering_angle * 1.0e5);    if (dtemp < 0.0)    {        dtemp = dtemp - 0.501;    }    else    {        dtemp = dtemp + 0.501;    }    sltemp = htonl((gsfsLong) dtemp);    memcpy(p, &sltemp, 4);    p += 4;    /* Next four byte integer contains applied roll information*/    dtemp = (sdata->gsfResonTSeriesSpecific.applied_roll * 1.0e5);    if (dtemp < 0.0)    {        dtemp = dtemp - 0.501;    }    else    {        dtemp = dtemp + 0.501;    }    sltemp = htonl((gsfsLong) dtemp);    memcpy(p, &sltemp, 4);    p += 4;    /* Next two byte integer contains the detection_algorithm */    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.detection_algorithm);    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains detection flags */    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.detection_flags);    memcpy(p, &ltemp, 4);    p += 4;    /* The next 60 bytes are the module description */    memcpy(p, (unsigned char *) sdata->gsfResonTSeriesSpecific.device_description, 60);    p += 60;    /* Next four byte integer contains sound speed with higher precision*/    dtemp = (sdata->gsfResonTSeriesSpecific.sound_velocity * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next 60 bytes are spare space for future growth in the 7027 datagram*/    memset(p, 0, 60);    p += 60;        /* Next byte contains the operation field for the match filter */    *p = (unsigned char)sdata->gsfResonTSeriesSpecific.match_filter_control;    p += 1;        /* Next four byte integer contains the start frequency for the match filter in Hz */    dtemp = (sdata->gsfResonTSeriesSpecific.match_filter_start_freq * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;        /* Next four byte integer contains the end frequency for the match filter in Hz */    dtemp = (sdata->gsfResonTSeriesSpecific.match_filter_end_freq * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;        /* Next byte contains the window type for the match filter */    *p = (unsigned char)sdata->gsfResonTSeriesSpecific.match_filter_window_type;    p += 1;        /* Next four byte integer contains the shading value for the match filter */    dtemp = (sdata->gsfResonTSeriesSpecific.match_filter_shading_value * 1.0e4) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;        /* Next four byte integer contains the effective pulse width for the match filter in seconds */    dtemp = (sdata->gsfResonTSeriesSpecific.match_filter_effect_pulse_width * 1.0e11) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next 52 bytes are spare space for future growth in the 7002 datagram */    memset(p, 0, sizeof(unsigned int) * 13);    p += 52;        /* The next 32 bytes are spare space for future growth */    memset(p, 0, 32);    p += 32;        /* The next 264 bytes are spare space for future growth */    memset(p, 0, 288);    p += 288;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeDeltaTSpecific * * Description : This function encodes the Imagenex Delta T *  sensor specific information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeDeltaTSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;    double          dtemp;    /* The next four bytes contains the file extension */    memcpy (p, (unsigned char *) (sdata->gsfDeltaTSpecific.decode_file_type), 4);    p += 4;    /* The next byte contains the version number */    *p = (unsigned char) sdata->gsfDeltaTSpecific.version;    p += 1;    /* The next two bytes contains the ping byte size field */    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.ping_byte_size);    memcpy(p, &stemp, 2);    p += 2;    /* Next 8 bytes contains the original sonar interrogation time */    ltemp = htonl(sdata->gsfDeltaTSpecific.interrogation_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    ltemp = htonl(sdata->gsfDeltaTSpecific.interrogation_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* The next two bytes contains the samples per beam field */    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.samples_per_beam);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contains the sector size field */    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.sector_size);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contains the start angle field. */    dtemp = ((sdata->gsfDeltaTSpecific.start_angle + 180.0) * 100.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contains the angle increment field. */    dtemp = ((sdata->gsfDeltaTSpecific.angle_increment) * 100.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contains the acoustic range field */    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.acoustic_range);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contains the acoustic frequency field */    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.acoustic_frequency);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contains the sound speed field. */    dtemp = ((sdata->gsfDeltaTSpecific.sound_velocity) * 10.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contains the range resolution field. */    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.range_resolution);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contains the profile tilt field. */    dtemp = ((sdata->gsfDeltaTSpecific.profile_tilt_angle) + 180.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contains the repetition rate field. */    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.repetition_rate);    memcpy(p, &stemp, 2);    p += 2;    /* The next four bytes contains the ping number field */    ltemp = htonl((gsfuLong) sdata->gsfDeltaTSpecific.ping_number);    memcpy(p, &ltemp, 4);    p += 4;    /* The next byte contains the intensity flag field. */    *p = (unsigned char) sdata->gsfDeltaTSpecific.intensity_flag;    p += 1;    /* The next two bytes contains the ping latency field. */    dtemp = ((sdata->gsfDeltaTSpecific.ping_latency) * 10000.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes contains the data latency field. */    dtemp = ((sdata->gsfDeltaTSpecific.data_latency) * 10000.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next byte contains the sample rate flag field. */    *p = (unsigned char) sdata->gsfDeltaTSpecific.sample_rate_flag;    p += 1;    /* The next byte contains the option flags field. */    *p = (unsigned char) sdata->gsfDeltaTSpecific.option_flags;    p += 1;    /* The next byte contains the number of pings averaged field. */    *p = (unsigned char) sdata->gsfDeltaTSpecific.num_pings_avg;    p += 1;    /* The next two bytes contains the center ping time offset field. */    dtemp = ((sdata->gsfDeltaTSpecific.center_ping_time_offset) * 10000.0) + 0.501;    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next byte contains the user defined byte field. */    *p = (unsigned char) sdata->gsfDeltaTSpecific.user_defined_byte;    p += 1;    /* Next four byte integer contains the altitude field.*/    dtemp = ((sdata->gsfDeltaTSpecific.altitude) * 100.0) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next byte contains the external sensor flags field. */    *p = (unsigned char) sdata->gsfDeltaTSpecific.external_sensor_flags;    p += 1;    /* Next four byte integer contains the pulse length field.*/    dtemp = (sdata->gsfDeltaTSpecific.pulse_length * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next byte contains the fore aft beamwidth field. */    dtemp = (sdata->gsfDeltaTSpecific.fore_aft_beamwidth * 10.0) + 0.501;    *p = (unsigned char) dtemp;    p += 1;    /* The next byte contains the athwartships beamwidth field. */    dtemp = (sdata->gsfDeltaTSpecific.athwartships_beamwidth * 10.0) + 0.501;    *p = (unsigned char) dtemp;    p += 1;    /* The next 32 bytes are spare space for future growth */    memset(p, 0, 32);    p += 32;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeR2SonicSpecific * * Description : This function encodes the R2Sonic 2020/2022/2024 *  sensor specific information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeR2SonicSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata){    int i;    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;    double          dtemp;    /* The next 12 bytes contains the model number */    memcpy (p, (unsigned char *) (sdata->gsfR2SonicSpecific.model_number), 12);    p += 12;    /* The next 12 bytes contains the serial number */    memcpy (p, (unsigned char *) (sdata->gsfR2SonicSpecific.serial_number), 12);    p += 12;    /* The next four bytes contains the time in seconds */    ltemp = htonl((gsfuLong) sdata->gsfR2SonicSpecific.dg_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the fractional portion of the time in nanoseconds */    ltemp = htonl((gsfuLong) sdata->gsfR2SonicSpecific.dg_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the ping number */    ltemp = htonl((gsfuLong) sdata->gsfR2SonicSpecific.ping_number);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the ping period * 1,000,000 */    dtemp = (sdata->gsfR2SonicSpecific.ping_period * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the sound speed * 100 */    dtemp = (sdata->gsfR2SonicSpecific.sound_speed * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the frequency * 1000 */    dtemp = (sdata->gsfR2SonicSpecific.frequency * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit source level * 100 */    dtemp = (sdata->gsfR2SonicSpecific.tx_power * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit pulse width * 10,000,000.0*/    dtemp = (sdata->gsfR2SonicSpecific.tx_pulse_width * 1.0e7) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit beamwidth in the vertical * 1,000,000 */    dtemp = (sdata->gsfR2SonicSpecific.tx_beamwidth_vert * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit beamwidth in the horizontal * 1,000,000*/    dtemp = (sdata->gsfR2SonicSpecific.tx_beamwidth_horiz * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit steering in the vertical  * 1,000,000*/    dtemp = sdata->gsfR2SonicSpecific.tx_steering_vert * 1.0e6;    if (dtemp < 0.0)        dtemp -= 0.501;    else        dtemp += 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit steering in the horizontal  * 1,000,000*/    dtemp = sdata->gsfR2SonicSpecific.tx_steering_horiz * 1.0e6;    if (dtemp < 0.0)        dtemp -= 0.501;    else        dtemp += 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains misc. transmit info */    ltemp = htonl((gsfuLong) sdata->gsfR2SonicSpecific.tx_misc_info);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver bandwidth * 10,000 */    dtemp = (sdata->gsfR2SonicSpecific.rx_bandwidth * 1.0e4) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver sample rate * 1000 */    dtemp = (sdata->gsfR2SonicSpecific.rx_sample_rate * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver range * 100,000 */    dtemp = (sdata->gsfR2SonicSpecific.rx_range * 1.0e5) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver gain * 100 */    dtemp = (sdata->gsfR2SonicSpecific.rx_gain * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver spreading law coefficient * 1000 */    dtemp = (sdata->gsfR2SonicSpecific.rx_spreading * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver absorption coefficient * 1000 */    dtemp = (sdata->gsfR2SonicSpecific.rx_absorption * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver mount tilt angle * 1,000,000 */    dtemp = sdata->gsfR2SonicSpecific.rx_mount_tilt * 1.0e6;    if (dtemp < 0.0)        dtemp -= 0.501;    else        dtemp += 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains misc. receiver info */    ltemp = htonl((gsfuLong) sdata->gsfR2SonicSpecific.rx_misc_info);    memcpy(p, &ltemp, 4);    p += 4;    /* The next two bytes are reserved */    stemp = htons((gsfuShort) sdata->gsfR2SonicSpecific.reserved);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes are for the number of beams */    stemp = htons((gsfuShort) sdata->gsfR2SonicSpecific.num_beams);    memcpy(p, &stemp, 2);    p += 2;    /* The next set of 6x4 (24) bytes contains reserved fields from the A0 subgroup of the BTH0 */    for (i=0; i<6; i++)    {        dtemp = sdata->gsfR2SonicSpecific.A0_more_info[i] * 1.0e6;        if (dtemp < 0.0)            dtemp -= 0.501;        else            dtemp += 0.501;        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;    }    /* The next set of 6x4 (24) bytes contains reserved fields from the A2 subgroup of BTH0 */    for (i=0; i<6; i++)    {        dtemp = sdata->gsfR2SonicSpecific.A2_more_info[i] * 1.0e6;        if (dtemp < 0.0)            dtemp -= 0.501;        else            dtemp += 0.501;        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;    }    /* The next four bytes contain minimum depth gate from the G0 subgroup of BTH0 */    dtemp = (sdata->gsfR2SonicSpecific.G0_depth_gate_min * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contain maximum depth gate from the G0 subgroup of BTH0 */    dtemp = (sdata->gsfR2SonicSpecific.G0_depth_gate_max * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contain the depth gate slope from the G0 subgroup of BTH0 */    dtemp = sdata->gsfR2SonicSpecific.G0_depth_gate_slope * 1.0e6;    if (dtemp < 0.0)        dtemp -= 0.501;    else        dtemp += 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* write the spare bytes */    memcpy(p, sdata->gsfR2SonicSpecific.spare, 32);    p += 32;    return (p - sptr);} /* end EncodeR2SonicSpecific() *//******************************************************************** * * Function Name : EncodeSBEchotracSpecific * * Description : This function encodes the Bathy 2000 and echotrac *  sensor specific data from the HSPS source files. * * Inputs : *   sptr = a pointer to an unsigned char buffer to write into *   sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSBEchotracSpecific(unsigned char *sptr, const t_gsfSBEchotracSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the navigation error */    stemp = htons((gsfuShort) (sdata->navigation_error));    memcpy(p, &stemp, 2);    p += 2;        /* Next byte contains the most probable position source navigation */    *p = (unsigned char) sdata->mpp_source;    p += 1;    /* Next byte contains the tide source */    *p = (unsigned char) sdata->tide_source;    p += 1;    /* Next two byte integer contains the dynamic draft. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = sdata->dynamic_draft * 100.0;    if (dtemp < 0.0)    {            dtemp -= 0.501;    }    else    {            dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* write the spare bytes */    memcpy(p, sdata->spare, 4);    p += 4;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeSBMGD77Specific * * Description : This function encodes the MGD77 fields * into an MGD77 record. The MGD77 Singlebeam is essentially * survey trackline data, and actual survey data can be retrieved * from the source. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSBMGD77Specific(unsigned char *sptr, const t_gsfSBMGD77Specific *sdata){    unsigned char  *p = sptr;    gsfuLong        ltemp;    gsfuShort       stemp;    double          dtemp;    /* First two byte integer contains the time zone correction */    stemp = htons((gsfuShort) (sdata->time_zone_corr));    memcpy(p, &stemp, 2);    p += 2;    /* The Next two byte integer contains how the navigation was obtained */    stemp = htons((gsfuShort) (sdata->position_type_code));    memcpy(p, &stemp, 2);    p += 2;    /* The Next two byte integer contains on how the sound velocity       correction was made */    stemp = htons((gsfuShort) (sdata->correction_code));    memcpy(p, &stemp, 2);    p += 2;    /* The Next two byte integer contains how the bathymetry was obtained */    stemp = htons((gsfuShort) (sdata->bathy_type_code));    memcpy(p, &stemp, 2);    p += 2;    /* The Next two byte integer contains the quality code for Nav */    stemp = htons((gsfuShort) (sdata->quality_code));    memcpy(p, &stemp, 2);    p += 2;    /* Next four byte integer contains the the two way travel time */    dtemp = sdata->travel_time * 10000;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* write the spare bytes */    memcpy(p, sdata->spare, 4);    p += 4;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeSBBDBSpecific * * Description : This function encodes the BDB fields * into a BDB record. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSBBDBSpecific(unsigned char *sptr, const t_gsfSBBDBSpecific *sdata){    unsigned char  *p = sptr;    gsfuLong        ltemp;    /* Next four byte integer contains the the document number */    ltemp = htonl((gsfuLong) (sdata->doc_no));    memcpy(p, &ltemp, 4);    p += 4;    /* Next byte contains the evaluation flag */    *p = (unsigned char) sdata->eval;    p += 1;    /* Next byte contains the classification flag */    *p = (unsigned char) sdata->classification;    p += 1;    /* Next byte contains the track adjustment flag */    *p = (unsigned char) sdata->track_adj_flag;    p += 1;    /* Next byte contains the source flag */    *p = (unsigned char) sdata->source_flag;    p += 1;    /* Next byte contains the discrete point or track line flag */    *p = (unsigned char) sdata->pt_or_track_ln;    p += 1;    /* Next byte contains the datum flag */    *p = (unsigned char) sdata->datum_flag;    p += 1;    /* write the spare bytes */    memcpy(p, sdata->spare, 4);    p += 4;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeSBNOSHDBSpecific * * Description : This function encodes the NOSHDB fields into a *               NOSHDB record. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSBNOSHDBSpecific(unsigned char *sptr, const t_gsfSBNOSHDBSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    /* First two byte integer contains the depth type code */    stemp = htons((gsfuShort) (sdata->type_code));    memcpy(p, &stemp, 2);    p += 2;    /* The Next two byte integer contains the cartographic code */    stemp = htons((gsfuShort) (sdata->carto_code));    memcpy(p, &stemp, 2);    p += 2;    /* write the spare bytes */    memcpy(p, sdata->spare, 4);    p += 4;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeSBNavisoundSpecific * * Description : This function encodes the Navisound *  sensor specific data * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data *    major_version = the major version of GSF used to create the file. *    minor_version = the minor version of GSF used to create the file. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeSBNavisoundSpecific(unsigned char *sptr, const t_gsfSBNavisoundSpecific *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* First two byte value contains the pulse length */    dtemp = sdata->pulse_length * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* write the spare bytes */    memcpy(p, sdata->spare, 8);    p += 8;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeEM3ImagerySpecific * * Description : This function encodes the Simrad EM3000 series sensor *  specific imagery information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific imagery data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEM3ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    double          dtemp;    /* Next two bytes contain the range to normal incidence to correct amplitudes */    stemp = htons((gsfuShort) sdata->gsfEM3ImagerySpecific.range_norm);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the start range sample of TVG ramp */    stemp = htons((gsfuShort) sdata->gsfEM3ImagerySpecific.start_tvg_ramp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the stop range sample of TVG ramp */    stemp = htons((gsfuShort) sdata->gsfEM3ImagerySpecific.stop_tvg_ramp);    memcpy(p, &stemp, 2);    p += 2;    /* Next byte contains the normal incidence BS in dB */    *p = (unsigned char) (sdata->gsfEM3ImagerySpecific.bsn);    p += 1;    /* Next byte contains the oblique BS in dB */    *p = (unsigned char) (sdata->gsfEM3ImagerySpecific.bso);    p += 1;    /* The next two byte value contains the mean absorption coefficient */    dtemp = sdata->gsfEM3ImagerySpecific.mean_absorption * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the imagery offset value used to positive bias the imagery values. This value has been added to all imagery samples     *  as the Kongsberg imagery datagram is decoded into GSF.     */    stemp = htons((gsfsShort) sdata->gsfEM3ImagerySpecific.offset);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the imagery scale value as specified by the manufacturer.  This value is 2 for the EM3000/EM3002/EM1002/EM300/EM120.     *  The following formula can be used to convert from the GSF positive biased value to dB:     *  dB_value = (GSF_I_value - offset) / scale     */    stemp = htons((gsfsShort) sdata->gsfEM3ImagerySpecific.scale);    memcpy(p, &stemp, 2);    p += 2;    /* write the spare bytes */    memcpy(p, sdata->gsfEM3ImagerySpecific.spare, 4);    p += 4;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeEM4ImagerySpecific * * Description : This function encodes the Simrad EM4 series sensor *  specific imagery information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific imagery data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeEM4ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;    double          dtemp;    /* The next four bytes contains the integer portion of the sampling frequency in Hz */    ltemp = htonl((gsfuLong) sdata->gsfEM4ImagerySpecific.sampling_frequency);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contain the fractional portion of the sampling frequency in Hz scaled by 4.0e9 */    dtemp = sdata->gsfEM4ImagerySpecific.sampling_frequency - ((gsfuLong) sdata->gsfEM4ImagerySpecific.sampling_frequency);    dtemp *= 4.0e9;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two bytes contain the mean absorption coefficient in dB/KM. */    dtemp = sdata->gsfEM4ImagerySpecific.mean_absorption * 100.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the transmit pulse length in microseconds. */    dtemp = sdata->gsfEM4ImagerySpecific.tx_pulse_length;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the range to normal incidence to correct amplitudes */    stemp = htons((gsfuShort) sdata->gsfEM4ImagerySpecific.range_norm);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the start range sample of TVG ramp */    stemp = htons((gsfuShort) sdata->gsfEM4ImagerySpecific.start_tvg_ramp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the stop range sample of TVG ramp */    stemp = htons((gsfuShort) sdata->gsfEM4ImagerySpecific.stop_tvg_ramp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the normal incidence BS in dB */    dtemp = sdata->gsfEM4ImagerySpecific.bsn * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the oblique incidence BS in dB */    dtemp = sdata->gsfEM4ImagerySpecific.bso * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfsShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the transmit beam width value in degrees */    dtemp = sdata->gsfEM4ImagerySpecific.tx_beam_width * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* The next two byte value contains the TVG cross over anlge in degrees */    dtemp = sdata->gsfEM4ImagerySpecific.tvg_cross_over * 10.0;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    stemp = htons((gsfuShort) dtemp);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the imagery offset value used to positive bias the imagery values. This value has been added to all imagery samples     *  as the Kongsberg imagery datagram is decoded into GSF.     */    stemp = htons((gsfsShort) sdata->gsfEM4ImagerySpecific.offset);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the imagery scale value as specified by the manufacturer.  This value is 10 for the EM710/EM302/EM122/EM2040/ME70BO.     *  The following formula can be used to convert from the GSF positive biased value to dB:     *  dB_value = (GSF_I_value - offset) / scale     */    stemp = htons((gsfsShort) sdata->gsfEM4ImagerySpecific.scale);    memcpy(p, &stemp, 2);    p += 2;    /* write the spare bytes */    memcpy(p, sdata->gsfEM4ImagerySpecific.spare, 20);    p += 20;    return (p - sptr);}/********************************************************************** Function Name : EncodeKMALLImagerySpecific** Description : This function encodes the kongsberg kmall compliant sensor*  specific imagery information into external byte stream form.** Inputs :*    sptr = a pointer to an unsigned char buffer to write into*    sdata = a pointer to a union of sensor specific imagery data.** Returns : This function returns the number of bytes encoded.** Error Conditions : none*********************************************************************/static intEncodeKMALLImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata){    unsigned char  *p = sptr;   /* The next 32 bytes are our spare for later use */    memset(p,0,(size_t)64);    p += 64;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeKlein5410BssSpecific * * Description : This function encodes the Simrad EM4 series sensor *  specific imagery information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific imagery data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeKlein5410BssImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata){    int i;    unsigned char  *p = sptr;    gsfuShort       stemp;    /* First two bytes contain the descriptor for resolution mode. */    stemp = htons((gsfuShort) sdata->gsfKlein5410BssImagerySpecific.res_mode);    memcpy(p, &stemp, 2);    p += 2;    /* Next two bytes contain the TVG page. */    stemp = htons((gsfuShort) sdata->gsfKlein5410BssImagerySpecific.tvg_page);    memcpy(p, &stemp, 2);    p += 2;    /* Next 10 bytes contain an array of beam identifiers */    for (i = 0; i < 5; i++)    {        stemp = htons((gsfuShort) sdata->gsfKlein5410BssImagerySpecific.beam_id[i]);        memcpy(p, &stemp, 2);        p += 2;    }    /* write the spare bytes */    memcpy(p, sdata->gsfKlein5410BssImagerySpecific.spare, 4);    p += 4;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeReson7100ImagerySpecific * * Description : This function encodes the Reson 7100 series sensor *  specific imagery information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific imagery data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeReson7100ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    stemp = htons ((gsfuShort) sdata->gsfReson7100ImagerySpecific.size);    memcpy(p, &stemp, 2);    p += 2;    /* write the spare bytes */    memcpy(p, sdata->gsfReson7100ImagerySpecific.spare, 64);    p += 64;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeReson8100ImagerySpecific * * Description : This function encodes the Reson 8100 series sensor *  specific imagery information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific imagery data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeReson8100ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata){    unsigned char  *p = sptr;    /* write the spare bytes */    memcpy(p, sdata->gsfReson8100ImagerySpecific.spare, 8);    p += 8;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeResonTSeriesImagerySpecific * * Description : This function encodes the Reson 7100 series sensor *  specific imagery information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific imagery data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeResonTSeriesImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata){    unsigned char  *p = sptr;    gsfuShort       stemp;    stemp = htons ((gsfuShort) sdata->gsfResonTSeriesImagerySpecific.size);    memcpy(p, &stemp, 2);    p += 2;    /* write the spare bytes */    memcpy(p, sdata->gsfResonTSeriesImagerySpecific.spare, 64);    p += 64;    return (p - sptr);}/******************************************************************** * * Function Name : EncodeR2SonicImagerySpecific * * Description : This function encodes the R2Sonic 2020/2022/2024 *  sensor specific imagery information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    sdata = a pointer to a union of sensor specific data. * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/static intEncodeR2SonicImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata){    int i;    unsigned char  *p = sptr;    gsfuShort       stemp;    gsfuLong        ltemp;    double          dtemp;    /* The next 12 bytes contains the model number */    memcpy (p, (unsigned char *) (sdata->gsfR2SonicImagerySpecific.model_number), 12);    p += 12;    /* The next 12 bytes contains the serial number */    memcpy (p, (unsigned char *) (sdata->gsfR2SonicImagerySpecific.serial_number), 12);    p += 12;    /* The next four bytes contains the time in seconds */    ltemp = htonl((gsfuLong) sdata->gsfR2SonicImagerySpecific.dg_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the fractional portion of the time in nanoseconds */    ltemp = htonl((gsfuLong) sdata->gsfR2SonicImagerySpecific.dg_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the ping number */    ltemp = htonl((gsfuLong) sdata->gsfR2SonicImagerySpecific.ping_number);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the ping period * 1,000,000 */    dtemp = (sdata->gsfR2SonicImagerySpecific.ping_period * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the sound speed * 100 */    dtemp = (sdata->gsfR2SonicImagerySpecific.sound_speed * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the frequency * 1000 */    dtemp = (sdata->gsfR2SonicImagerySpecific.frequency * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit source level * 100 */    dtemp = (sdata->gsfR2SonicImagerySpecific.tx_power * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit pulse width * 10,000,000.0*/    dtemp = (sdata->gsfR2SonicImagerySpecific.tx_pulse_width * 1.0e7) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit beamwidth in the vertical * 1,000,000 */    dtemp = (sdata->gsfR2SonicImagerySpecific.tx_beamwidth_vert * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit beamwidth in the horizontal * 1,000,000*/    dtemp = (sdata->gsfR2SonicImagerySpecific.tx_beamwidth_horiz * 1.0e6) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit steering in the vertical  * 1,000,000*/    dtemp = sdata->gsfR2SonicImagerySpecific.tx_steering_vert * 1.0e6;    if (dtemp < 0.0)        dtemp -= 0.501;    else        dtemp += 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the transmit steering in the horizontal  * 1,000,000*/    dtemp = sdata->gsfR2SonicImagerySpecific.tx_steering_horiz * 1.0e6;    if (dtemp < 0.0)        dtemp -= 0.501;    else        dtemp += 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains misc. transmit info */    ltemp = htonl((gsfuLong) sdata->gsfR2SonicImagerySpecific.tx_misc_info);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver bandwidth * 10,000 */    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_bandwidth * 1.0e4) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver sample rate * 1000 */    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_sample_rate * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver range * 100,000 */    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_range * 1.0e5) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver gain * 100 */    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_gain * 1.0e2) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver spreading law coefficient * 1000 */    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_spreading * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver absorption coefficient * 1000 */    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_absorption * 1.0e3) + 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains the receiver mount tilt angle * 1,000,000 */    dtemp = sdata->gsfR2SonicImagerySpecific.rx_mount_tilt * 1.0e6;    if (dtemp < 0.0)        dtemp -= 0.501;    else        dtemp += 0.501;    ltemp = htonl((gsfuLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four bytes contains misc. receiver info */    ltemp = htonl((gsfuLong) sdata->gsfR2SonicImagerySpecific.rx_misc_info);    memcpy(p, &ltemp, 4);    p += 4;    /* The next two bytes are reserved */    stemp = htons((gsfuShort) sdata->gsfR2SonicImagerySpecific.reserved);    memcpy(p, &stemp, 2);    p += 2;    /* The next two bytes are for the number of beams */    stemp = htons((gsfuShort) sdata->gsfR2SonicImagerySpecific.num_beams);    memcpy(p, &stemp, 2);    p += 2;    /* The next set of 6x4 (24) bytes contains "more_info" from the SNI0 datagram */    for (i=0; i<6; i++)    {        dtemp = sdata->gsfR2SonicImagerySpecific.more_info[i] * 1.0e6;        if (dtemp < 0.0)            dtemp -= 0.501;        else            dtemp += 0.501;        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;    }    /* write the spare bytes */    memcpy(p, sdata->gsfR2SonicImagerySpecific.spare, 32);    p += 32;    return (p - sptr);} /* end EncodeR2SonicImagerySpecific() *//******************************************************************** * * Function Name : EncodeBRBIntensity * * Description : This function encodes the Bathymetric Receive Beam *  time series intensity information into external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write into *    idata = a pointer to the gsfBRBIntensity structure containg *            imagery data *    num_beams = the integer number of beams (number of *                gsfTimeSeriesIntensity structures in the array) *    sensor_id = the sensor specific subrecord id * * Returns : *   This function returns the number of bytes encoded if successful, *   or -1 if an error occurred. * * Error Conditions : *   GSF_MB_PING_RECORD_ENCODE_FAILED *   GSF_RECORD_SIZE_ERROR * ********************************************************************/static intEncodeBRBIntensity(unsigned char *sptr, const gsfBRBIntensity *idata, int num_beams, int sensor_id, int bytes_used){    unsigned char  *ptr = sptr;    unsigned char  *temp_ptr;    gsfuLong        ltemp;    gsfuShort       stemp;    int             i, j;    int             size;    int             sensor_size;    int             bytes_per_sample;    unsigned char   bytes_to_pack[4];    /* check to make sure the bits per sample value is supported */    if ((idata->bits_per_sample != 8) &&        (idata->bits_per_sample != 12) &&        (idata->bits_per_sample != 16) &&        (idata->bits_per_sample != 32))    {        /* unsupported number of bits per sample, return an error */        gsfError = GSF_MB_PING_RECORD_ENCODE_FAILED;        return -1;    }    /* Save the current pointer, and leave room for the four byte subrecord identifier. */    temp_ptr = ptr;    ptr += 4;    /* write the bits per sample */    *ptr = idata->bits_per_sample;    ptr += 1;    /* write the sample applied corrections description */    ltemp = htonl(idata->applied_corrections);    memcpy(ptr, &ltemp, 4);    ptr += 4;    /* write the spare header bytes */    memcpy(ptr, idata->spare, 16);    ptr += 16;    /* write the sensor specifiuc imagery info */    switch (sensor_id)    {        case (GSF_SWATH_BATHY_SUBRECORD_EM2000_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3000_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM1002_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM300_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM120_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3002_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3000D_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3002D_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM121A_SIS_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM2000_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3000_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM1002_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM300_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM120_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3002_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3000D_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM3002D_RAW_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM121A_SIS_RAW_SPECIFIC):            sensor_size = EncodeEM3ImagerySpecific(ptr, &idata->sensor_imagery);            break;        case (GSF_SWATH_BATHY_SUBRECORD_RESON_7125_SPECIFIC):            sensor_size = EncodeReson7100ImagerySpecific(ptr, &idata->sensor_imagery);            break;		case (GSF_SWATH_BATHY_SUBRECORD_RESON_TSERIES_SPECIFIC):            sensor_size = EncodeResonTSeriesImagerySpecific(ptr, &idata->sensor_imagery);            break;        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8101_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8111_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8124_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8125_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8150_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8160_SPECIFIC):            sensor_size = EncodeReson8100ImagerySpecific(ptr, &idata->sensor_imagery);            break;        case (GSF_SWATH_BATHY_SUBRECORD_EM122_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM302_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM710_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_EM2040_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_ME70BO_SPECIFIC):            sensor_size = EncodeEM4ImagerySpecific(ptr, &idata->sensor_imagery);            break;        case (GSF_SWATH_BATHY_SUBRECORD_KMALL_SPECIFIC):            sensor_size = EncodeKMALLImagerySpecific(ptr,&idata->sensor_imagery);            break;        case (GSF_SWATH_BATHY_SUBRECORD_KLEIN_5410_BSS_SPECIFIC):            sensor_size = EncodeKlein5410BssImagerySpecific(ptr, &idata->sensor_imagery);            break;        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2020_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2022_SPECIFIC):        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2024_SPECIFIC):            sensor_size = EncodeR2SonicImagerySpecific(ptr, &idata->sensor_imagery);            break;        default:            sensor_size = 0;            break;    }    ptr += sensor_size;    bytes_per_sample = idata->bits_per_sample / 8;    for (i = 0; i < num_beams; i++)    {        /* check to see if the GSF_MAX_RECORD_SIZE will get exceeded */        if (12 + idata->time_series[i].sample_count * idata->bits_per_sample / 8  + bytes_used + ptr - sptr > GSF_MAX_RECORD_SIZE)        {            /* the GSF_MAX_RECORD_SIZE would be exceeded. return an error */            gsfError = GSF_RECORD_SIZE_ERROR;            return -1;        }        stemp = htons ((gsfuShort) idata->time_series[i].sample_count);        memcpy(ptr, &stemp, 2);        ptr += 2;        stemp = htons ((gsfuShort) idata->time_series[i].detect_sample);        memcpy(ptr, &stemp, 2);        ptr += 2;        /* write the kmall start value */        stemp = htons ((gsfuShort) idata->time_series[i].start_range_samples);        memcpy(ptr, &stemp, 2);        ptr += 2;        memset(ptr, 0, 6);        ptr += 6;        if (idata->bits_per_sample == 12)        {            for (j = 0; j < idata->time_series[i].sample_count; j+=2)            {                /* pack 2 samples into 3 bytes */                /* pack the first sample */                ltemp = htonl ((gsfuLong) idata->time_series[i].samples[j]);                memcpy (bytes_to_pack, &ltemp, 4);                /* Although bytes_to_pack is 4 bytes, we know that bytes 0 and 1 are zero. */                /* We want to save the lower bits of byte 2 in the upper bits of ptr[0] (we */                /* know the upper bits of byte 2 are zero) */                ptr[0] = bytes_to_pack[2] << 4;                /* We sant to save the upper bits of bytes_to_pack[3] in the lower bits of */                /* ptr[0].  The lower bits of bytes_to_pack[3] need to be saved in the upper */                /* bits of ptr[1] */                ptr[0] |= (bytes_to_pack[3] & 0xf0) >> 4;                ptr[1] = bytes_to_pack[3] << 4;                if (j+1 < idata->time_series[i].sample_count)                {                    /* pack the second sample */                    ltemp = htonl ((gsfuLong) idata->time_series[i].samples[j+1]);                    memcpy (bytes_to_pack, &ltemp, 4);                    /* We know the upper bits of bytes_to_pack[2] are 0, so save the lower */                    /* bits in the lower bits of ptr[1].  Then save bytes_to_pack[3] in ptr[2] */                    ptr[1] |= (bytes_to_pack[2] & 0x0f);                    ptr[2] = bytes_to_pack[3];                }                else                {                    ptr[2] = 0;                }                ptr += 3;            }        }        else        {            for (j=0; j < idata->time_series[i].sample_count; j++)            {                if (bytes_per_sample == 1)                {                    *ptr = (unsigned char) idata->time_series[i].samples[j];                    ptr++;;                }                else if (bytes_per_sample == 2)                {                    stemp = htons ((gsfuShort) idata->time_series[i].samples[j]);                    memcpy(ptr, &stemp, 2);                    ptr += 2;                }                else if (bytes_per_sample == 4)                {                    ltemp = htonl ((gsfuLong) idata->time_series[i].samples[j]);                    memcpy(ptr, &ltemp, 4);                    ptr += 4;                }                else                {                    memcpy (ptr, &idata->time_series[i].samples[j], bytes_per_sample);                    ptr += bytes_per_sample;                }            }        }    }    /* subrecord identifier has array id in first byte, and size in the    *  remaining three bytes    */    size = ptr - sptr;    ltemp = GSF_SWATH_BATHY_SUBRECORD_INTENSITY_SERIES_ARRAY << 24;    ltemp |= size;    ltemp = htonl(ltemp);    memcpy(temp_ptr, &ltemp, 4);    return (ptr - sptr);}/******************************************************************** * * Function Name : gsfEncodeSoundVelocityProfile * * Description : This function encodes a GSF sound velocity profile *   record from internal form to external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to be written to *    svp = a pointer to the gsfSVP structure to read from * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/intgsfEncodeSoundVelocityProfile(unsigned char *sptr, gsfSVP * svp){    unsigned char  *p = sptr;    double          dtemp;    gsfuLong        ltemp;    int             i;    /* First four byte integer contains the observation time seconds */    ltemp = htonl(svp->observation_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the observation time nanoseconds */    ltemp = htonl(svp->observation_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the seconds portion of the time the    *  new profile was put into use by the sonar system    */    ltemp = htonl(svp->application_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the application time nanoseconds */    ltemp = htonl(svp->application_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the longitude of profile observation.     * Round the scaled quantity to the nearest whole integer.     */    dtemp = svp->longitude * 1.0e7;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the latitude. Round the scaled     * quantity to the nearest whole integer.     */    dtemp = svp->latitude * 1.0e7;    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the number of points in the profile */    ltemp = htonl((gsfuLong) (svp->number_points));    memcpy(p, &ltemp, 4);    p += 4;    /* Now loop to encode the depth/sound speed pairs    * Scale both the depth and sound speed by 100    */    for (i = 0; i < svp->number_points; i++)    {        /* Next four byte integer contains the depth. Round the scaled         * quantity to the nearest whole integer.         */        dtemp = svp->depth[i] * 100.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;        /* Next four byte integer contains the sound_speed. Round the scaled         * quantity to the nearest whole integer.         */        dtemp = svp->sound_speed[i] * 100.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        ltemp = htonl((gsfuLong) dtemp);        memcpy(p, &ltemp, 4);        p += 4;    }    return (p - sptr);}/******************************************************************** * * Function Name : gsfEncodeProcessingParameters * * Description : This function encodes into external GSF byte stream form *   a record of processing parameters. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write to *    param = a pointer to the gsfProcessingParameters structure to read from * * Returns : This function returns the number of bytes encoded * * Error Conditions : none * ********************************************************************/intgsfEncodeProcessingParameters(unsigned char *sptr, gsfProcessingParameters * param){    unsigned char  *p = sptr;    gsfuLong        ltemp;    gsfuShort       stemp;    int             i;    /* First four byte integer contains the seconds portion of the time    *  application of the new parameters.    */    ltemp = htonl(param->param_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the application time nanoseconds */    ltemp = htonl(param->param_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the number of parameters in this record */    stemp = htons(param->number_parameters);    memcpy(p, &stemp, 2);    p += 2;    /* Now loop to encode these parameters */    for (i = 0; i < param->number_parameters; i++)    {        if (param->param[i] != (char *) NULL)         {            /* next is the size of the parameter name as a two byte integer */            param->param_size[i] = strlen(param->param[i]) + 1;     /* add one to carry null */            stemp = htons(param->param_size[i]);            memcpy(p, &stemp, 2);            p += 2;            memcpy(p, param->param[i], param->param_size[i]);            p += param->param_size[i];        }    }    return (p - sptr);}/******************************************************************** * * Function Name : gsfEncodeSensorParameters * * Description : This function encodes into external GSF byte stream form *   a record of sonar parameters. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write to *    param = a pointer to a gsfSensorParameters structure to read from * * Returns : This function returns the number of bytes encoded * * Error Conditions : none * ********************************************************************/intgsfEncodeSensorParameters(unsigned char *sptr, gsfSensorParameters * param){    unsigned char  *p = sptr;    gsfuLong        ltemp;    gsfuShort       stemp;    int             i;    /* First four byte integer contains the seconds portion of the time    *  application of the new parameters.    */    ltemp = htonl(param->param_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the application time nanoseconds */    ltemp = htonl(param->param_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the number of parameters in this record */    stemp = htons(param->number_parameters);    memcpy(p, &stemp, 2);    p += 2;    /* Now loop to encode these parameters */    for (i = 0; i < param->number_parameters; i++)    {        if (param->param[i] != (char *) NULL)         {            /* next is the size of the parameter name as a two byte integer */            param->param_size[i] = strlen(param->param[i]) + 1;     /* add one to carry null */            stemp = htons(param->param_size[i]);            memcpy(p, &stemp, 2);            p += 2;            memcpy(p, param->param[i], param->param_size[i]);            p += param->param_size[i];        }    }    return (p - sptr);}/******************************************************************** * * Function Name : gsfEncodeComment * * Description : This function is used to encode a gsfComment record *  from internal to external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to be written to *    comment = a pointer to the gsfComment structure to read from * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/intgsfEncodeComment(unsigned char *sptr, gsfComment * comment){    unsigned char  *p = sptr;    gsfuLong        ltemp;    /* First four byte integer contains the seconds portion of the time    *  the operator comment was made.    */    ltemp = htonl(comment->comment_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the nanoseconds portion of the    * comment time    */    ltemp = htonl(comment->comment_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the length of the comment */    ltemp = htonl(comment->comment_length);    memcpy(p, &ltemp, 4);    p += 4;    /* Next "length" bytes contain the operator comment */    memcpy(p, comment->comment, comment->comment_length);    p += comment->comment_length;    return (p - sptr);}/******************************************************************** * * Function Name : gsfEncodeHistory * * Description : This function encodes a GSF history record from internal *   to external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write to *    history = a pointer to a gsfHistory structure to read from * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/intgsfEncodeHistory(unsigned char *sptr, gsfHistory * history){    unsigned char  *p = sptr;    int             len;    gsfuLong        ltemp;    gsfuShort       stemp;    /* First four byte integer contains the seconds portion of the time    *  the history record was added to the data.    */    ltemp = htonl(history->history_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the nanoseconds portion of the    * history time.    */    ltemp = htonl(history->history_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next 2 bytes contains the size of the machines host name */    len = strlen(history->host_name) + 1;    stemp = htons(len);    memcpy(p, &stemp, 2);    p += 2;    /* Next "len" bytes contains the host name of the machine used to process the data */    memcpy(p, history->host_name, len);    p += len;    /* Next two byte integer contains the size of the of operator field  */    len = strlen(history->operator_name) + 1;    stemp = htons(len);    memcpy(p, &stemp, 2);    p += 2;    /* Next "len" bytes contains the name of the operator who processed this data */    memcpy(p, history->operator_name, len);    p += len;    /* Next two byte integer contains the size of the command line field */    if (history->command_line == (char *) NULL)    {        history->command_line = "";    }    len = strlen(history->command_line) + 1;    stemp = htons(len);    memcpy(p, &stemp, 2);    p += 2;    /* Next "len" bytes contains the command line used to run the processing program */    memcpy(p, history->command_line, len);    p += len;    /* Next two byte integer contains the size of the history record comment */    if (history->comment == (char *) NULL)    {        history->comment = "";    }    len = strlen(history->comment);    stemp = htons(len);    memcpy(p, &stemp, 2);    p += 2;    /* Next "len" bytes contains the comment for this history record */    memcpy(p, history->comment, len);    p += len;    return (p - sptr);}/******************************************************************** * * Function Name : gsfEncodeNavigationError * * Description : This function encodes a navigation error record from *  internal to external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write to *    nav_error = a pointer to a gsfNavigationError structure to read from * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/intgsfEncodeNavigationError(unsigned char *sptr, gsfNavigationError * nav_error){    unsigned char  *p = sptr;    gsfuLong        ltemp;    /* First four byte integer contains the seconds portion of the time    *  of navigation error.    */    ltemp = htonl(nav_error->nav_error_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the nanoseconds portion of the    * history time.    */    ltemp = htonl(nav_error->nav_error_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the record id for the record    *  containing a position with this error. (registry and type number)    */    ltemp = htonl(nav_error->record_id);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the longitude error estimate */    ltemp = htonl((gsfuLong) (nav_error->longitude_error * 10.0 + 0.501));    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the latitude error estimate */    ltemp = htonl((gsfuLong) (nav_error->latitude_error * 10.0 + 0.501));    memcpy(p, &ltemp, 4);    p += 4;    return (p - sptr);}/******************************************************************** * * Function Name : gsfEncodeHVNavigationError * * Description : This function encodes the new horizontal and vertical *  navigation error record. * * Inputs : *   sptr = a pointer to an unsigned char buffer to write to *   hv_nav_error = a pointer to a gsfHVNavigationError structure to read from * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/intgsfEncodeHVNavigationError(unsigned char *sptr, gsfHVNavigationError *hv_nav_error){    double          dtemp;    unsigned char  *p = sptr;    int             length;    gsfsLong        ltemp;    gsfsShort       stemp;    gsfuShort       utemp;    /* First four byte integer contains the seconds portion of the time    *  of navigation error.    */    ltemp = htonl(hv_nav_error->nav_error_time.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four byte integer contains the nanoseconds portion of the    * history time.    */    ltemp = htonl(hv_nav_error->nav_error_time.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four byte integer contains the record id for the record    *  containing a position with this error. (registry and type number)    */    ltemp = htonl(hv_nav_error->record_id);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four byte integer contains the horizontal error estimate */    dtemp = (hv_nav_error->horizontal_error * 1000.0);    if (dtemp < 0.0)    {        dtemp -= 0.501;    }    else    {        dtemp += 0.501;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next four byte integer contains the vertical error estimate */    dtemp = (hv_nav_error->vertical_error * 1000.0);    if (dtemp < 0.0)    {        dtemp -= 0.5;    }    else    {        dtemp += 0.5;    }    ltemp = htonl((gsfsLong) dtemp);    memcpy(p, &ltemp, 4);    p += 4;    /* The next two bytes contains the SEP uncertainty estimate.     * This value is always >= 0.0, so rounding is a simple addition     */    dtemp = (hv_nav_error->SEP_uncertainty * 100.0);    dtemp += 0.501;    utemp = htons((gsfuShort) dtemp);    memcpy(p, &utemp, 2);    p += 2;    /* The next two bytes are reserved for future use */    *p = (unsigned char) (hv_nav_error->spare[0]);    p += 1;    *p = (unsigned char) (hv_nav_error->spare[1]);    p += 1;    /* The next two byte integer contains the length of the positioning system type string */    if (hv_nav_error->position_type == (char *) NULL)    {        length = 0;    }    else    {        length = strlen(hv_nav_error->position_type);    }    stemp = htons(length);    memcpy(p, &stemp, 2);    p += 2;    /* The next length bytes contains the positioning system type string. */    if (hv_nav_error->position_type == (char *) NULL)    {        /* Put a null character down only if there is no string to record */        *p = '\0';        p += 1;    }    else    {        memcpy(p, hv_nav_error->position_type, length);        p += length;    }    return (p - sptr);}/******************************************************************** * * Function Name : LocalSubtractTimes * * Description : Subtract two times given in a timespec structure *   and return the result expressed as a double. * * Inputs : *   base_time = The first time given in a timespec struct. *   subtrahend = The second time given in a timespec struct. *	 difference = The difference returned to the calling program * * Returns : none. * * Error Conditions : none * ********************************************************************/static void LocalSubtractTimes (const struct timespec *base_time, const struct timespec *subtrahend, double *difference){    double fraction = 0.0;    double seconds  = 0.0;    seconds  = difftime(base_time->tv_sec, subtrahend->tv_sec);    fraction = ((double)(base_time->tv_nsec - subtrahend->tv_nsec))/1.0e9;    *difference = seconds + fraction;}/******************************************************************** * * Function Name : gsfEncodeAttitude * * Description : This function encodes a GSF attitude record from internal *  to external byte stream form. * * Inputs : *    sptr = a pointer to an unsigned char buffer to write to *    attitude = a pointer to a gsfAttitude structure to read from * * Returns : This function returns the number of bytes encoded. * * Error Conditions : none * ********************************************************************/intgsfEncodeAttitude(unsigned char *sptr, gsfAttitude * attitude){    unsigned char  *p = sptr;    gsfuLong        ltemp;    gsfuShort       stemp;    double          dtemp;    int             i;    struct timespec basetime;    double          time_offset;    /* write the full time for the first time in the record, and save subsequent times     *  as an offset from this basetime     */    basetime = attitude->attitude_time[0];    /* First four byte integer contains the seconds portion of the base     *  time for the attitude record     */    ltemp = htonl(basetime.tv_sec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next four byte integer contains the nanoseconds portion of the    * attitude base time.    */    ltemp = htonl(basetime.tv_nsec);    memcpy(p, &ltemp, 4);    p += 4;    /* Next two byte integer contains the number of measurements */    stemp = htons(attitude->num_measurements);    memcpy(p, &stemp, 2);    p += 2;    for (i = 0; i < attitude->num_measurements; i++)    {        /* Next two byte integer contains the time offset from basetime for this         * measurement. Round the scaled quantity to the nearest whole integer.         */        LocalSubtractTimes (&attitude->attitude_time[i], &basetime, &time_offset);        stemp = htons((gsfuShort) (time_offset * 1000.0 + 0.501));        memcpy(p, &stemp, 2);        p += 2;        /* Next two byte integer contains the pitch. Round the scaled quantity         * to the nearest whole integer.         */        dtemp = attitude->pitch[i] * 100.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        stemp = htons((gsfsShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* Next two byte integer contains the roll. Round the scaled quantity         * to the nearest whole integer.         */        dtemp = attitude->roll[i] * 100.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        stemp = htons((gsfsShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* Next two byte integer contains the heave. Round the scaled quantity         * to the nearest whole integer.         */        dtemp = attitude->heave[i] * 100.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        stemp = htons((gsfsShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;        /* Next two byte integer contains the heading. Round the scaled quantity         * to the nearest whole integer.         */        dtemp = attitude->heading[i] * 100.0;        if (dtemp < 0.0)        {            dtemp -= 0.501;        }        else        {            dtemp += 0.501;        }        stemp = htons((gsfuShort) dtemp);        memcpy(p, &stemp, 2);        p += 2;    }    return (p - sptr);}/******************************************************************** * * Function Name : gsfSetDefaultScaleFactor * * Description : This function is used to estimate and set scale *               factors for a ping record * * Inputs : *    mb_ping - a pointer to a ping record.  The scale factors *              will be set in this record. * * Returns : This function returns 0. * * Error Conditions : none * ********************************************************************/int gsfSetDefaultScaleFactor(gsfSwathBathyPing *mb_ping){    const double GSF_DEPTH_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_ACROSS_TRACK_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_ALONG_TRACK_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_TRAVEL_TIME_ASSUMED_HIGHEST_PRECISION = 10e6;    const double GSF_BEAM_ANGLE_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_MEAN_CAL_AMPLITUDE_ASSUMED_HIGHEST_PRECISION = 10;    const double GSF_MEAN_REL_AMPLITUDE_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_ECHO_WIDTH_ASSUMED_HIGHEST_PRECISION = 10e5;    const double GSF_QUALITY_FACTOR_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_RECEIVE_HEAVE_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_DEPTH_ERROR_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_ACROSS_TRACK_ERROR_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_ALONG_TRACK_ERROR_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_NOMINAL_DEPTH_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_QUALITY_FLAGS_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_BEAM_FLAGS_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_SIGNAL_TO_NOISE_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_BEAM_ANGLE_FORWARD_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_TVG_dB_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_VERTICAL_ERROR_ASSUMED_HIGHEST_PRECISION = 200;    const double GSF_HORIZONTAL_ERROR_ASSUMED_HIGHEST_PRECISION = 200;    const double GSF_SECTOR_NUMBER_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_DETECTION_INFO_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_INCIDENT_BEAM_ADJ_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_SYSTEM_CLEANING_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_DOPPLER_CORRECTION_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_SONAR_VERT_UNCERT_ASSUMED_HIGHEST_PRECISION = 100;    const double GSF_MEAN_ABS_COEFF_ASSUMED_HIGHEST_PRECISION = 100;    int             i, j; /* iterators */    double          *dptr; /* pointer to ping array */    unsigned short  *usptr; /* pointer to ping array */    unsigned char   *ucptr; /* pointer to ping array */    int             id; /* type of ping array subrecord */    double          max, min; /* min and max value of each ping array */    double          max_scale_factor, min_scale_factor; /* min and max allowable size of values in ping array */    double          highest_precision; /* starting value for multiplier */    for (i = 1; i <= GSF_MAX_PING_ARRAY_SUBRECORDS; i++)    {        dptr = NULL;        usptr = NULL;        switch (i)        {            case GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY:                dptr = mb_ping->depth;                highest_precision = GSF_DEPTH_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY:                dptr = mb_ping->across_track;                highest_precision = GSF_ACROSS_TRACK_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY;                max_scale_factor = SHRT_MAX;                min_scale_factor = SHRT_MIN;                break;            case GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY:                dptr = mb_ping->along_track;                highest_precision = GSF_ALONG_TRACK_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY;                max_scale_factor = SHRT_MAX;                min_scale_factor = SHRT_MIN;                break;            case GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY:                dptr = mb_ping->travel_time;                highest_precision = GSF_TRAVEL_TIME_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_ARRAY:                dptr = mb_ping->beam_angle;                highest_precision = GSF_BEAM_ANGLE_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_ARRAY;                max_scale_factor = SHRT_MAX;                min_scale_factor = SHRT_MIN;                break;            case GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY:                dptr = mb_ping->mc_amplitude;                highest_precision = GSF_MEAN_CAL_AMPLITUDE_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY;                max_scale_factor = SCHAR_MAX;                min_scale_factor = SCHAR_MIN;                break;            case GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY:                dptr = mb_ping->mr_amplitude;                highest_precision = GSF_MEAN_REL_AMPLITUDE_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY;                max_scale_factor = UCHAR_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY:                dptr = mb_ping->echo_width;                highest_precision = GSF_ECHO_WIDTH_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY;                max_scale_factor = UCHAR_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_QUALITY_FACTOR_ARRAY:                dptr = mb_ping->quality_factor;                highest_precision = GSF_QUALITY_FACTOR_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_QUALITY_FACTOR_ARRAY;                max_scale_factor = UCHAR_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_RECEIVE_HEAVE_ARRAY:                dptr = mb_ping->receive_heave;                highest_precision = GSF_RECEIVE_HEAVE_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_RECEIVE_HEAVE_ARRAY;                max_scale_factor = UCHAR_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_DEPTH_ERROR_ARRAY:                dptr = mb_ping->depth_error;                highest_precision = GSF_DEPTH_ERROR_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_DEPTH_ERROR_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ERROR_ARRAY:                dptr = mb_ping->across_track_error;                highest_precision = GSF_ACROSS_TRACK_ERROR_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ERROR_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ERROR_ARRAY:                dptr = mb_ping->along_track_error;                highest_precision = GSF_ALONG_TRACK_ERROR_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ERROR_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY:                dptr = mb_ping->nominal_depth;                highest_precision = GSF_NOMINAL_DEPTH_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_QUALITY_FLAGS_ARRAY:                ucptr = mb_ping->quality_flags;                highest_precision = GSF_QUALITY_FLAGS_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_QUALITY_FLAGS_ARRAY;                max_scale_factor = UCHAR_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_BEAM_FLAGS_ARRAY:                ucptr = mb_ping->beam_flags;                highest_precision = GSF_BEAM_FLAGS_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_BEAM_FLAGS_ARRAY;                max_scale_factor = UCHAR_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_SIGNAL_TO_NOISE_ARRAY:                dptr = mb_ping->signal_to_noise;                highest_precision = GSF_SIGNAL_TO_NOISE_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_SIGNAL_TO_NOISE_ARRAY;                max_scale_factor = UCHAR_MAX;                min_scale_factor = 0;                break;           case GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_FORWARD_ARRAY:                dptr = mb_ping->beam_angle_forward;                highest_precision = GSF_BEAM_ANGLE_FORWARD_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_FORWARD_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY:                dptr = mb_ping->TVG_dB;                highest_precision = GSF_TVG_dB_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_VERTICAL_ERROR_ARRAY:                dptr = mb_ping->vertical_error;                highest_precision = GSF_VERTICAL_ERROR_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_VERTICAL_ERROR_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_HORIZONTAL_ERROR_ARRAY:                dptr = mb_ping->horizontal_error;                highest_precision = GSF_HORIZONTAL_ERROR_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_HORIZONTAL_ERROR_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_SECTOR_NUMBER_ARRAY:                usptr = mb_ping->sector_number;                highest_precision = GSF_SECTOR_NUMBER_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_SECTOR_NUMBER_ARRAY;                max_scale_factor = UCHAR_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_DETECTION_INFO_ARRAY:                usptr = mb_ping->detection_info;                highest_precision = GSF_DETECTION_INFO_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_DETECTION_INFO_ARRAY;                max_scale_factor = UCHAR_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_INCIDENT_BEAM_ADJ_ARRAY:                dptr = mb_ping->incident_beam_adj;                highest_precision = GSF_INCIDENT_BEAM_ADJ_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_INCIDENT_BEAM_ADJ_ARRAY;                max_scale_factor = SCHAR_MAX;                min_scale_factor = SCHAR_MIN;                break;            case GSF_SWATH_BATHY_SUBRECORD_SYSTEM_CLEANING_ARRAY:                usptr = mb_ping->system_cleaning;                highest_precision = GSF_SYSTEM_CLEANING_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_SYSTEM_CLEANING_ARRAY;                max_scale_factor = UCHAR_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_DOPPLER_CORRECTION_ARRAY:                dptr = mb_ping->doppler_corr;                highest_precision = GSF_DOPPLER_CORRECTION_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_DOPPLER_CORRECTION_ARRAY;                max_scale_factor = SCHAR_MAX;                min_scale_factor = SCHAR_MIN;                break;            case GSF_SWATH_BATHY_SUBRECORD_SONAR_VERT_UNCERT_ARRAY:                dptr = mb_ping->sonar_vert_uncert;                highest_precision = GSF_SONAR_VERT_UNCERT_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_SONAR_VERT_UNCERT_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;            case GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY:                dptr = mb_ping->mean_abs_coeff;                highest_precision = GSF_MEAN_ABS_COEFF_ASSUMED_HIGHEST_PRECISION;                id = GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY;                max_scale_factor = USHRT_MAX;                min_scale_factor = 0;                break;        }        if (dptr != NULL || usptr != NULL)        {            max = DBL_MIN;            min = DBL_MAX;            if (dptr != NULL)            {                for (j = 0; j < mb_ping->number_beams; j++)                {                    if (dptr[j] > max)                        max = dptr[j];                    if (dptr[j] < min)                        min = dptr[j];                }            }            else if (usptr != NULL)            {                for (j = 0; j < mb_ping->number_beams; j++)                {                    if (usptr[j] > max)                        max = (double) usptr[j];                    if (usptr[j] < min)                        min = (double) usptr[j];                }            }            else if (ucptr != NULL)            {                for (j = 0; j < mb_ping->number_beams; j++)                {                    if (ucptr[j] > max)                        max = (double) ucptr[j];                    if (ucptr[j] < min)                        min = (double) ucptr[j];                }            }            mb_ping->scaleFactors.scaleTable[id - 1].offset = 0;            mb_ping->scaleFactors.scaleTable[id - 1].multiplier = highest_precision;            /* Clear the high order 4 bits of the compression flag field */            mb_ping->scaleFactors.scaleTable[id - 1].compressionFlag &= 0x0F;            /* set these bits to specify the default field size */            mb_ping->scaleFactors.scaleTable[id - 1].compressionFlag |= GSF_FIELD_SIZE_DEFAULT;            /* apply the multiplier and offset to the maximum value, if             * the new value is greater then the max scale factor multiplier             * size, decrease the multiplier by 2 until this condition is no             * longer violated. */            while (((( max + mb_ping->scaleFactors.scaleTable[id - 1].offset) * mb_ping->scaleFactors.scaleTable[id - 1].multiplier) > max_scale_factor)                    || ((( min + mb_ping->scaleFactors.scaleTable[id - 1].offset) * mb_ping->scaleFactors.scaleTable[id - 1].multiplier) < min_scale_factor ))            {                mb_ping->scaleFactors.scaleTable[id - 1].multiplier = (int) ( mb_ping->scaleFactors.scaleTable[id - 1].multiplier / 2.0 );            }            if (mb_ping->scaleFactors.scaleTable[id - 1].multiplier < 1.0)            {                mb_ping->scaleFactors.scaleTable[id - 1].multiplier = 1.0;            }        }    }    return 0;}
+/********************************************************************
+ *
+ * Module Name : GSF_ENC.C
+ *
+ * Author/Date : J. S. Byrne / 3 May 1994
+ *
+ * Description :
+ *  This source file contains the GSF functions for encoding a GSF byte
+ *   stream from host data structures.
+ *
+ * Restrictions/Limitations :
+ * 1) This library assumes the host computer uses the ASCII character set.
+ * 2) This library assumes that the data types u_short and u_int are defined
+ *    on the host machine, where a u_short is a 16 bit unsigned integer, and
+ *    a u_int is a 32 bit unsigned integer.
+ * 3) This library assumes that the type short is 16 bits, and that
+ *    the type int is 32 bits.
+ *
+ *
+ * Change Descriptions :
+ * who          when      what
+ * ---          ----      ----
+ * jsb          10-17-94  Added support for Reson SeaBat data
+ * jsb          03-10-95  Modified ping record to store dynamic depth
+ *                        corrector and tide corrector.
+ * jsb          11-13-95  Added Unique id for EM1000
+ * jsb          12-22-95  Added nearest scaled integer rounding on latitude
+ *                        longitude, roll, pitch, and heave.
+ * hem          08-20-96  Added gsfEncodeSinglebeam; added EncodeSASSSpecific,
+ *                        EncodeTypeIIISeaBeamSpecific, EncodeSeaMapSpecific,
+ *                        EncodeEchotracSpecific, EncodeMGD77Specific,
+ *                        EncodeBDBSpecific, & EncodeNOSHDBSpecific; changed
+ *                        gsfEncodeComment so that it uses the length of the
+ *                        comment specified in the record rather than using
+ *                        strlen to find the length of the comment (to allow
+ *                        nulls in the comment);
+ * jsb          09-27-96  Added support for SeaBeam with amplitude data
+ * jsb          03-24-97  Added support for gsfSeaBatIISpecific as a replacement
+ *                        of gsfSeaBatSpecific for the Reson 900x series sonars.
+ *                        Added gsfSeaBat8101Specific for the Reson 8101 series
+ *                        sonar.
+ * hem          07-23-97  Added code to gsfEncodeSwathBathySummary,
+ *                        gsfEncodeSinglebeam, and
+ *                        gsfEncodeSoundVelocityProfile to handle rounding
+ *                        latitudes, longitudes, depths, etc. properly before
+ *                        storage in the GSF file.
+ * bac          10-27-97  Added EncodeSeaBeam2112Specific to support the Sea
+ *                        Beam 2112/36 sonar.
+ * dwc          1-9-98    Added EncodeElacMkIISpecific to support the Elac
+ *                        Bottomchart MkII sonar.
+ * jsb          09/28/98  Added gsfEncodeHVNavigationError. This change made
+ *                        in response to CRs: GSF-98-001, and GSF-98-002. Also
+ *                        added support for horizontal error ping array subrecord
+ *                        in responce to CR: GSF-98-003. Removed the computation of
+ *                        error_sum from gsfEncodeSwathBathymetryPing, now the library
+ *                        will write horizontal and vertical depth estimates for each
+ *                        ping if the array pointers are non-null.
+ * jsb          12/29/98  Added support for Simrad em3000 series sonar systems.
+ * wkm          3-30-99   Added EncodeCmpSassSpecific to deal with CMP SASS data.
+ * wkm          8-02-99   Updated EncodeCmpSassSpecific to include lntens (heave) with CMP SASS data.
+ * bac          10-24-00  Updated EncodeEM3Specific to include data fields from updated
+ *                        EM series runtime parameter datagram.
+ * bac          07-18-01  Added support for the Reson 8100 series of sonars.  Also removed the usage
+ *                        of C++ reserved words "class" and "operator".
+ * bac          10-12-01  Added a new attitude record definition.  The attitude record provides
+ *                        a method for logging full time-series attitude measurements in the GSF
+ *                        file, instead of attitude samples only at ping time.  Each attitude
+ *                        record contains arrays of attitude measurements for time, roll, pitch,
+ *                        heave and heading.  The number of measurements is user-definable, but
+ *                        because of the way in which measurement times are stored, a single
+ *                        attitude record should never contain more than sixty seconds worth of
+ *                        data.
+ * jsb          01-19-02  Added support for Simrad EM120, and removed references to unused variables.
+ * bac          06-19-03  Added support for bathymetric receive beam time series intensity data (i.e., Simrad
+ *                        "Seabed image" and Reson "snippets").  Included RWL updates of 12-19-02 for adding
+ *                        sensor-specific singlebeam information to the MB sensor specific subrecords.
+ * bac          12-28-04  Added support for Navisound singlebeam, EM3000D, EM3002, and EM3002D.  Fixed
+ *                        encoding of 1-byte BRB intensity values.  Corrected the encode/decode of Reson
+ *                        projector angle.  Added beam_spacing to the gsfReson8100Specific subrecord.
+ * bac          06-28-06  Added support for EM121A data received via Kongsberg SIS, mapped to existing
+ *                        EM3 series sensor specific data structure. Replaced references to long types
+ *                        with int types, for compilation on 64-bit architectures.
+ * dhg          10-24-06  Added support for GeoSwathPlus interferometric sonar
+ * dhg          10-31-06  Added support for GeoSwathPlus "range_error" and "angle_error"
+ * dhg          11-01-06  Corrected "model_number" and "frequency" for "GeoSwathPlusSpecific" record
+ * mab          02-01-09  Updates to support Reson 7125. Added new subrecord IDs and subrecord definitions for Kongsberg
+ *                        sonar systems where TWTT and angle are populated from raw range and beam angle datagram. Added
+ *                        new subrecord definition for EM2000.  Bug fixes in gsfOpen and gsfPercent.
+ * clb          02-25-11  Changed the EncodeBRBIntensity() function when bits_per_sample is 12
+ * clb          04-06-11  Changes made for DeltaT
+ * clb          04-13-11  When encoding a ping, reject it if the number of beams <= 0
+ * clb          06-21-11  Added em12 to list of available sensors
+ * clb          09-20-11  Added support for R2Sonic
+ * jcd          02-17-12  fixed EncodeQualityFlagsArray to work with num_beams not evenly divisible by 4
+ *
+ * Classification : Unclassified
+ *
+ * References : DoDBL Generic Sensor Format Sept. 30, 1993
+ *
+ * Copyright 2019 Leidos, Inc.
+ * There is no charge to use the library, and it may be accessed at:
+ * https://www.leidos.com/products/ocean-marine#gsf
+ * This library may be redistributed and/or modified under the terms of
+ * the GNU Lesser General Public License version 2.1, as published by the
+ * Free Software Foundation.  A copy of the LGPL 2.1 license is included with
+ * the GSF distribution and is avaialbe at: http://opensource.org/licenses/LGPL-2.1.
+ *
+ * Leidos, Inc. configuration manages GSF, and provides GSF releases. Users are
+ * strongly encouraged to communicate change requests and change proposals to Leidos, Inc.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ ********************************************************************/
+
+/* Standard C Library Includes */
+#include <string.h>
+#include <stdlib.h>
+
+/* Get network byte swap functions */
+#include <sys/types.h>
+#if !defined WIN32  && !defined WIN64
+#include <netinet/in.h>
+#else
+#include <winsock.h>
+#endif
+
+/* GSF library interface description */
+#include "gsf.h"
+#include "gsf_enc.h"
+
+/* Global external data defined in this module */
+extern int      gsfError;  /* Defined in gsf.c */
+
+int EncodeCompressedUnsignedShortArray (unsigned char *sptr, const unsigned short *array, int num_beams, int subrecordID);
+int EncodeCompressedArray (unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int subrecordID);
+
+/* Function prototypes for this file */
+static int      EncodeScaleFactors(unsigned char *sptr, const gsfScaleFactors *sf);
+static int      EncodeTwoByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);
+static int      EncodeSignedTwoByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);
+static int      EncodeByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);
+static int      EncodeFourByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);
+static int      EncodeSignedFourByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);
+static int      EncodeSignedByteArray(unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors *sf, int id);
+static int      EncodeBeamFlagsArray(unsigned char *sptr, const unsigned char *array, int num_beams);
+static int      EncodeQualityFlagsArray(unsigned char *sptr, const unsigned char *array, int num_beams);
+static int      EncodeFromUnsignedShortToByteArray(unsigned char *sptr, const unsigned short *array, int num_beams, const gsfScaleFactors *sf, int id);
+static int      EncodeBRBIntensity(unsigned char *sptr, const gsfBRBIntensity *idata, int num_beams, int sensor_id, int bytes_used);
+static int      EncodeSeabeamSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeEM12Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeEM100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeEM950Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeEM1000Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeEM121ASpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeEM121Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeEM3ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);
+static int      EncodeEM4ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);
+static int      EncodeKMALLImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);
+static int      EncodeReson7100ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);
+static int      EncodeResonTSeriesImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);
+static int      EncodeR2SonicImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);
+static int      EncodeCmpSassSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeSeaMapSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata, const GSF_FILE_TABLE *ft);
+static int      EncodeSeaBatSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeEchotracSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata);
+static int      EncodeMGD77Specific(unsigned char *sptr, const gsfSBSensorSpecific *sdata);
+static int      EncodeBDBSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata);
+static int      EncodeNOSHDBSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata);
+static int      EncodeSBAmpSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeSeaBatIISpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeSeaBat8101Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeSeaBeam2112Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeElacMkIISpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeEM3Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeEM3RawSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeReson7100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeReson8100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeResonTSeriesSpecific(unsigned char *sptr, gsfSensorSpecific *sdata);
+static int      EncodeSBEchotracSpecific(unsigned char *sptr, const t_gsfSBEchotracSpecific *sdata);
+static int      EncodeSBMGD77Specific(unsigned char *sptr, const t_gsfSBMGD77Specific *sdata);
+static int      EncodeSBBDBSpecific(unsigned char *sptr, const t_gsfSBBDBSpecific *sdata);
+static int      EncodeSBNOSHDBSpecific(unsigned char *sptr, const t_gsfSBNOSHDBSpecific *sdata);
+static int      EncodeSBNavisoundSpecific(unsigned char *sptr, const t_gsfSBNavisoundSpecific *sdata);
+static int      EncodeEM4Specific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeKMALLSpecific(unsigned char *sptr, const gsfSensorSpecific * sdata);
+static int      EncodeGeoSwathPlusSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeKlein5410BssSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeDeltaTSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeR2SonicSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeKlein5410BssImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata);
+
+#if 1
+/* 3-30-99 wkm: obsolete */
+static int      EncodeTypeIIISeaBeamSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+static int      EncodeSASSSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata);
+#endif
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeHeader
+ *
+ * Description : This function encodes a GSF header into external byte
+ *   stream form from the passed gsfHeader structure.
+ *
+ * Inputs :
+ *    sptr = a pointer to the unsigned char buffer to write into.
+ *    header = a pointer to the gsfHeader structure to read from.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+int
+gsfEncodeHeader(unsigned char *sptr, gsfHeader * header)
+{
+    unsigned char  *p = sptr;
+
+    memset(header->version, 0, GSF_VERSION_SIZE);
+    strncpy(header->version, GSF_VERSION, (GSF_VERSION_SIZE-1));
+    header->version[GSF_VERSION_SIZE-1] = 0;
+
+    memcpy(p, header->version, GSF_VERSION_SIZE);
+    p += GSF_VERSION_SIZE;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeSwathBathySummary
+ *
+ * Description : This function encodes a GSF swath bathymetry summary record
+ *   into external byte stream form from the passed gsfHeader structure.
+ *
+ * Inputs :
+ *   sptr = a pointer to the unsigned char buffer to write into.
+ *   sum = a pointer to the gsfSwathBathySummary structure to read from.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+int
+gsfEncodeSwathBathySummary(unsigned char *sptr, gsfSwathBathySummary *sum)
+{
+    unsigned char  *p = sptr;
+    double          dtemp;
+    gsfuLong        ltemp;
+
+    /* First 8 bytes contain the time of the first ping in the file */
+    ltemp = htonl(sum->start_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    ltemp = htonl(sum->start_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next 8 bytes contain the time of the last ping in the file */
+    ltemp = htonl(sum->end_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    ltemp = htonl(sum->end_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the minimum latitude. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = sum->min_latitude * 1.0e7;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the minimum longitude. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = sum->min_longitude * 1.0e7;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the maximum latitude. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = sum->max_latitude * 1.0e7;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the maximum longitude. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = sum->max_longitude * 1.0e7;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the minimum depth. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = sum->min_depth * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the maximum depth. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = sum->max_depth * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEchotracSpecific
+ *
+ * Description : This function encodes the Bathy 2000 and echotrac
+ *  sensor specific data from the HSPS source files.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeEchotracSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+
+    /* First two byte integer contains the navigation error */
+    stemp = htons((gsfuShort) (sdata->gsfEchotracSpecific.navigation_error));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the most probable position source navigation */
+    *p = (unsigned char) sdata->gsfEchotracSpecific.mpp_source;
+    p += 1;
+
+    /* Next byte contains the tide source */
+    *p = (unsigned char) sdata->gsfEchotracSpecific.tide_source;
+    p += 1;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeMGD77Specific
+ *
+ * Description : This function encodes the MGD77 fields
+ * into an MGD77 record. The MGD77 Singlebeam is essentially
+ * survey trackline data, and actual survey data can be retrieved
+ * from the source.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeMGD77Specific(unsigned char *sptr, const gsfSBSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuLong        ltemp;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the time zone correction */
+    stemp = htons((gsfuShort) (sdata->gsfMGD77Specific.time_zone_corr));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The Next two byte integer contains how the navigation was obtained */
+    stemp = htons((gsfuShort) (sdata->gsfMGD77Specific.position_type_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The Next two byte integer contains on how the sound velocity
+       correction was made */
+    stemp = htons((gsfuShort) (sdata->gsfMGD77Specific.correction_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The Next two byte integer contains how the bathymetry was obtained */
+    stemp = htons((gsfuShort) (sdata->gsfMGD77Specific.bathy_type_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The Next two byte integer contains the quality code for Nav */
+    stemp = htons((gsfuShort) (sdata->gsfMGD77Specific.quality_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the two way travel time */
+    dtemp = sdata->gsfMGD77Specific.travel_time * 10000;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeBDBSpecific
+ *
+ * Description : This function encodes the BDB fields
+ * into a BDB record.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeBDBSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuLong        ltemp;
+
+    /* Next four byte integer contains the the document number */
+    ltemp = htonl((gsfuLong) (sdata->gsfBDBSpecific.doc_no));
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next byte contains the evaluation flag */
+    *p = (unsigned char) sdata->gsfBDBSpecific.eval;
+    p += 1;
+
+    /* Next byte contains the classification flag */
+    *p = (unsigned char) sdata->gsfBDBSpecific.classification;
+    p += 1;
+
+    /* Next byte contains the track adjustment flag */
+    *p = (unsigned char) sdata->gsfBDBSpecific.track_adj_flag;
+    p += 1;
+
+    /* Next byte contains the source flag */
+    *p = (unsigned char) sdata->gsfBDBSpecific.source_flag;
+    p += 1;
+
+    /* Next byte contains the discrete point or track line flag */
+    *p = (unsigned char) sdata->gsfBDBSpecific.pt_or_track_ln;
+    p += 1;
+
+    /* Next byte contains the datum flag */
+    *p = (unsigned char) sdata->gsfBDBSpecific.datum_flag;
+    p += 1;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeNOSHDBSpecific
+ *
+ * Description : This function encodes the NOSHDB fields into a
+ *               NOSHDB record.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeNOSHDBSpecific(unsigned char *sptr, const gsfSBSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+
+    /* First two byte integer contains the depth type code */
+    stemp = htons((gsfuShort) (sdata->gsfNOSHDBSpecific.type_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The Next two byte integer contains the cartographic code */
+    stemp = htons((gsfuShort) (sdata->gsfNOSHDBSpecific.carto_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeSinglebeam
+ *
+ * Description : This function encodes a GSF single beam ping record
+ *   in external byte stream form from a gsfSwathBathyPing structure.
+ *
+ * Inputs :
+ *   sptr = a pointer to the unsigned char buffer to write into
+ *   ping = a pointer to the gsfSwathBathPing record to read from
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *    GSF_UNRECOGNIZED_SENSOR_ID
+ *
+ ********************************************************************/
+int
+gsfEncodeSinglebeam(unsigned char *sptr, gsfSingleBeamPing * ping)
+{
+    gsfuLong        ltemp;
+    gsfuShort       stemp;
+    int             sensor_size = 0;
+    double          dtemp;
+    unsigned char  *p = sptr;
+    unsigned char  *temp_ptr;
+
+    /* First 8 bytes contain the time */
+    ltemp = htonl(ping->ping_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    ltemp = htonl(ping->ping_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the longitude. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = ping->longitude * 1.0e7;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the latitude. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = ping->latitude * 1.0e7;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the tide corrector for this ping.
+     * Round this to the nearest whole centimeter.
+     */
+    dtemp = ping->tide_corrector * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the depth corrector.
+     * Round this to the nearest whole centimeter.
+     */
+    dtemp = ping->depth_corrector * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the ship heading, round this value to the
+     * nearest one hundredth of a degree.
+     */
+    stemp = htons((gsfuShort) ((ping->heading * 100.0) + 0.501));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the pitch. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = ping->pitch * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the roll. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = ping->roll * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the heave. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = ping->heave * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the depth. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = ping->depth * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the sound speed correction.
+     * Round the scaled quantity to the nearest whole integer.
+     */
+    dtemp = ping->sound_speed_correction * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the positioning system type */
+    stemp = htons((gsfuShort) (ping->positioning_system_type));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+
+    /* Next possible subrecord is the sensor specific subrecord. Save the
+    *  current pointer, and leave room for the four byte subrecord identifier.
+    */
+    temp_ptr = p;
+    p += 4;
+
+    switch (ping->sensor_id)
+    {
+        case (GSF_SINGLE_BEAM_SUBRECORD_ECHOTRAC_SPECIFIC):
+            sensor_size = EncodeEchotracSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SINGLE_BEAM_SUBRECORD_BATHY2000_SPECIFIC):
+            sensor_size = EncodeEchotracSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SINGLE_BEAM_SUBRECORD_MGD77_SPECIFIC):
+            sensor_size = EncodeMGD77Specific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SINGLE_BEAM_SUBRECORD_BDB_SPECIFIC):
+            sensor_size = EncodeBDBSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SINGLE_BEAM_SUBRECORD_NOSHDB_SPECIFIC):
+            sensor_size = EncodeNOSHDBSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_UNKNOWN):
+            sensor_size = 0;
+            break;
+
+          default:
+            gsfError = GSF_UNRECOGNIZED_SENSOR_ID;
+            return (-1);
+    }
+
+    /*  Identifier has sensor specific id in first byte, and size in the
+    *  remaining three bytes
+    */
+    ltemp = ping->sensor_id << 24;
+    ltemp |= (gsfuLong) sensor_size;
+    ltemp = htonl(ltemp);
+    memcpy(temp_ptr, &ltemp, 4);
+    p += sensor_size;
+
+    /* Return the number of bytes written into the buffer. */
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeSwathBathymetryPing
+ *
+ * Description : This function encodes a GSF swath bathymetry ping record
+ *   in external byte stream form from a gsfSwathBathyPing structure.
+ *
+ * Inputs :
+ *    sptr = a pointer to the unsigned char buffer to write into
+ *    ping = a pointer to the gsfSwathBathPing record to read from
+ *    ft = a pointer to the gsfFileTable, where the scale factors are
+ *         maintained.
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *   GSF_UNRECOGNIZED_SENSOR_ID
+ *   GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER
+ *   GSF_INVALID_NUM_BEAMS
+ *   GSF_MB_PING_RECORD_ENCODE_FAILED
+ *   GSF_RECORD_SIZE_ERROR
+ *
+ ********************************************************************/
+int
+gsfEncodeSwathBathymetryPing(unsigned char *sptr, gsfSwathBathyPing *ping, GSF_FILE_TABLE *ft)
+{
+    gsfuLong        ltemp;
+    gsfuShort       stemp;
+    int             sensor_size = 0;
+    int             ret;
+    double          dtemp;
+    unsigned char  *p = sptr;
+    unsigned char  *temp_ptr;
+
+    /* First 8 bytes contain the time */
+    ltemp = htonl(ping->ping_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    ltemp = htonl(ping->ping_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the longitude. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = ping->longitude * 1.0e7;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the latitude. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = ping->latitude * 1.0e7;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the number of beams */
+    if (ping->number_beams <= 0)
+    {
+        gsfError = GSF_INVALID_NUM_BEAMS;
+        return(-1);
+    }
+    stemp = htons(ping->number_beams);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the center beam number, portmost
+    *  outer beam is beam number 1.
+    */
+    stemp = htons(ping->center_beam);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the ping flags field */
+    stemp = htons(ping->ping_flags);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer is a reserved field */
+    stemp = htons(ping->reserved);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the tide corrector for this ping.
+     * Round this to the nearest whole centimeter.
+     */
+    dtemp = ping->tide_corrector * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the depth corrector.
+     * Round this to the nearest whole centimeter.
+     */
+    dtemp = ping->depth_corrector * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the ship heading, round this value to the
+     * nearest one hundredth of a degree. (Heading is always a positive value)
+     */
+    stemp = htons((gsfuShort) ((ping->heading * 100.0) + 0.501));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the pitch. Round the scaled quantity
+     * to the nearest whole integer.
+     */
+    dtemp = ping->pitch * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the roll. Round the scaled quantity
+     * to the nearest whole integer.
+     */
+    dtemp = ping->roll * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the heave. Round the scaled quantity
+     * to the nearest whole integer.
+     */
+    dtemp = ping->heave * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the course, round this value to the
+     * nearest one hundredth of a degree. (Course is always a positive value)
+     */
+    stemp = htons((gsfuShort) ((ping->course * 100.0) + 0.501));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the speed. Round the scaled quantity
+     * to the nearest integer. (Speed is always a positive quantity)
+     */
+    stemp = htons((gsfuShort) ((ping->speed * 100.0) + 0.501));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    if (ft->major_version_number > 2)
+    {
+        /* Next four byte integer contains the height. Round the scaled quantity
+         * to the nearest whole integer.
+         */
+        dtemp = ping->height * 1000.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfsLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* Next four byte integer contains the SEP. Round the scaled quantity
+         * to the nearest whole integer.
+         */
+        dtemp = ping->sep * 1000.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfsLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* Next four byte integer contains the GPS tide corrector for this ping.
+         * Round this to the nearest whole millimeter.
+         */
+        dtemp = ping->gps_tide_corrector * 1000.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfsLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* Next two bytes are spare space */
+        memset (p, 0, (size_t) 2);
+        p += 2;
+    }
+
+    /* The first possible subrecord is the scale factors.  The scale factor
+     * record is encoded for writing to the file once at the beginning of the
+     * file, and again whenever the scale factors change.
+     */
+    if ((memcmp(&ft->rec.mb_ping.scaleFactors, &ping->scaleFactors, sizeof(gsfScaleFactors))) ||
+        (ft->scales_read))
+    {
+        memcpy(&ft->rec.mb_ping.scaleFactors, &ping->scaleFactors, sizeof(gsfScaleFactors));
+        ret = EncodeScaleFactors(p, &ping->scaleFactors);
+        if (ret <= 0)
+        {
+            return(-1);
+        }
+        p += ret;
+        /* scales_read is set in gsfOpen if the file is opened create to ensure that scale factors
+         * are written with the first ping of each file. Clear scales_read here.
+         */
+        ft->scales_read = 0;
+    }
+
+    /* Next possible subrecord is the depth array.  For this array to be
+     * encoded there must be data, and a scale factor.
+     */
+    if (ping->depth != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY);
+        }
+        else
+        {
+            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY - 1].compressionFlag & 0xF0)
+            {
+                default:
+                case GSF_FIELD_SIZE_DEFAULT:
+                case GSF_FIELD_SIZE_TWO:
+                    ret = EncodeTwoByteArray(p, ping->depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY);
+                    break;
+
+                case GSF_FIELD_SIZE_FOUR:
+                    ret = EncodeFourByteArray(p, ping->depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY);
+                    break;
+            }
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the nominal depth array.  For this array
+     * to be encoded there must be data, and a scale factor.
+     */
+    if (ping->nominal_depth != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->nominal_depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY);
+        }
+        else
+        {
+            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY - 1].compressionFlag & 0xF0)
+            {
+                default:
+                case GSF_FIELD_SIZE_DEFAULT:
+                case GSF_FIELD_SIZE_TWO:
+                    ret = EncodeTwoByteArray(p, ping->nominal_depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY);
+                    break;
+
+                case GSF_FIELD_SIZE_FOUR:
+                    ret = EncodeFourByteArray(p, ping->nominal_depth, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY);
+                    break;
+            }
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the across track distance array.  For this
+    * array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->across_track != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->across_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY);
+        }
+        else
+        {
+            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY - 1].compressionFlag & 0xF0)
+            {
+                default:
+                case GSF_FIELD_SIZE_DEFAULT:
+                case GSF_FIELD_SIZE_TWO:
+                    ret = EncodeSignedTwoByteArray(p, ping->across_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY);
+                    break;
+
+                case GSF_FIELD_SIZE_FOUR:
+                    ret = EncodeSignedFourByteArray(p, ping->across_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY);
+                    break;
+            }
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the along track distance array.  For this
+    * array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->along_track != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->along_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY);
+        }
+        else
+        {
+            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY - 1].compressionFlag & 0xF0)
+            {
+                default:
+                case GSF_FIELD_SIZE_DEFAULT:
+                case GSF_FIELD_SIZE_TWO:
+                    ret = EncodeSignedTwoByteArray(p, ping->along_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY);
+                    break;
+
+                case GSF_FIELD_SIZE_FOUR:
+                    ret = EncodeSignedFourByteArray(p, ping->along_track, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY);
+                    break;
+            }
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the travel time array.  For this
+    * array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->travel_time != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->travel_time, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY);
+        }
+        else
+        {
+            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY - 1].compressionFlag & 0xF0)
+            {
+                default:
+                case GSF_FIELD_SIZE_DEFAULT:
+                case GSF_FIELD_SIZE_TWO:
+                    ret = EncodeTwoByteArray(p, ping->travel_time, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY);
+                    break;
+
+                case GSF_FIELD_SIZE_FOUR:
+                    ret = EncodeFourByteArray(p, ping->travel_time, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY);
+                    break;
+            }
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the beam angle array. For this
+    * array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->beam_angle != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->beam_angle, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_ARRAY);
+        }
+        else
+        {
+            ret = EncodeSignedTwoByteArray(p, ping->beam_angle, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the mean, calibrated amplitude array. For
+    * this array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->mc_amplitude != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->mc_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY);
+        }
+        else
+        {
+            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY - 1].compressionFlag & 0xF0)
+            {
+                default:
+                case GSF_FIELD_SIZE_DEFAULT:
+                case GSF_FIELD_SIZE_ONE:
+                    ret = EncodeSignedByteArray(p, ping->mc_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY);
+                    break;
+
+                case GSF_FIELD_SIZE_TWO:
+                    ret = EncodeSignedTwoByteArray(p, ping->mc_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY);
+                    break;
+            }
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the mean, relative amplitude array.  For
+    * this array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->mr_amplitude != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->mr_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY);
+        }
+        else
+        {
+            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY - 1].compressionFlag & 0xF0)
+            {
+                default:
+                case GSF_FIELD_SIZE_DEFAULT:
+                case GSF_FIELD_SIZE_ONE:
+                    ret = EncodeByteArray(p, ping->mr_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY);
+                    break;
+
+                case GSF_FIELD_SIZE_TWO:
+                    ret = EncodeTwoByteArray(p, ping->mr_amplitude, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY);
+                    break;
+            }
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the echo width array. For this
+    * array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->echo_width != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->echo_width, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY);
+        }
+        else
+        {
+            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY - 1].compressionFlag & 0xF0)
+            {
+                default:
+                case GSF_FIELD_SIZE_DEFAULT:
+                case GSF_FIELD_SIZE_ONE:
+                    ret = EncodeByteArray(p, ping->echo_width, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY);
+                    break;
+
+                case GSF_FIELD_SIZE_TWO:
+                    ret = EncodeTwoByteArray(p, ping->echo_width, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY);
+                    break;
+            }
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the quality factor array.  For this
+    * array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->quality_factor != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_QUALITY_FACTOR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->quality_factor, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_QUALITY_FACTOR_ARRAY);
+        }
+        else
+        {
+            ret = EncodeByteArray(p, ping->quality_factor, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_QUALITY_FACTOR_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of ship heave at beam reception
+    * time. For this array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->receive_heave != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_RECEIVE_HEAVE_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->receive_heave, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_RECEIVE_HEAVE_ARRAY);
+        }
+        else
+        {
+        ret = EncodeSignedByteArray(p, ping->receive_heave, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_RECEIVE_HEAVE_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of estimated depth errors.
+    * For this array to be encoded there must be data, and a scale factor.
+    * jsb 10/19/98 This subrecord is obsolete, it is replaced with vertical_error.
+    */
+    if (ping->depth_error != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DEPTH_ERROR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->depth_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DEPTH_ERROR_ARRAY);
+        }
+        else
+        {
+            ret = EncodeTwoByteArray(p, ping->depth_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DEPTH_ERROR_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of estimated across track errors.
+    * For this array to be encoded there must be data, and a scale factor.
+    * jsb 10/19/98 This subrecord is obsolete, it is replaced with horizontal_error.
+    */
+    if (ping->across_track_error != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ERROR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->across_track_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ERROR_ARRAY);
+        }
+        else
+        {
+            ret = EncodeTwoByteArray(p, ping->across_track_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ERROR_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of estimated along track errors.
+    * For this array to be encoded there must be data, and a scale factor.
+    * jsb 10/19/98 This subrecord is obsolete, it is replaced with horizontal_error.
+    */
+    if (ping->along_track_error != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ERROR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->along_track_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ERROR_ARRAY);
+        }
+        else
+        {
+            ret = EncodeTwoByteArray(p, ping->along_track_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ERROR_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of beam status flags */
+    if (ping->beam_flags != (unsigned char *) NULL)
+    {
+        ret = EncodeBeamFlagsArray(p, ping->beam_flags, ping->number_beams);
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the beam quality flags provided by the
+     * Reson SeaBat system.  There are two bits per beam.
+     */
+    if (ping->quality_flags != (unsigned char *) NULL)
+    {
+        ret = EncodeQualityFlagsArray(p, ping->quality_flags, ping->number_beams);
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of signal to noise ratios.
+    * For this array to be encoded there must be new data, and a scale factor.
+    */
+    if (ping->signal_to_noise != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_SIGNAL_TO_NOISE_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->signal_to_noise, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SIGNAL_TO_NOISE_ARRAY);
+        }
+        else
+        {
+            ret = EncodeByteArray(p, ping->signal_to_noise, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SIGNAL_TO_NOISE_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the beam angle forward array. For this
+    * array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->beam_angle_forward != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_FORWARD_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->beam_angle_forward, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_FORWARD_ARRAY);
+        }
+        else
+        {
+            ret = EncodeTwoByteArray(p, ping->beam_angle_forward, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_FORWARD_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of estimated vertical errors.
+    * For this array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->vertical_error != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_VERTICAL_ERROR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->vertical_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_VERTICAL_ERROR_ARRAY);
+        }
+        else
+        {
+            ret = EncodeTwoByteArray(p, ping->vertical_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_VERTICAL_ERROR_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of estimated horizontal errors.
+    * For this array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->horizontal_error != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_HORIZONTAL_ERROR_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->horizontal_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_HORIZONTAL_ERROR_ARRAY);
+        }
+        else
+        {
+            ret = EncodeTwoByteArray(p, ping->horizontal_error, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_HORIZONTAL_ERROR_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of transmit sector numbers. */
+    if (ping->sector_number != (unsigned short *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_SECTOR_NUMBER_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedUnsignedShortArray (p, ping->sector_number, ping->number_beams, GSF_SWATH_BATHY_SUBRECORD_SECTOR_NUMBER_ARRAY);
+        }
+        else
+        {
+            /* By default this array is coded as a one byte value */
+            ret = EncodeFromUnsignedShortToByteArray(p, ping->sector_number, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SECTOR_NUMBER_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of beam detection information values. */
+    if (ping->detection_info != (unsigned short *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DETECTION_INFO_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedUnsignedShortArray (p, ping->detection_info, ping->number_beams, GSF_SWATH_BATHY_SUBRECORD_DETECTION_INFO_ARRAY);
+        }
+        else
+        {
+            /* By default this array is coded as a one byte value */
+            ret = EncodeFromUnsignedShortToByteArray(p, ping->detection_info, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DETECTION_INFO_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of beam detection information values. */
+    if (ping->incident_beam_adj != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_INCIDENT_BEAM_ADJ_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->incident_beam_adj, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_INCIDENT_BEAM_ADJ_ARRAY);
+        }
+        else
+        {
+            ret = EncodeSignedByteArray(p, ping->incident_beam_adj, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_INCIDENT_BEAM_ADJ_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the array of data cleaning information received from the system. */
+    if (ping->system_cleaning != (unsigned short *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_SYSTEM_CLEANING_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedUnsignedShortArray (p, ping->system_cleaning, ping->number_beams, GSF_SWATH_BATHY_SUBRECORD_SYSTEM_CLEANING_ARRAY);
+        }
+        else
+        {
+            /* By default this array is coded as a one byte value */
+            ret = EncodeFromUnsignedShortToByteArray(p, ping->system_cleaning, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SYSTEM_CLEANING_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* The next possible subrecord is the array of correction values used to correct the travel time array for Doppler for FM signals */
+    if (ping->doppler_corr != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DOPPLER_CORRECTION_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->doppler_corr, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DOPPLER_CORRECTION_ARRAY);
+        }
+        else
+        {
+            ret = EncodeSignedByteArray(p, ping->doppler_corr, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DOPPLER_CORRECTION_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* The next possible subrecord is the array of vertical uncertainties provided by the sonar */
+    if (ping->sonar_vert_uncert != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_SONAR_VERT_UNCERT_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->sonar_vert_uncert, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SONAR_VERT_UNCERT_ARRAY);
+        }
+        else
+        {
+            ret = EncodeTwoByteArray(p, ping->sonar_vert_uncert, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SONAR_VERT_UNCERT_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* The next possible subrecord is the array of vertical uncertainties provided by the sonar */
+    if (ping->sonar_horz_uncert != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_SONAR_HORZ_UNCERT_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->sonar_horz_uncert, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SONAR_HORZ_UNCERT_ARRAY);
+        }
+        else
+        {
+            ret = EncodeTwoByteArray(p, ping->sonar_horz_uncert, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_SONAR_HORZ_UNCERT_ARRAY);
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the detction window length array. For this
+    * array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->detection_window != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->detection_window, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY);
+        }
+        else
+        {
+            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY - 1].compressionFlag & 0xF0)
+            {
+                case GSF_FIELD_SIZE_ONE:
+                    ret = EncodeByteArray(p, ping->detection_window, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY);
+                    break;
+
+                default:
+                case GSF_FIELD_SIZE_DEFAULT:
+                case GSF_FIELD_SIZE_TWO:
+                    ret = EncodeTwoByteArray(p, ping->detection_window, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY);
+                    break;
+
+                case GSF_FIELD_SIZE_FOUR:
+                    ret = EncodeFourByteArray(p, ping->detection_window, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_DETECTION_WINDOW_ARRAY);
+                    break;
+            }
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the mean absolute coefficient array. For this
+    * array to be encoded there must be data, and a scale factor.
+    */
+    if (ping->mean_abs_coeff != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->mean_abs_coeff, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY);
+        }
+        else
+        {
+            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY - 1].compressionFlag & 0xF0)
+            {
+                case GSF_FIELD_SIZE_ONE:
+                    ret = EncodeByteArray(p, ping->mean_abs_coeff, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY);
+                    break;
+
+                default:
+                case GSF_FIELD_SIZE_DEFAULT:
+                case GSF_FIELD_SIZE_TWO:
+                    ret = EncodeTwoByteArray(p, ping->mean_abs_coeff, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY);
+                    break;
+
+                case GSF_FIELD_SIZE_FOUR:
+                    ret = EncodeFourByteArray(p, ping->mean_abs_coeff, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY);
+                    break;
+            }
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+    
+    if (ping->TVG_dB != (double *) NULL)
+    {
+        if ((ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY - 1].compressionFlag & 0x0F) == GSF_ENABLE_COMPRESSION)
+        {
+            ret = EncodeCompressedArray (p, ping->TVG_dB, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY);
+        }
+        else
+        {
+            switch (ft->rec.mb_ping.scaleFactors.scaleTable[GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY - 1].compressionFlag & 0xF0)
+            {
+                case GSF_FIELD_SIZE_ONE:
+                    ret = EncodeByteArray(p, ping->TVG_dB, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY);
+                    break;
+
+                default:
+                case GSF_FIELD_SIZE_DEFAULT:
+                case GSF_FIELD_SIZE_TWO:
+                    ret = EncodeTwoByteArray(p, ping->TVG_dB, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY);
+                    break;
+
+                case GSF_FIELD_SIZE_FOUR:
+                    ret = EncodeFourByteArray(p, ping->TVG_dB, ping->number_beams, &ping->scaleFactors, GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY);
+                    break;
+            }
+        }
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Next possible subrecord is the sensor specific subrecord. Save the
+    *  current pointer, and leave room for the four byte subrecord identifier.
+    */
+    temp_ptr = p;
+    p += 4;
+
+    switch (ping->sensor_id)
+    {
+        case (GSF_SWATH_BATHY_SUBRECORD_UNKNOWN):
+            sensor_size = 0;
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_SEABEAM_SPECIFIC):
+            sensor_size = EncodeSeabeamSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_EM100_SPECIFIC):
+            sensor_size = EncodeEM100Specific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_EM12_SPECIFIC):
+            sensor_size = EncodeEM12Specific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_EM950_SPECIFIC):
+            sensor_size = EncodeEM950Specific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_EM121A_SPECIFIC):
+            sensor_size = EncodeEM121ASpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_EM121_SPECIFIC):
+            sensor_size = EncodeEM121Specific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_SASS_SPECIFIC):
+            sensor_size = EncodeSASSSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_SEAMAP_SPECIFIC):
+            sensor_size = EncodeSeaMapSpecific(p, &ping->sensor_data, ft);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_SEABAT_SPECIFIC):
+            sensor_size = EncodeSeaBatSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_EM1000_SPECIFIC):
+            sensor_size = EncodeEM1000Specific(p, &ping->sensor_data);
+            break;
+
+            #if 1
+            /* 3-30-99 wkm: obsolete */
+        case (GSF_SWATH_BATHY_SUBRECORD_TYPEIII_SEABEAM_SPECIFIC):
+            sensor_size = EncodeTypeIIISeaBeamSpecific(p, &ping->sensor_data);
+            break;
+            #endif
+
+        case (GSF_SWATH_BATHY_SUBRECORD_SB_AMP_SPECIFIC):
+            sensor_size = EncodeSBAmpSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_SEABAT_II_SPECIFIC):
+            sensor_size = EncodeSeaBatIISpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_SEABAT_8101_SPECIFIC):
+            sensor_size = EncodeSeaBat8101Specific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_SEABEAM_2112_SPECIFIC):
+            sensor_size = EncodeSeaBeam2112Specific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_ELAC_MKII_SPECIFIC):
+            sensor_size = EncodeElacMkIISpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_CMP_SASS_SPECIFIC):
+            sensor_size = EncodeCmpSassSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_EM2000_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3000_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM1002_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM300_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM120_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3002_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3000D_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3002D_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM121A_SIS_SPECIFIC):
+            sensor_size = EncodeEM3Specific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_EM2000_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3000_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM1002_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM300_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM120_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3002_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3000D_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3002D_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM121A_SIS_RAW_SPECIFIC):
+            sensor_size = EncodeEM3RawSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8101_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8111_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8124_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8125_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8150_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8160_SPECIFIC):
+            sensor_size = EncodeReson8100Specific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_7125_SPECIFIC):
+            sensor_size = EncodeReson7100Specific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_TSERIES_SPECIFIC):
+            sensor_size = EncodeResonTSeriesSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SB_SUBRECORD_ECHOTRAC_SPECIFIC):
+            sensor_size = EncodeSBEchotracSpecific(p, &ping->sensor_data.gsfSBEchotracSpecific);
+            break;
+
+        case (GSF_SWATH_BATHY_SB_SUBRECORD_BATHY2000_SPECIFIC):
+            sensor_size = EncodeSBEchotracSpecific(p, &ping->sensor_data.gsfSBEchotracSpecific);
+            break;
+
+        case (GSF_SWATH_BATHY_SB_SUBRECORD_MGD77_SPECIFIC):
+            sensor_size = EncodeSBMGD77Specific(p, &ping->sensor_data.gsfSBMGD77Specific);
+            break;
+
+        case (GSF_SWATH_BATHY_SB_SUBRECORD_BDB_SPECIFIC):
+            sensor_size = EncodeSBBDBSpecific(p, &ping->sensor_data.gsfSBBDBSpecific);
+            break;
+
+        case (GSF_SWATH_BATHY_SB_SUBRECORD_NOSHDB_SPECIFIC):
+            sensor_size = EncodeSBNOSHDBSpecific(p, &ping->sensor_data.gsfSBNOSHDBSpecific);
+            break;
+
+        case (GSF_SWATH_BATHY_SB_SUBRECORD_PDD_SPECIFIC):
+            sensor_size = EncodeSBEchotracSpecific(p, &ping->sensor_data.gsfSBPDDSpecific);
+            break;
+
+        case (GSF_SWATH_BATHY_SB_SUBRECORD_NAVISOUND_SPECIFIC):
+            sensor_size = EncodeSBNavisoundSpecific(p, &ping->sensor_data.gsfSBNavisoundSpecific);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_EM710_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM302_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM122_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM2040_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_ME70BO_SPECIFIC):
+            sensor_size = EncodeEM4Specific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_KMALL_SPECIFIC):
+            sensor_size = EncodeKMALLSpecific(p,&ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_GEOSWATH_PLUS_SPECIFIC):
+            sensor_size = EncodeGeoSwathPlusSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_KLEIN_5410_BSS_SPECIFIC):
+            sensor_size = EncodeKlein5410BssSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_DELTA_T_SPECIFIC):
+            sensor_size = EncodeDeltaTSpecific(p, &ping->sensor_data);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2020_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2022_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2024_SPECIFIC):
+            sensor_size = EncodeR2SonicSpecific(p, &ping->sensor_data);
+            break;
+
+        default:
+            gsfError = GSF_UNRECOGNIZED_SENSOR_ID;
+            return (-1);
+    }
+
+   /*  Identifier has sensor specific id in first byte, and size in the
+    *  remaining three bytes
+    */
+    ltemp = ping->sensor_id << 24;
+    ltemp |= (gsfuLong) sensor_size;
+    ltemp = htonl(ltemp);
+    memcpy(temp_ptr, &ltemp, 4);
+    p += sensor_size;
+
+    /* Next possible subrecord is the array of intensity series */
+    if (ping->brb_inten != (gsfBRBIntensity *) NULL)
+    {
+        ret = EncodeBRBIntensity(p, ping->brb_inten, ping->number_beams, ping->sensor_id, p-sptr-12);  /* 12 = GSF_FILL_SIZE_CHECKSUM */
+        if (ret <= 0)
+        {
+            return (-1);
+        }
+        p += ret;
+    }
+
+    /* Return the number of byte written into the buffer */
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeScaleFactors
+ *
+ * Description : This function encodes the ping scale factor subrecord
+ *  from internal form into external byte stream stream form.
+ *
+ * Inputs :
+ *   sptr = a pointer to the unsigned char buffer to write into
+ *   sf = a pointer to the GSF scale factors used to scale the data
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *   GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER
+ *
+ ********************************************************************/
+
+static int
+EncodeScaleFactors(unsigned char *sptr, const gsfScaleFactors *sf)
+{
+    unsigned char  *p = sptr;
+    gsfuLong        ltemp, subID;
+    double          dtemp;
+    unsigned int    subrecordID;
+    int             sf_counter;
+    unsigned int    itemp;
+
+    /* First byte contains the subrecord identifier */
+    ltemp = GSF_SWATH_BATHY_SUBRECORD_SCALE_FACTORS << 24;
+
+    /* Next four bytes contain the size of the subrecord, need to
+    * compute this value:
+    *  4 byte number of scale factors
+    * 12 bytes per number of scale factors
+    */
+    ltemp |= 4 + (12 * sf->numArraySubrecords);
+    subID = htonl(ltemp);
+    memcpy(p, &subID, 4);
+    p += 4;
+
+    /* Next four byte integer contains the number of scale factors */
+    ltemp = htonl((gsfuShort) (sf->numArraySubrecords));
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Loop to encode each scale factor which has been defined.
+    * The loop counter i indexes through the known subrecord ids
+    */
+    sf_counter = 0;
+    for (subrecordID = 1; subrecordID <= GSF_MAX_PING_ARRAY_SUBRECORDS; subrecordID++)
+    {
+        itemp = (int) (sf->scaleTable[subrecordID - 1].multiplier + 0.001);
+        if ((itemp >= MIN_GSF_SF_MULT_VALUE) && (itemp <= MAX_GSF_SF_MULT_VALUE))
+        {
+            /* First four byte integer has the id in the first byte, the
+             *  compression flags in the second byte, and the two lower
+             *  order bytes are reserved
+             */
+            ltemp = ((gsfuLong) subrecordID) << 24;     /* ID = loop counter */
+            ltemp |= (((gsfuLong) (sf->scaleTable[subrecordID - 1].compressionFlag)) << 16);
+
+            ltemp = htonl(ltemp);
+
+            memcpy(p, &ltemp, 4);
+            p += 4;
+
+            /* encode the scale factor multiplier */
+            dtemp = sf->scaleTable[subrecordID - 1].multiplier;
+            ltemp = htonl((gsfsLong) dtemp);
+            memcpy(p, &ltemp, 4);
+            p += 4;
+
+            /* encode the scale factor offset */
+            ltemp = htonl((gsfsLong) (sf->scaleTable[subrecordID - 1].offset));
+            memcpy(p, &ltemp, 4);
+            p += 4;
+
+            sf_counter++;
+        }
+    }
+
+    /* Make sure that we encoded the expected number of array subrecords. If not return an error condition */
+    if (sf_counter != sf->numArraySubrecords)
+    {
+        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;
+        return (-1);
+    }
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeTwoByteArray
+ *
+ * Description : This function encodes a two byte beam array subrecord
+ *  from internal form to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to the unsigned char buffer to write to
+ *    array = a pointer to the array of doubles from which to read
+ *    num_beams = the integer number of beams (number of doubles in the array)
+ *    sf = a pointer to the GSF scale factors used to scale the data
+ *    id = the array subrecord id
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER
+ *    GSF_INVALID_NUM_BEAMS
+ *
+ ********************************************************************/
+
+static int
+EncodeTwoByteArray(unsigned char *sptr, const double *array, int num_beams,
+    const gsfScaleFactors *sf, int id)
+{
+    unsigned char  *ptr = sptr;
+    gsfuLong        ltemp;
+    gsfuShort       stemp;
+    double          dtemp;
+    int             i;
+
+
+    /* Make sure we have a multiplier for this array */
+    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)
+    {
+        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;
+        return (-1);
+    }
+
+    if (num_beams <= 0)
+    {
+        gsfError = GSF_INVALID_NUM_BEAMS;
+        return(-1);
+    }
+
+    /* subrecord identifier has array id in first byte, and size in the
+    *  remaining three bytes
+    */
+    ltemp = id << 24;
+    ltemp |= num_beams * 2;
+    ltemp = htonl(ltemp);
+    memcpy(ptr, &ltemp, 4);
+    ptr += 4;
+
+    for (i = 0; i < num_beams; i++)
+    {
+        dtemp = (array[i] + sf->scaleTable[id - 1].offset) * sf->scaleTable[id - 1].multiplier;
+
+        /* Make sure we round to the nearest whole integer */
+        if (dtemp >= 0.0)
+        {
+            dtemp += 0.501;
+        }
+        else
+        {
+            dtemp -= 0.501;
+        }
+        stemp = (gsfuShort) dtemp;
+        stemp = htons(stemp);
+        memcpy(ptr, &stemp, 2);
+        ptr += 2;
+    }
+    return (ptr - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSignedTwoByteArray
+ *
+ * Description : This function encodes a two byte beam array subrecord
+ *  from internal form to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to the unsigned char buffer to write to
+ *    array = a pointer to the array of doubles from which to read
+ *    num_beams = the integer number of beams (number of doubles in the array)
+ *    sf = a pointer to the GSF scale factors used to scale the data
+ *    id = the array subrecord id
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER
+ *    GSF_INVALID_NUM_BEAMS
+ *
+ ********************************************************************/
+
+static int
+EncodeSignedTwoByteArray(unsigned char *sptr, const double *array, int num_beams,
+    const gsfScaleFactors *sf, int id)
+{
+    unsigned char  *ptr = sptr;
+    gsfuLong        ltemp;
+    gsfsShort       stemp;
+    double          dtemp;
+    int             i;
+
+    /* Make sure we have a multiplier for this array */
+    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)
+    {
+        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;
+        return (-1);
+    }
+
+    if (num_beams <= 0)
+    {
+        gsfError = GSF_INVALID_NUM_BEAMS;
+        return(-1);
+    }
+
+    /* subrecord identifier has array id in first byte, and size in the
+    *  remaining three bytes
+    */
+    ltemp = id << 24;
+    ltemp |= num_beams * 2;
+    ltemp = htonl(ltemp);
+    memcpy(ptr, &ltemp, 4);
+    ptr += 4;
+
+    for (i = 0; i < num_beams; i++)
+    {
+        dtemp = (array[i] + sf->scaleTable[id - 1].offset) *
+            sf->scaleTable[id - 1].multiplier;
+
+        /* Make sure we round to the nearest whole integer */
+        if (dtemp >= 0.0)
+        {
+            dtemp += 0.501;
+        }
+        else
+        {
+            dtemp -= 0.501;
+        }
+        stemp = (gsfsShort) dtemp;
+        stemp = htons(stemp);
+        memcpy(ptr, &stemp, 2);
+        ptr += 2;
+    }
+    return (ptr - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeFourByteArray
+ *
+ * Description : This function encodes a four byte beam array subrecord
+ *  from internal form to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to the unsigned char buffer to write to
+ *    array = a pointer to the array of doubles from which to read
+ *    num_beams = the integer number of beams (number of doubles in the array)
+ *    sf = a pointer to the GSF scale factors used to scale the data
+ *    id = the array subrecord id
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER
+ *    GSF_INVALID_NUM_BEAMS
+ *
+ ********************************************************************/
+
+static int
+EncodeFourByteArray(unsigned char *sptr, const double *array, int num_beams,
+    const gsfScaleFactors *sf, int id)
+{
+    unsigned char  *ptr = sptr;
+    gsfuLong        ltemp;
+    double          dtemp;
+    int             i;
+
+
+    /* Make sure we have a multiplier for this array */
+    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)
+    {
+        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;
+        return (-1);
+    }
+
+    if (num_beams <= 0)
+    {
+        gsfError = GSF_INVALID_NUM_BEAMS;
+        return(-1);
+    }
+
+    /* subrecord identifier has array id in first byte, and size in the
+    *  remaining three bytes
+    */
+    ltemp = id << 24;
+    ltemp |= num_beams * 4;
+    ltemp = htonl(ltemp);
+    memcpy(ptr, &ltemp, 4);
+    ptr += 4;
+
+    for (i = 0; i < num_beams; i++)
+    {
+        dtemp = (array[i] + sf->scaleTable[id - 1].offset) * sf->scaleTable[id - 1].multiplier;
+
+        /* Make sure we round to the nearest whole integer */
+        if (dtemp >= 0.0)
+        {
+            dtemp += 0.501;
+        }
+        else
+        {
+            dtemp -= 0.501;
+        }
+        ltemp = (gsfuLong) dtemp;
+        ltemp = htonl(ltemp);
+        memcpy(ptr, &ltemp, 4);
+        ptr += 4;
+    }
+    return (ptr - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSignedFourByteArray
+ *
+ * Description : This function encodes a two byte beam array subrecord
+ *  from internal form to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to the unsigned char buffer to write to
+ *    array = a pointer to the array of doubles from which to read
+ *    num_beams = the integer number of beams (number of doubles in the array)
+ *    sf = a pointer to the GSF scale factors used to scale the data
+ *    id = the array subrecord id
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER
+ *    GSF_INVALID_NUM_BEAMS
+ *
+ ********************************************************************/
+
+static int
+EncodeSignedFourByteArray(unsigned char *sptr, const double *array, int num_beams,
+    const gsfScaleFactors *sf, int id)
+{
+    unsigned char  *ptr = sptr;
+    gsfuLong        ltemp;
+    gsfsLong        stemp;
+    double          dtemp;
+    int             i;
+
+    /* Make sure we have a multiplier for this array */
+    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)
+    {
+        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;
+        return (-1);
+    }
+
+    if (num_beams <= 0)
+    {
+        gsfError = GSF_INVALID_NUM_BEAMS;
+        return(-1);
+    }
+
+    /* subrecord identifier has array id in first byte, and size in the
+    *  remaining three bytes
+    */
+    ltemp = id << 24;
+    ltemp |= num_beams * 4;
+    ltemp = htonl(ltemp);
+    memcpy(ptr, &ltemp, 4);
+    ptr += 4;
+
+    for (i = 0; i < num_beams; i++)
+    {
+        dtemp = (array[i] + sf->scaleTable[id - 1].offset) *
+            sf->scaleTable[id - 1].multiplier;
+
+        /* Make sure we round to the nearest whole integer */
+        if (dtemp >= 0.0)
+        {
+            dtemp += 0.501;
+        }
+        else
+        {
+            dtemp -= 0.501;
+        }
+        stemp = (gsfsLong) dtemp;
+        stemp = htonl(stemp);
+        memcpy(ptr, &stemp, 4);
+        ptr += 4;
+    }
+    return (ptr - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeByteArray
+ *
+ * Description : This function encodes a byte beam array subrecord
+ *  from internal form to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to the unsigned char buffer to write to
+ *    array = a pointer to the array of doubles from which to read
+ *    num_beams = the integer number of beams (number of doubles in the array)
+ *    sf = a pointer to the GSF scale factors used to scale the data
+ *    id = the array subrecord id
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER
+ *    GSF_INVALID_NUM_BEAMS
+ *
+ ********************************************************************/
+
+static int
+EncodeByteArray(unsigned char *sptr, const double *array, int num_beams,
+    const gsfScaleFactors * sf, int id)
+{
+    unsigned char  *ptr = sptr;
+    unsigned char   ctemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+    int             i;
+
+
+    /* Make sure we have a multiplier for this array */
+    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)
+    {
+        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;
+        return (-1);
+    }
+
+    if (num_beams <= 0)
+    {
+        gsfError = GSF_INVALID_NUM_BEAMS;
+        return(-1);
+    }
+
+    /* subrecord identifier has array id in first byte, and size in the
+    *  remaining three bytes
+    */
+    ltemp = id << 24;
+    ltemp |= num_beams;
+    ltemp = htonl(ltemp);
+    memcpy(ptr, &ltemp, 4);
+    ptr += 4;
+
+    for (i = 0; i < num_beams; i++)
+    {
+        dtemp = (array[i] + sf->scaleTable[id - 1].offset) *
+            sf->scaleTable[id - 1].multiplier;
+
+        /* Make sure we round to the nearest whole integer */
+        if (dtemp >= 0.0)
+        {
+            dtemp += 0.501;
+        }
+        else
+        {
+            dtemp -= 0.501;
+        }
+
+        ctemp = (unsigned char) dtemp;
+        memcpy(ptr, &ctemp, 1);
+        ptr++;
+    }
+    return (ptr - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSignedByteArray
+ *
+ * Description : This function encodes a byte beam array subrecord
+ *  from internal form to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to the unsigned char buffer to write to
+ *    array = a pointer to the array of doubles from which to read
+ *    num_beams = the integer number of beams (number of doubles in the array)
+ *    sf = a pointer to the GSF scale factors used to scale the data
+ *    id = the array subrecord id
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER
+ *    GSF_INVALID_NUM_BEAMS
+ *
+ ********************************************************************/
+
+static int
+EncodeSignedByteArray (unsigned char *sptr, const double *array, int num_beams, const gsfScaleFactors * sf, int id)
+{
+    unsigned char  *ptr = sptr;
+    char   ctemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+    int             i;
+
+
+    /* Make sure we have a multiplier for this array */
+    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)
+    {
+        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;
+        return (-1);
+    }
+
+    if (num_beams <= 0)
+    {
+        gsfError = GSF_INVALID_NUM_BEAMS;
+        return(-1);
+    }
+
+    /* subrecord identifier has array id in first byte, and size in the
+    *  remaining three bytes
+    */
+
+    ltemp = id << 24;
+    ltemp |= num_beams;
+    ltemp = htonl(ltemp);
+    memcpy(ptr, &ltemp, 4);
+    ptr += 4;
+
+    for (i = 0; i < num_beams; i++)
+    {
+        dtemp = (array[i] + sf->scaleTable[id - 1].offset) * sf->scaleTable[id - 1].multiplier;
+
+        ctemp = (char) dtemp;
+        memcpy(ptr, &ctemp, 1);
+        ptr++;
+    }
+    return (ptr - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeFromUnsignedShortToByteArray
+ *
+ * Description : This function encodes data from an unsigned short integer
+ *  beam array into a subrecord packed as one byte values on the byte stream.
+ *  Note that this function deliberately packs the unsigned short value
+ *  from each element of the array into a single byte on the stream.
+ *  Thus, the encoded dynamic range is 0 - 255.
+ *
+ * Inputs :
+ *    sptr = a pointer to the unsigned char buffer to write to
+ *    array = a pointer to the array of ints from which to read
+ *    num_beams = the integer number of beams (number of doubles in the array)
+ *    sf = a pointer to the GSF scale factors used to scale the data
+ *    id = the array subrecord id
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *    GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER
+ *    GSF_INVALID_NUM_BEAMS
+ *
+ ********************************************************************/
+
+static int
+EncodeFromUnsignedShortToByteArray(unsigned char *sptr, const unsigned short *array, int num_beams, const gsfScaleFactors *sf, int id)
+{
+    unsigned char  *ptr = sptr;
+    gsfuLong        ltemp;
+    double          dtemp;
+    int             i;
+
+    /* Make sure we have a multiplier for this array */
+    if (sf->scaleTable[id - 1].multiplier < 1.0e-6)
+    {
+        gsfError = GSF_ILLEGAL_SCALE_FACTOR_MULTIPLIER;
+        return (-1);
+    }
+
+    if (num_beams <= 0)
+    {
+        gsfError = GSF_INVALID_NUM_BEAMS;
+        return(-1);
+    }
+
+    /* subrecord identifier has array id in first byte, and size in the
+     *  remaining three bytes
+     */
+    ltemp = id << 24;
+    ltemp |= num_beams;
+    ltemp = htonl(ltemp);
+    memcpy(ptr, &ltemp, 4);
+    ptr += 4;
+
+    for (i = 0; i < num_beams; i++)
+    {
+        dtemp = (array[i] + sf->scaleTable[id - 1].offset) * sf->scaleTable[id - 1].multiplier;
+        *ptr = (unsigned char)dtemp;
+        ptr++;
+    }
+    return (ptr - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeBeamFlagsArray
+ *
+ * Description : This function encodes the array of beam flags from internal
+ *  form to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to the unsigned char buffer to write to
+ *    array = a pointer to the unsigned char buffer to read from
+ *    num_beams = an integer containing the number of beams (elements in array)
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *     GSF_INVALID_NUM_BEAMS
+ *
+ ********************************************************************/
+
+static int
+EncodeBeamFlagsArray(unsigned char *sptr, const unsigned char *array, int num_beams)
+{
+    unsigned char  *ptr = sptr;
+    gsfuLong        ltemp;
+    int             i;
+
+    if (num_beams <= 0)
+    {
+        gsfError = GSF_INVALID_NUM_BEAMS;
+        return(-1);
+    }
+
+    /* subrecord identifier has array id in first byte, and size in the
+    *  remaining three bytes
+    */
+    ltemp = GSF_SWATH_BATHY_SUBRECORD_BEAM_FLAGS_ARRAY << 24;
+    ltemp |= num_beams;
+    ltemp = htonl(ltemp);
+    memcpy(ptr, &ltemp, 4);
+    ptr += 4;
+
+    for (i = 0; i < num_beams; i++)
+    {
+        *ptr = array[i];
+        ptr++;
+    }
+
+    return (ptr - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeQualityFlagsArray
+ *
+ * Description : This function encodes the array of beam detection
+ *  quality flags for Reson SeaBat data from internal form to external
+ *  byte stream form. This field only has two bits so it packed as two
+ *  bits per beam.
+ *
+ * Inputs :
+ *    sptr = a pointer to the unsigned char buffer to write to
+ *    array = a pointer to the unsigned char buffer to read from
+ *    num_beams = an integer containing the number of beams (elements in array)
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *     GSF_INVALID_NUM_BEAMS
+ *
+ ********************************************************************/
+
+static int
+EncodeQualityFlagsArray(unsigned char *sptr, const unsigned char *array, int num_beams)
+{
+    unsigned char  *ptr = sptr;
+    gsfuLong        ltemp;
+    int             i;
+    int             shift;
+
+    if (num_beams <= 0)
+    {
+        gsfError = GSF_INVALID_NUM_BEAMS;
+        return(-1);
+    }
+
+    /* Leave four bytes free for the subrecord id and size */
+    ptr += 4;
+
+    /* Pack the array values */
+    shift = 6;
+    *ptr = 0;
+    for (i = 0; i < num_beams; i++)
+    {
+        *ptr |= array[i] << shift;
+
+        if (shift == 0)
+        {
+            ptr++;
+            *ptr = 0;
+            shift = 6;
+        }
+        else
+        {
+            shift -= 2;
+        }
+    }
+
+
+    /*  If shift doesn't get reset to 6 then we have a number of beams that is not evenly divisible by 4.  The problem is that
+        we actually encoded part of another byte but we didn't increment the ptr.  */
+
+    if (shift != 6) ptr++;
+
+
+    /* subrecord identifier has array id in first byte, and size in the
+    *  remaining three bytes
+    */
+    ltemp = GSF_SWATH_BATHY_SUBRECORD_QUALITY_FLAGS_ARRAY << 24;
+    ltemp |= (ptr - sptr - 4);
+    ltemp = htonl(ltemp);
+    memcpy(sptr, &ltemp, 4);
+
+    return (ptr - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSeabeamSpecific
+ *
+ * Description : This function encodes the sensor specific data from
+ *  a SeaBeam system into external byte stream form.
+ *
+ * Inputs :
+ *   sptr = a pointer to an unsigned char to write into
+ *   sdata = a pointer to a union of GSF sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSeabeamSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    gsfuShort       stemp;
+
+    stemp = htons((gsfuShort) sdata->gsfSeaBeamSpecific.EclipseTime);
+    memcpy(sptr, &stemp, 2);
+
+    return (2);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEM12Specific
+ *
+ * Description : This function encodes the sensor specific data from
+ *   a EM12 system into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+static int
+EncodeEM12Specific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the ping number */
+    stemp = htons((gsfuShort) (sdata->gsfEM12Specific.ping_number));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the resolution */
+    *p = (unsigned char)  sdata->gsfEM12Specific.resolution;
+    p += 1;
+
+    /* Next byte contains the ping quality factor*/
+    *p = (unsigned char)  sdata->gsfEM12Specific.ping_quality;
+    p += 1;
+
+    /* Next two byte integer contains the sound velocity * 10 */
+    dtemp = (sdata->gsfEM12Specific.sound_velocity * 10.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the operational mode */
+    *p = (unsigned char)  sdata->gsfEM12Specific.mode;
+    p += 1;
+
+    /* The next 32 bytes are spare space for future growth */
+    memset(p, 0, 32);
+    p += 32;
+
+    return (p - sptr);}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEm100Specific
+ *
+ * Description : This function encodes the EM100 sensor specific information
+ *  into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeEM100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the ship pitch */
+    dtemp = sdata->gsfEM100Specific.ship_pitch * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the transducer pitch */
+    dtemp = sdata->gsfEM100Specific.transducer_pitch * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the sonar mode (from the em100 amplitude datagram) */
+    *p = (unsigned char) sdata->gsfEM100Specific.mode;
+    p += 1;
+
+    /* Next byte contains the power (from the em100 amplitude datagram) */
+    *p = (unsigned char)  sdata->gsfEM100Specific.power;
+    p += 1;
+
+    /* Next byte contains the attenuation (from the em100 amplitude datagram) */
+    *p = (unsigned char)  sdata->gsfEM100Specific.attenuation;
+    p += 1;
+
+    /* Next byte contains the tvg (from the em100 amplitude datagram) */
+    *p = (unsigned char)  sdata->gsfEM100Specific.tvg;
+    p += 1;
+
+    /* Next byte contains the pulse length from the em100 amplitude datagram) */
+    *p = (unsigned char)  sdata->gsfEM100Specific.pulse_length;
+    p += 1;
+
+    /* Next two byte integer contains the counter from the em100
+    * amplitude datagram
+    */
+    stemp = htons((gsfuShort) (sdata->gsfEM100Specific.counter));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEm950Specific
+ *
+ * Description :  This function encodes the EM950 sensor specific information
+ *  into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeEM950Specific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the ping number */
+    stemp = htons((gsfuShort) (sdata->gsfEM950Specific.ping_number));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the sonar mode of operation */
+    *p = (unsigned char) sdata->gsfEM950Specific.mode;
+    p += 1;
+
+    /* Next byte contains the ping quality factor*/
+    *p = (unsigned char) sdata->gsfEM950Specific.ping_quality;
+    p += 1;
+
+    /* Next two byte integer contains the transducer pitch */
+    dtemp = sdata->gsfEM950Specific.ship_pitch * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the transducer pitch */
+    dtemp = sdata->gsfEM950Specific.transducer_pitch * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sea surface sound speed * 10
+     */
+    dtemp = (sdata->gsfEM950Specific.surface_velocity * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEm1000Specific
+ *
+ * Description :  This function encodes the EM1000 sensor specific information
+ *  into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeEM1000Specific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the ping number */
+    stemp = htons((gsfuShort) (sdata->gsfEM1000Specific.ping_number));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the sonar mode of operation */
+    *p = (unsigned char) sdata->gsfEM1000Specific.mode;
+    p += 1;
+
+    /* Next byte contains the ping quality factor*/
+    *p = (unsigned char) sdata->gsfEM1000Specific.ping_quality;
+    p += 1;
+
+    /* Next two byte integer contains the transducer pitch */
+    dtemp = sdata->gsfEM1000Specific.ship_pitch * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the transducer pitch */
+    dtemp = sdata->gsfEM1000Specific.transducer_pitch * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sea surface sound speed * 10 */
+    dtemp = (sdata->gsfEM1000Specific.surface_velocity * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEm121ASpecific
+ *
+ * Description : This function encodes the EM121A sensor specific
+ *  information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeEM121ASpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the ping number */
+    stemp = htons((gsfuShort) (sdata->gsfEM121ASpecific.ping_number));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the sonar mode of operation */
+    *p = (unsigned char) sdata->gsfEM121ASpecific.mode;
+    p += 1;
+
+    /* Next byte contains the number of valid beams */
+    *p = (unsigned char) sdata->gsfEM121ASpecific.valid_beams;
+    p += 1;
+
+    /* Next byte contains the transmit pulse length */
+    *p = (unsigned char) sdata->gsfEM121ASpecific.pulse_length;
+    p += 1;
+
+    /* Next byte contains the sonar beam width */
+    *p = (unsigned char) sdata->gsfEM121ASpecific.beam_width;
+    p += 1;
+
+    /* Next byte contains the transmit power level */
+    *p = (unsigned char) sdata->gsfEM121ASpecific.tx_power;
+    p += 1;
+
+    /* Next byte contains the number of transmit channels NOT working */
+    *p = (unsigned char) sdata->gsfEM121ASpecific.tx_status;
+    p += 1;
+
+    /* Next byte contains the number of receive channels NOT working */
+    *p = (unsigned char) sdata->gsfEM121ASpecific.rx_status;
+    p += 1;
+
+    /* Next two byte integer contains the sea surface sound speed * 10
+     */
+    dtemp = (sdata->gsfEM121ASpecific.surface_velocity * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEm121Specific
+ *
+ * Description : This function encodes the EM121 sensor specific
+ *  information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeEM121Specific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the ping number */
+    stemp = htons((gsfuShort) (sdata->gsfEM121Specific.ping_number));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the sonar mode of operation */
+    *p = (unsigned char) sdata->gsfEM121Specific.mode;
+    p += 1;
+
+    /* Next byte contains the number of valid beams */
+    *p = (unsigned char) sdata->gsfEM121Specific.valid_beams;
+    p += 1;
+
+    /* Next byte contains the transmit pulse length */
+    *p = (unsigned char) sdata->gsfEM121Specific.pulse_length;
+    p += 1;
+
+    /* Next byte contains the sonar beam width */
+    *p = (unsigned char) sdata->gsfEM121Specific.beam_width;
+    p += 1;
+
+    /* Next byte contains the transmit power level */
+    *p = (unsigned char) sdata->gsfEM121Specific.tx_power;
+    p += 1;
+
+    /* Next byte contains the number of transmit channels NOT working */
+    *p = (unsigned char) sdata->gsfEM121Specific.tx_status;
+    p += 1;
+
+    /* Next byte contains the number of receive channels NOT working */
+    *p = (unsigned char) sdata->gsfEM121Specific.rx_status;
+    p += 1;
+
+    /* Next two byte integer contains the sea surface sound speed * 10
+     */
+    dtemp = (sdata->gsfEM121Specific.surface_velocity * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeCmpSassSpecific
+ *
+ * Description : This function encodes the Compressed SASS
+ *               specific data record to external byte stream format.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeCmpSassSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double      dtemp;
+
+    dtemp = (sdata->gsfCmpSassSpecific.lfreq * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    dtemp = (sdata->gsfCmpSassSpecific.lntens * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+
+#if 1
+/* 3-30-99 wkm: obsolete */
+/********************************************************************
+ *
+ * Function Name : EncodeSASSSpecific
+ *
+ * Description : This function encodes the Typeiii SASS
+ *               specific data record to external byte stream format.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSASSSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+
+    /* First two byte integer contains the leftmost beam */
+    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.leftmost_beam));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the rightmost beam */
+    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.rightmost_beam));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the total number of beams */
+    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.total_beams));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the navigation mode */
+    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.nav_mode));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the ping number */
+    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.ping_number));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the mission number */
+    stemp = htons((gsfuShort) (sdata->gsfSASSSpecific.mission_number));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeTypeIIISeaBeamSpecific
+ *
+ * Description : This function encodes the Type III Seabeam specific
+ *               data record to external byte stream format.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeTypeIIISeaBeamSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+
+    /* First two byte integer contains the leftmost beam */
+    stemp = htons((gsfuShort) (sdata->gsfTypeIIISeaBeamSpecific.leftmost_beam));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the rightmost beam */
+    stemp = htons((gsfuShort)(sdata->gsfTypeIIISeaBeamSpecific.rightmost_beam));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the total number of beams */
+    stemp = htons((gsfuShort)(sdata->gsfTypeIIISeaBeamSpecific.total_beams));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the navigation mode */
+    stemp = htons((gsfuShort)(sdata->gsfTypeIIISeaBeamSpecific.nav_mode));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the ping number */
+    stemp = htons((gsfuShort)(sdata->gsfTypeIIISeaBeamSpecific.ping_number));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the mission number */
+    stemp = htons((gsfuShort)(sdata->gsfTypeIIISeaBeamSpecific.mission_number));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+#endif
+
+
+/********************************************************************
+ *
+ * Function Name : EncodeSeaMapSpecific
+ *
+ * Description : not implimented yet
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSeaMapSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata, const GSF_FILE_TABLE *ft)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    dtemp = (sdata->gsfSeamapSpecific.portTransmitter[0] * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    dtemp = (sdata->gsfSeamapSpecific.portTransmitter[1] * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    dtemp = (sdata->gsfSeamapSpecific.stbdTransmitter[0] * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    dtemp = (sdata->gsfSeamapSpecific.stbdTransmitter[1] * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    dtemp = (sdata->gsfSeamapSpecific.portGain * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    dtemp = (sdata->gsfSeamapSpecific.stbdGain * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    dtemp = (sdata->gsfSeamapSpecific.portPulseLength * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    dtemp = (sdata->gsfSeamapSpecific.stbdPulseLength * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    dtemp = (sdata->gsfSeamapSpecific.pressureDepth * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    /* JSB 11/08/2007; looks like the pointer increment for this field in the encode processing has been missing
+     *  since this code block was first written in GSFv1.03
+     */
+    if ((ft->major_version_number > 2) || ((ft->major_version_number == 2) && (ft->minor_version_number > 7)))
+    {
+        p += 2;
+    }
+
+    dtemp = (sdata->gsfSeamapSpecific.altitude * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    dtemp = (sdata->gsfSeamapSpecific.temperature * 10.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSeaBatSpecific
+ *
+ * Description : This function encodes the Reson SeaBat sensor specific
+ *  information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSeaBatSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the ping number */
+    stemp = htons((gsfuShort) sdata->gsfSeaBatSpecific.ping_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sea surface sound speed * 10 */
+    dtemp = sdata->gsfSeaBatSpecific.surface_velocity * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the sonar mode of operation */
+    *p = (unsigned char) sdata->gsfSeaBatSpecific.mode;
+    p += 1;
+
+    /* Next byte contains the sonar mode setting for this ping */
+    *p = (unsigned char) sdata->gsfSeaBatSpecific.sonar_range;
+    p += 1;
+
+    /* Next byte contains the sonar transmit power for this ping */
+    *p = (unsigned char) sdata->gsfSeaBatSpecific.transmit_power;
+    p += 1;
+
+    /* Next byte contains the sonar receive gain for this setting */
+    *p = (unsigned char) sdata->gsfSeaBatSpecific.receive_gain;
+    p += 1;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSBAmpSpecific
+ *
+ * Description : This function encodes the Sea Beam with amplitude
+ *  sensor specific information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSBAmpSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuLong        ltemp;
+    gsfuShort       stemp;
+
+    /* First byte contains the hour from the Eclipse */
+    *p = (unsigned char) sdata->gsfSBAmpSpecific.hour;
+    p += 1;
+
+    /* Next byte contains the minute from the Eclipse */
+    *p = (unsigned char) sdata->gsfSBAmpSpecific.minute;
+    p += 1;
+
+    /* Next byte contains the second from the Eclipse */
+    *p = (unsigned char) sdata->gsfSBAmpSpecific.second;
+    p += 1;
+
+    /* Next byte the hundredths of seconds from the Eclipse */
+    *p = (unsigned char) sdata->gsfSBAmpSpecific.hundredths;
+    p += 1;
+
+    /* Next four byte integer contains the block number */
+    ltemp = htonl((gsfuLong) sdata->gsfSBAmpSpecific.block_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the average gate depth */
+    stemp = htons((gsfuShort) sdata->gsfSBAmpSpecific.avg_gate_depth);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSeaBatIISpecific
+ *
+ * Description : This function encodes the Reson SeaBat II sensor specific
+ *  information into external byte stream form.  The SeaBat II sensor
+ *  specific data structure was defined to replace the gsfSeaBatSpecific
+ *  data structure as of GSF version 1.04
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSeaBatIISpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the ping number */
+    stemp = htons((gsfuShort) sdata->gsfSeaBatIISpecific.ping_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sea surface sound speed * 10 */
+    dtemp = sdata->gsfSeaBatIISpecific.surface_velocity * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sonar mode of operation */
+    stemp = htons((gsfuShort) sdata->gsfSeaBatIISpecific.mode);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sonar range setting */
+    stemp = htons((gsfuShort) sdata->gsfSeaBatIISpecific.sonar_range);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the power setting */
+    stemp = htons((gsfuShort) sdata->gsfSeaBatIISpecific.transmit_power);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the gain setting */
+    stemp = htons((gsfuShort) sdata->gsfSeaBatIISpecific.receive_gain);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the fore/aft beam width */
+    *p = (unsigned char) ((sdata->gsfSeaBatIISpecific.fore_aft_bw * 10.0) + 0.5);
+    p += 1;
+
+    /* Next byte contains the athwartships beam width */
+    *p = (unsigned char) ((sdata->gsfSeaBatIISpecific.athwart_bw * 10.0) + 0.5);
+    p += 1;
+
+    /* Next four bytes are reserved as spare space. */
+    *p = (unsigned char) (sdata->gsfSeaBatIISpecific.spare[0]);
+    p += 1;
+    *p = (unsigned char) (sdata->gsfSeaBatIISpecific.spare[1]);
+    p += 1;
+    *p = (unsigned char) (sdata->gsfSeaBatIISpecific.spare[2]);
+    p += 1;
+    *p = (unsigned char) (sdata->gsfSeaBatIISpecific.spare[3]);
+    p += 1;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSeaBat8101Specific
+ *
+ * Description : This function encodes the Reson SeaBat 8101 sensor specific
+ *  information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSeaBat8101Specific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the ping number */
+    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.ping_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sea surface sound speed * 10 */
+    dtemp = sdata->gsfSeaBat8101Specific.surface_velocity * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sonar mode of operation */
+    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.mode);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sonar range setting */
+    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.range);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the power setting */
+    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.power);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the gain setting */
+    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.gain);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the pulse width, in microseconds */
+    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.pulse_width);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the tvg spreading coefficient * 4 */
+    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.tvg_spreading);
+    p += 1;
+
+    /* Next byte contains the tvg absorption coefficient */
+    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.tvg_absorption);
+    p += 1;
+
+    /* Next byte contains the fore/aft beam width */
+    *p = (unsigned char) ((sdata->gsfSeaBat8101Specific.fore_aft_bw * 10.0) + 0.5);
+    p += 1;
+
+    /* Next byte contains the athwartships beam width */
+    *p = (unsigned char) ((sdata->gsfSeaBat8101Specific.athwart_bw * 10.0) + 0.5);
+    p += 1;
+
+    /* Next two byte integer is reserved for future use, to store the range filter min */
+    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.range_filt_min);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer is reserved for future use, to store the range filter max */
+    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.range_filt_max);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer is reserved for future use, to store the depth filter min */
+    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.depth_filt_min);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer is reserved for future use, to store the depth filter max */
+    stemp = htons((gsfuShort) sdata->gsfSeaBat8101Specific.depth_filt_max);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte is reserved for future use, to store the projector type */
+    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.projector);
+    p += 1;
+
+    /* Next four bytes are reserved as spare space. */
+    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.spare[0]);
+    p += 1;
+    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.spare[1]);
+    p += 1;
+    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.spare[2]);
+    p += 1;
+    *p = (unsigned char) (sdata->gsfSeaBat8101Specific.spare[3]);
+    p += 1;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSeaBeam2112Specific
+ *
+ * Description : This function encodes the Sea Beam 2112/36 sensor specific
+ *  information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSeaBeam2112Specific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First byte contains the sonar mode of operation */
+    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.mode);
+    p += 1;
+
+    /* Next two byte integer contains the surface sound velocity * 100 - 130000 */
+    dtemp = (sdata->gsfSeaBeam2112Specific.surface_velocity * 100.0) - 130000;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the SSV source */
+    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.ssv_source);
+    p += 1;
+
+    /* Next byte contains the ping gain */
+    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.ping_gain);
+    p += 1;
+
+    /* Next byte contains the ping pulse width */
+    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.pulse_width);
+    p += 1;
+
+    /* Next byte contains the transmitter attenuation */
+    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.transmitter_attenuation);
+    p += 1;
+
+    /* Next byte contains the number of algorithms */
+    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.number_algorithms);
+    p += 1;
+
+    /* Next 4 bytes contain the algorithm order */
+    memcpy (p, (unsigned char *) (sdata->gsfSeaBeam2112Specific.algorithm_order), 4);
+    p += 4;
+
+    /* Next two bytes are reserved as spare space. */
+    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.spare[0]);
+    p += 1;
+    *p = (unsigned char) (sdata->gsfSeaBeam2112Specific.spare[1]);
+    p += 1;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeElacMkIISpecific
+ *
+ * Description : This function encodes the Elac Bottomchart MkII sensor specific
+ *  information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeElacMkIISpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+
+    /* First byte contains the sonar mode of operation */
+    *p = (unsigned char) (sdata->gsfElacMkIISpecific.mode);
+    p += 1;
+
+    /* Next two byte integer contains the ping counter */
+    stemp = htons((gsfuShort) sdata->gsfElacMkIISpecific.ping_num);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the surface sound velocity in m/s */
+    stemp = htons((gsfuShort) sdata->gsfElacMkIISpecific.sound_vel);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the pulse length in 0.01 ms */
+    stemp = htons((gsfuShort) sdata->gsfElacMkIISpecific.pulse_length);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the starboard receiver gain in dB */
+    *p = (unsigned char) (sdata->gsfElacMkIISpecific.receiver_gain_stbd);
+    p += 1;
+
+    /* Next byte contains the port receiver gain in dB */
+    *p = (unsigned char) (sdata->gsfElacMkIISpecific.receiver_gain_port);
+    p += 1;
+
+    /* Next two byte integer is reserved for future use */
+    stemp = htons((gsfuShort) sdata->gsfElacMkIISpecific.reserved);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEM3Specific
+ *
+ * Description : This function encodes the Simrad EM3000 series sensor
+ *  specific information into external byte stream form.
+ *
+ * Inputs :
+ *   sptr = a pointer to an unsigned char buffer to write into
+ *   sdata = a pointer to a union of sensor specific data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeEM3Specific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+    int             run_time_id;
+
+    /* Next two bytes contain the EM model number */
+    stemp = htons((gsfuShort) sdata->gsfEM3Specific.model_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the ping number */
+    stemp = htons((gsfuShort) sdata->gsfEM3Specific.ping_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the system 1 or 2 serial number */
+    stemp = htons((gsfuShort) sdata->gsfEM3Specific.serial_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the sourface sound speed */
+    dtemp = sdata->gsfEM3Specific.surface_velocity * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the transmit depth */
+    dtemp = sdata->gsfEM3Specific.transducer_depth * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the maximum number of beams possible */
+    stemp = htons((gsfuShort) sdata->gsfEM3Specific.valid_beams);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the sample rate */
+    stemp = htons((gsfuShort) sdata->gsfEM3Specific.sample_rate);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the depth difference between sonar heads in the EM3000D */
+    dtemp = sdata->gsfEM3Specific.depth_difference * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the transducer depth offset multiplier */
+    *p = (unsigned char) (sdata->gsfEM3Specific.offset_multiplier);
+    p += 1;
+
+    /* Encode and write the run-time paremeters if any of them have changed. */
+    run_time_id = 1;
+
+    /* JSB 3/31/99 Commented out the following code block.  For now we will encode all of the
+     *  run-time parameter fields in the sensor specific sub-record for each ping, whether the
+     *  values have been updated or not.  In a future release, we plan to support encoding this
+     *  portion of the subrecord only when the values have been updated.  This can be done by
+     *  using the model in place for the scale factors record.  We will need to support a
+     *  "scales_read" flag for write after read access, and direct access back to the ping record
+     *  with the updated run-time params prior to a direct access read.
+     *
+     * run_time_id = 0;
+     * if (memcmp(&sdata->gsfEM3Specific.run_time[0], &ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[0], sizeof(gsfEM3RunTime)))
+     * {
+     *     memcpy (&ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[0], &sdata->gsfEM3Specific.run_time[0], sizeof(gsfEM3RunTime));
+     *     run_time_id |= 0x00000001;
+     * }
+     *
+     * If this is an em 3000 series dual head installation, then we'll need to save both sets of run time parameters when either set
+     *  has been updated.
+     *
+     * if ((sdata->gsfEM3Specific.model_number == 3002) ||
+     *    (sdata->gsfEM3Specific.model_number == 3003) ||
+     *    (sdata->gsfEM3Specific.model_number == 3004) ||
+     *    (sdata->gsfEM3Specific.model_number == 3005) ||
+     *    (sdata->gsfEM3Specific.model_number == 3006) ||
+     *    (sdata->gsfEM3Specific.model_number == 3007) ||
+     *    (sdata->gsfEM3Specific.model_number == 3008))
+     * {
+     *     if ((memcmp(&sdata->gsfEM3Specific.run_time[0], &ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[0], sizeof(gsfEM3RunTime))) ||
+     *         (memcmp(&sdata->gsfEM3Specific.run_time[1], &ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[1], sizeof(gsfEM3RunTime))))
+     *     {
+     *         memcpy (&ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[0], &sdata->gsfEM3Specific.run_time[0], sizeof(gsfEM3RunTime));
+     *         memcpy (&ft->rec.mb_ping.sensor_data.gsfEM3Specific.run_time[1], &sdata->gsfEM3Specific.run_time[1], sizeof(gsfEM3RunTime));
+     *         run_time_id |= 0x00000001;
+     *         run_time_id |= 0x00000002;
+     *     }
+     * }
+     */
+
+    /* The next four byte value specifies the existence of the run-time data structure */
+    ltemp = htonl(run_time_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* If the first bit is set, then this subrecord contains a new set of run-time parameters
+     *  for a single head system, otherwise the run-time parameters have not changed.
+     */
+    if (run_time_id & 0x00000001)
+    {
+        /* The next two byte value contains the em model number */
+        stemp = htons(sdata->gsfEM3Specific.run_time[0].model_number);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* First 8 bytes contain the time */
+        ltemp = htonl(sdata->gsfEM3Specific.run_time[0].dg_time.tv_sec);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        ltemp = htonl(sdata->gsfEM3Specific.run_time[0].dg_time.tv_nsec);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* The next two byte value contains the sequential ping number */
+        stemp = htons(sdata->gsfEM3Specific.run_time[0].ping_number);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* The next two byte value contains the sonar head serial number */
+        stemp = htons(sdata->gsfEM3Specific.run_time[0].serial_number);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* The next four byte value contains the system status */
+        ltemp = htonl(sdata->gsfEM3Specific.run_time[0].system_status);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* The next one byte value contains the mode identifier */
+        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].mode;
+        p += 1;
+
+        /* The next one byte value contains the filter identifier */
+        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].filter_id;
+        p += 1;
+
+        /* The next two byte value contains the minimum depth */
+        dtemp = sdata->gsfEM3Specific.run_time[0].min_depth;
+        stemp = htons((gsfuShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* The next two byte value contains the maximum depth */
+        dtemp = sdata->gsfEM3Specific.run_time[0].max_depth;
+        stemp = htons((gsfuShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* The next two byte value contains the absorption coefficient */
+        dtemp = sdata->gsfEM3Specific.run_time[0].absorption * 100.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        stemp = htons((gsfuShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* The next two byte value contains the transmit pulse length */
+        dtemp = sdata->gsfEM3Specific.run_time[0].pulse_length;
+        stemp = htons((gsfuShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* The next two byte value contains the transmit beam width */
+        dtemp = sdata->gsfEM3Specific.run_time[0].transmit_beam_width * 10.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        stemp = htons((gsfuShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* The next one byte value contains the transmit power reduction */
+        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].power_reduction;
+        p += 1;
+
+        /* The next one byte value contains the receive beam width */
+        *p = (unsigned char) (sdata->gsfEM3Specific.run_time[0].receive_beam_width * 10.0 + 0.501);
+        p += 1;
+
+        /* The next one byte value contains the receive band width in Hz. This value is
+         *  provided by the sonar with a precision of 50 hz.
+         */
+        *p = (unsigned char) (sdata->gsfEM3Specific.run_time[0].receive_bandwidth / 50.0 + 0.501);
+        p += 1;
+
+        /* The next one byte value contains the receive gain */
+        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].receive_gain;
+        p += 1;
+
+        /* The next one byte value contains the TVG law cross-over angle */
+        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].cross_over_angle;
+        p += 1;
+
+        /* The next one byte value contains the source of the surface sound speed value */
+        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].ssv_source;
+        p += 1;
+
+        /* The next two byte value contains the maximum port swath width */
+        stemp = htons(sdata->gsfEM3Specific.run_time[0].port_swath_width);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* The next one byte value contains the beam spacing value */
+        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].beam_spacing;
+        p += 1;
+
+        /* The next one byte value contains the port coverage sector */
+        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].port_coverage_sector;
+        p += 1;
+
+        /* The next one byte value contains the yaw and pitch stabilization mode */
+        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].stabilization;
+        p += 1;
+
+        /* The next one byte value contains the starboard coverage sector */
+        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].stbd_coverage_sector;
+        p += 1;
+
+        /* The next two byte value contains the maximum starboard swath width */
+        stemp = htons(sdata->gsfEM3Specific.run_time[0].stbd_swath_width);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* The next one byte value contains the HiLo frequency absorption coefficient ratio */
+        *p = (unsigned char) sdata->gsfEM3Specific.run_time[0].hilo_freq_absorp_ratio;
+        p += 1;
+
+        /* The next four bytes are reserved for future use */
+        memset(p, 0, 4);
+        p += 4;
+
+        /* If the second bit is set then this subrecord contains a second set of new run-time
+         *  for an em3000d series sonar system.
+         */
+        if (run_time_id & 0x00000002)
+        {
+            /* The next two byte value contains the em model number */
+            stemp = htons(sdata->gsfEM3Specific.run_time[1].model_number);
+            memcpy(p, &stemp, 2);
+            p += 2;
+
+            /* First 8 bytes contain the time */
+            ltemp = htonl(sdata->gsfEM3Specific.run_time[1].dg_time.tv_sec);
+            memcpy(p, &ltemp, 4);
+            p += 4;
+
+            ltemp = htonl(sdata->gsfEM3Specific.run_time[1].dg_time.tv_nsec);
+            memcpy(p, &ltemp, 4);
+            p += 4;
+
+            /* The next two byte value contains the sequential ping number */
+            stemp = htons(sdata->gsfEM3Specific.run_time[1].ping_number);
+            memcpy(p, &stemp, 2);
+            p += 2;
+
+            /* The next two byte value contains the sonar head serial number */
+            stemp = htons(sdata->gsfEM3Specific.run_time[1].serial_number);
+            memcpy(p, &stemp, 2);
+            p += 2;
+
+            /* The next four byte value contains the system status */
+            ltemp = htonl(sdata->gsfEM3Specific.run_time[1].system_status);
+            memcpy(p, &ltemp, 4);
+            p += 4;
+
+            /* The next one byte value contains the mode identifier */
+            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].mode;
+            p += 1;
+
+            /* The next one byte value contains the filter identifier */
+            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].filter_id;
+            p += 1;
+
+            /* The next two byte value contains the minimum depth */
+            dtemp = sdata->gsfEM3Specific.run_time[1].min_depth;
+            stemp = htons((gsfuShort) dtemp);
+            memcpy(p, &stemp, 2);
+            p += 2;
+
+            /* The next two byte value contains the maximum depth */
+            dtemp = sdata->gsfEM3Specific.run_time[1].max_depth;
+            stemp = htons((gsfuShort) dtemp);
+            memcpy(p, &stemp, 2);
+            p += 2;
+
+            /* The next two byte value contains the absorption coefficient */
+            dtemp = sdata->gsfEM3Specific.run_time[1].absorption * 100.0;
+            if (dtemp < 0.0)
+            {
+                dtemp -= 0.501;
+            }
+            else
+            {
+                dtemp += 0.501;
+            }
+            stemp = htons((gsfuShort) dtemp);
+            memcpy(p, &stemp, 2);
+            p += 2;
+
+            /* The next two byte value contains the transmit pulse length */
+            dtemp = sdata->gsfEM3Specific.run_time[1].pulse_length;
+            stemp = htons((gsfuShort) dtemp);
+            memcpy(p, &stemp, 2);
+            p += 2;
+
+            /* The next two byte value contains the transmit beam width */
+            dtemp = sdata->gsfEM3Specific.run_time[1].transmit_beam_width * 10.0;
+            if (dtemp < 0.0)
+            {
+                dtemp -= 0.501;
+            }
+            else
+            {
+                dtemp += 0.501;
+            }
+            stemp = htons((gsfuShort) dtemp);
+            memcpy(p, &stemp, 2);
+            p += 2;
+
+            /* The next one byte value contains the transmit power reduction */
+            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].power_reduction;
+            p += 1;
+
+            /* The next one byte value contains the receive beam width */
+            *p = (unsigned char) (sdata->gsfEM3Specific.run_time[1].receive_beam_width * 10.0 + 0.501);
+            p += 1;
+
+            /* The next one byte value contains the receive band width in Hz. This value is
+             *  provided by the sonar with a precision of 50 hz.
+             */
+            *p = (unsigned char) (sdata->gsfEM3Specific.run_time[1].receive_bandwidth / 50.0 + 0.501);
+            p += 1;
+
+            /* The next one byte value contains the receive gain */
+            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].receive_gain;
+            p += 1;
+
+            /* The next one byte value contains the TVG law cross-over angle */
+            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].cross_over_angle;
+            p += 1;
+
+            /* The next one byte value contains the source of the surface sound speed value */
+            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].ssv_source;
+            p += 1;
+
+            /* The next two byte value contains the maximum port swath width */
+            stemp = htons(sdata->gsfEM3Specific.run_time[1].port_swath_width);
+            memcpy(p, &stemp, 2);
+            p += 2;
+
+            /* The next one byte value contains the beam spacing value */
+            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].beam_spacing;
+            p += 1;
+
+            /* The next one byte value contains the port coverage sector */
+            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].port_coverage_sector;
+            p += 1;
+
+            /* The next one byte value contains the yaw and pitch stabilization mode */
+            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].stabilization;
+            p += 1;
+
+            /* The next one byte value contains the starboard coverage sector */
+            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].stbd_coverage_sector;
+            p += 1;
+
+            /* The next two byte value contains the maximum starboard swath width */
+            stemp = htons(sdata->gsfEM3Specific.run_time[1].stbd_swath_width);
+            memcpy(p, &stemp, 2);
+            p += 2;
+
+            /* The next one byte value contains the HiLo frequency absorption coefficient ratio */
+            *p = (unsigned char) sdata->gsfEM3Specific.run_time[1].hilo_freq_absorp_ratio;
+            p += 1;
+
+            /* The next four bytes are reserved for future use */
+            memset(p, 0, 4);
+            p += 4;
+         }
+    }
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEM3RawSpecific
+ *
+ * Description : This function encodes the Kongsberg EM710/EM302/EM122/EM2040
+ *  sensor specific information into external byte stream form.
+ *
+ * Inputs :
+ *   sptr = a pointer to an unsigned char buffer to write into
+ *   sdata = a pointer to a union of sensor specific data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeEM3RawSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+    int             i;
+
+
+    /* The next two bytes contain the model number */
+    stemp = htons (sdata->gsfEM3RawSpecific.model_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contain the ping counter */
+    stemp = htons (sdata->gsfEM3RawSpecific.ping_counter);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contain the serial number */
+    stemp = htons (sdata->gsfEM3RawSpecific.serial_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contain the surface velocity */
+    dtemp = sdata->gsfEM3RawSpecific.surface_velocity * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next four bytes contain the transmit transducer depth */
+    dtemp = sdata->gsfEM3RawSpecific.transducer_depth * 20000.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next two bytes contain the number of valid detections for this ping */
+    stemp = htons (sdata->gsfEM3RawSpecific.valid_detections);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next four bytes contains the integer portion of the sampling frequency in Hz */
+    ltemp = htonl((gsfuLong) sdata->gsfEM3RawSpecific.sampling_frequency);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contain the fractional portion of the sampling frequency in Hz scaled by 4.0e9 */
+    dtemp = sdata->gsfEM3RawSpecific.sampling_frequency - ((gsfuLong) sdata->gsfEM3RawSpecific.sampling_frequency);
+    dtemp *= 4.0e9;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contains the "ROV depth" */
+    dtemp = sdata->gsfEM3RawSpecific.vehicle_depth * 1000.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two bytes contain the depth difference between sonar heads in the EM3000D */
+    dtemp = sdata->gsfEM3RawSpecific.depth_difference * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the transducer depth offset multiplier */
+    *p = (unsigned char) (sdata->gsfEM3RawSpecific.offset_multiplier);
+    p += 1;
+
+    /* The next 16 bytes are spare space for future use */
+    memset (p, 0, (size_t) 16);
+    p += 16;
+
+    /* The next two bytes contains the number of transmit sectors */
+    stemp = htons (sdata->gsfEM3RawSpecific.transmit_sectors);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Now loop over the transmit sectors to encode the sector specific information */
+    for (i = 0; i < sdata->gsfEM3RawSpecific.transmit_sectors; i++)
+    {
+        /* Next two bytes contains the tilt angle */
+        dtemp = sdata->gsfEM3RawSpecific.sector[i].tilt_angle * 100.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        stemp = htons((gsfsShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* Next two bytes contains the focus range */
+        dtemp = sdata->gsfEM3RawSpecific.sector[i].focus_range * 10.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        stemp = htons((gsfuShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* Next four bytes contains the signal length */
+        dtemp = sdata->gsfEM3RawSpecific.sector[i].signal_length * 1.0e6;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* Next four bytes contains the transmit delay */
+        dtemp = sdata->gsfEM3RawSpecific.sector[i].transmit_delay * 1.0e6;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* Next four bytes contains the center frequency */
+        dtemp = sdata->gsfEM3RawSpecific.sector[i].center_frequency * 1.0e3;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* Next byte contains the signal wave form identifier */
+        *p = (unsigned char) sdata->gsfEM3RawSpecific.sector[i].waveform_id;
+        p += 1;
+
+        /* Next byte contains the transmit sector number */
+        *p = (unsigned char) sdata->gsfEM3RawSpecific.sector[i].sector_number;
+        p += 1;
+
+        /* Next four bytes contains the signal bandwidth */
+        dtemp = sdata->gsfEM3RawSpecific.sector[i].signal_bandwidth * 1.0e3;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* The next 16 bytes are spare space for future use */
+        memset (p, 0, (size_t) 16);
+        p += 16;
+    }
+
+    /* The next 16 bytes are spare space for future use */
+    memset (p, 0, (size_t) 16);
+    p += 16;
+
+    /* Encode and write the run-time parameters.
+     *
+     * The next two byte value contains the em model number
+     */
+    stemp = htons(sdata->gsfEM3RawSpecific.run_time.model_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* First 8 bytes contain the time */
+    ltemp = htonl(sdata->gsfEM3RawSpecific.run_time.dg_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    ltemp = htonl(sdata->gsfEM3RawSpecific.run_time.dg_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next two byte value contains the sequential ping number */
+    stemp = htons(sdata->gsfEM3RawSpecific.run_time.ping_counter);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the sonar head serial number */
+    stemp = htons(sdata->gsfEM3RawSpecific.run_time.serial_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the operator station status */
+    *p = sdata->gsfEM3RawSpecific.run_time.operator_station_status;
+    p += 1;
+
+    /* Next byte contains the processing unit status */
+    *p = sdata->gsfEM3RawSpecific.run_time.processing_unit_status;
+    p += 1;
+
+    /* Next byte contains the BSP status */
+    *p = sdata->gsfEM3RawSpecific.run_time.bsp_status;
+    p += 1;
+
+    /* Next byte contains the sonar head or transceiver status */
+    *p = sdata->gsfEM3RawSpecific.run_time.head_transceiver_status;
+    p += 1;
+
+    /* The next one byte value contains the mode identifier */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.mode;
+    p += 1;
+
+    /* The next one byte value contains the filter identifier */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.filter_id;
+    p += 1;
+
+    /* The next two byte value contains the minimum depth */
+    dtemp = sdata->gsfEM3RawSpecific.run_time.min_depth;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the maximum depth */
+    dtemp = sdata->gsfEM3RawSpecific.run_time.max_depth;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the absorption coefficient */
+    dtemp = sdata->gsfEM3RawSpecific.run_time.absorption * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the transmit pulse length in micro seconds */
+    dtemp = sdata->gsfEM3RawSpecific.run_time.tx_pulse_length;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the transmit beam width */
+    dtemp = sdata->gsfEM3RawSpecific.run_time.tx_beam_width * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next one byte value contains the transmit power reduction */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.tx_power_re_max;
+    p += 1;
+
+    /* The next one byte value contains the receive beam width */
+    *p = (unsigned char) ((sdata->gsfEM3RawSpecific.run_time.rx_beam_width * 10.0) + 0.501);
+    p += 1;
+
+    /* The next one byte value contains the receive band width in Hz. This value is
+     *  provided by the sonar with a precision of 50 hz.
+     */
+    *p = (unsigned char) ((sdata->gsfEM3RawSpecific.run_time.rx_bandwidth / 50.0) + 0.501);
+    p += 1;
+
+    /* The next one byte value contains the receive gain */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.rx_fixed_gain;
+    p += 1;
+
+    /* The next one byte value contains the TVG law cross-over angle */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.tvg_cross_over_angle;
+    p += 1;
+
+    /* The next one byte value contains the source of the surface sound speed value */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.ssv_source;
+    p += 1;
+
+    /* The next two byte value contains the maximum port swath width */
+    stemp = htons(sdata->gsfEM3RawSpecific.run_time.max_port_swath_width);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next one byte value contains the beam spacing value */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.beam_spacing;
+    p += 1;
+
+    /* The next one byte value contains the port coverage in degrees */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.max_port_coverage;
+    p += 1;
+
+    /* The next one byte value contains the yaw and pitch stabilization mode */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.stabilization;
+    p += 1;
+
+    /* The next one byte value contains the starboard coverage in degrees */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.max_stbd_coverage;
+    p += 1;
+
+    /* The next two byte value contains the maximum starboard swath width */
+    stemp = htons(sdata->gsfEM3RawSpecific.run_time.max_stbd_swath_width);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The contents of the next two byte value depends on the sonar model number */
+    switch (sdata->gsfEM3RawSpecific.run_time.model_number)
+    {
+        case 1002:
+            /* The next two byte value contains the Durotong speed. This field is valid only for the EM1002 */
+            dtemp = sdata->gsfEM3RawSpecific.run_time.durotong_speed * 10.0;
+            if (dtemp < 0.0)
+            {
+                dtemp -= 0.501;
+            }
+            else
+            {
+                dtemp += 0.501;
+            }
+            stemp = htons((gsfuShort) dtemp);
+            memcpy(p, &stemp, 2);
+            p += 2;
+            break;
+
+        case 300:
+        case 120:
+        case 3000:
+        case 3020:
+            /* The next two byte value contains the transmit along track tilt in degrees.
+             * JSB: As of 3/1/09, still don't have final datagram documentation from KM
+             * to know whether the tx_along_tilt field is EM4 specific or if it will be supported
+             * on EM3 systems.
+             */
+            dtemp = sdata->gsfEM3RawSpecific.run_time.tx_along_tilt * 100.0;
+            if (dtemp < 0.0)
+            {
+                dtemp -= 0.501;
+            }
+            else
+            {
+                dtemp += 0.501;
+            }
+            stemp = htons((gsfsShort) dtemp);
+            memcpy(p, &stemp, 2);
+            p += 2;
+            break;
+
+        default:
+            /* Then next two byte value is spare */
+            p += 2;
+            break;
+    }
+
+    /* The contents of the next one byte value depends on the sonar model number */
+    switch (sdata->gsfEM3RawSpecific.run_time.model_number)
+    {
+        default:
+            /* The next one byte value contains the HiLo frequency absorption coefficient ratio
+             * JSB: As of 3/1/09, still don't have final datagram documentation from KM
+             * to know whether the filter ID 2 field is EM4 specific or if it will be supported
+             * on EM3 systems.
+             */
+            *p = (unsigned char) sdata->gsfEM3RawSpecific.run_time.hi_low_absorption_ratio;
+            p += 1;
+            break;
+    }
+
+    /* The next 16 bytes of space on the byte stream are spare space for future use. */
+    memset (p, 0, (size_t) 16);
+    p += 16;
+
+    /* Encode and write the PU status fields. */
+
+    /* The next one byte value contains the processor unit CPU load */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.pu_status.pu_cpu_load;
+    p += 1;
+
+    /* The next two bytes contain a bit mask detailing valid/invalid status of sensor inputs */
+    stemp = htons(sdata->gsfEM3RawSpecific.pu_status.sensor_status);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next one byte value contains the achieved port coverage */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.pu_status.achieved_port_coverage;
+    p += 1;
+
+    /* The next one byte value contains the achieved starboard coverage */
+    *p = (unsigned char) sdata->gsfEM3RawSpecific.pu_status.achieved_stbd_coverage;
+    p += 1;
+
+    /* The next two bytes contain the yaw stabilization */
+    dtemp = sdata->gsfEM3RawSpecific.pu_status.yaw_stabilization * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next 16 bytes are reserved for future use */
+    memset (p, 0, (size_t) 16);
+    p += 16;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEM4Specific
+ *
+ * Description : This function encodes the Kongsberg EM710/EM302/EM122/EM2040/ME70BO
+ *  sensor specific information into external byte stream form.
+ *
+ * Inputs :
+ *   sptr = a pointer to an unsigned char buffer to write into
+ *   sdata = a pointer to a union of sensor specific data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeEM4Specific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+    int             i;
+
+    /* The next two bytes contain the model number */
+    stemp = htons (sdata->gsfEM4Specific.model_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contain the ping counter */
+    stemp = htons (sdata->gsfEM4Specific.ping_counter);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contain the serial number */
+    stemp = htons (sdata->gsfEM4Specific.serial_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contain the surface velocity */
+    dtemp = sdata->gsfEM4Specific.surface_velocity * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next four bytes contain the transmit transducer depth */
+    dtemp = sdata->gsfEM4Specific.transducer_depth * 20000.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next two bytes contain the number of valid detections for this ping */
+    stemp = htons (sdata->gsfEM4Specific.valid_detections);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next four bytes contains the integer portion of the sampling frequency in Hz */
+    ltemp = htonl((gsfuLong) sdata->gsfEM4Specific.sampling_frequency);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contain the fractional portion of the sampling frequency in Hz scaled by 4.0e9 */
+    dtemp = sdata->gsfEM4Specific.sampling_frequency - ((gsfuLong) sdata->gsfEM4Specific.sampling_frequency);
+    dtemp *= 4.0e9;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contains the scale factor value for the FM Doppler frequency correction */
+    ltemp = htonl((gsfuLong) sdata->gsfEM4Specific.doppler_corr_scale);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contains the "ROV depth" from the 0x66 datagram */
+    dtemp = sdata->gsfEM4Specific.vehicle_depth * 1000.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next 16 bytes are spare space for future use */
+    memset (p, 0, (size_t) 16);
+    p += 16;
+
+    /* The next two bytes contains the number of transmit sectors */
+    stemp = htons (sdata->gsfEM4Specific.transmit_sectors);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Now loop over the transmit sectors to encode the sector specific information */
+    for (i = 0; i < sdata->gsfEM4Specific.transmit_sectors; i++)
+    {
+        /* Next two bytes contains the tilt angle */
+        dtemp = sdata->gsfEM4Specific.sector[i].tilt_angle * 100.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        stemp = htons((gsfsShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* Next two bytes contains the focus range */
+        dtemp = sdata->gsfEM4Specific.sector[i].focus_range * 10.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        stemp = htons((gsfuShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* Next four bytes contains the signal length */
+        dtemp = sdata->gsfEM4Specific.sector[i].signal_length * 1.0e6;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* Next four bytes contains the transmit delay */
+        dtemp = sdata->gsfEM4Specific.sector[i].transmit_delay * 1.0e6;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* Next four bytes contains the center frequency */
+        dtemp = sdata->gsfEM4Specific.sector[i].center_frequency * 1.0e3;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* Next two bytes contains the mean absorption */
+        dtemp = sdata->gsfEM4Specific.sector[i].mean_absorption * 100.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        stemp = htons((gsfuShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* Next byte contains the signal wave form identifier */
+        *p = (unsigned char) sdata->gsfEM4Specific.sector[i].waveform_id;
+        p += 1;
+
+        /* Next byte contains the transmit sector number */
+        *p = (unsigned char) sdata->gsfEM4Specific.sector[i].sector_number;
+        p += 1;
+
+        /* Next four bytes contains the signal bandwidth */
+        dtemp = sdata->gsfEM4Specific.sector[i].signal_bandwidth * 1.0e3;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* The next 16 bytes are spare space for future use */
+        memset (p, 0, (size_t) 16);
+        p += 16;
+    }
+
+    /* The next 16 bytes are spare space for future use */
+    memset (p, 0, (size_t) 16);
+    p += 16;
+
+    /* Encode and write the run-time parameters.
+     *
+     * The next two byte value contains the em model number
+     */
+    stemp = htons(sdata->gsfEM4Specific.run_time.model_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* First 8 bytes contain the time */
+    ltemp = htonl(sdata->gsfEM4Specific.run_time.dg_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    ltemp = htonl(sdata->gsfEM4Specific.run_time.dg_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next two byte value contains the sequential ping number */
+    stemp = htons(sdata->gsfEM4Specific.run_time.ping_counter);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the sonar head serial number */
+    stemp = htons(sdata->gsfEM4Specific.run_time.serial_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the operator station status */
+    *p = sdata->gsfEM4Specific.run_time.operator_station_status;
+    p += 1;
+
+    /* Next byte contains the processing unit status */
+    *p = sdata->gsfEM4Specific.run_time.processing_unit_status;
+    p += 1;
+
+    /* Next byte contains the BSP status */
+    *p = sdata->gsfEM4Specific.run_time.bsp_status;
+    p += 1;
+
+    /* Next byte contains the sonar head or transceiver status */
+    *p = sdata->gsfEM4Specific.run_time.head_transceiver_status;
+    p += 1;
+
+    /* The next one byte value contains the mode identifier */
+    *p = (unsigned char) sdata->gsfEM4Specific.run_time.mode;
+    p += 1;
+
+    /* The next one byte value contains the filter identifier */
+    *p = (unsigned char) sdata->gsfEM4Specific.run_time.filter_id;
+    p += 1;
+
+    /* The next two byte value contains the minimum depth */
+    dtemp = sdata->gsfEM4Specific.run_time.min_depth;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the maximum depth */
+    dtemp = sdata->gsfEM4Specific.run_time.max_depth;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the absorption coefficient */
+    dtemp = sdata->gsfEM4Specific.run_time.absorption * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the transmit pulse length in micro seconds */
+    dtemp = sdata->gsfEM4Specific.run_time.tx_pulse_length;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the transmit beam width */
+    dtemp = sdata->gsfEM4Specific.run_time.tx_beam_width * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next one byte value contains the transmit power reduction */
+    *p = (unsigned char) sdata->gsfEM4Specific.run_time.tx_power_re_max;
+    p += 1;
+
+    /* The next one byte value contains the receive beam width */
+    *p = (unsigned char) ((sdata->gsfEM4Specific.run_time.rx_beam_width * 10.0) + 0.501);
+    p += 1;
+
+    /* The next one byte value contains the receive band width in Hz. This value is
+     *  provided by the sonar with a precision of 50 hz.
+     */
+    *p = (unsigned char) ((sdata->gsfEM4Specific.run_time.rx_bandwidth / 50.0) + 0.501);
+    p += 1;
+
+    /* The next one byte value contains the receive gain */
+    *p = (unsigned char) sdata->gsfEM4Specific.run_time.rx_fixed_gain;
+    p += 1;
+
+    /* The next one byte value contains the TVG law cross-over angle */
+    *p = (unsigned char) sdata->gsfEM4Specific.run_time.tvg_cross_over_angle;
+    p += 1;
+
+    /* The next one byte value contains the source of the surface sound speed value */
+    *p = (unsigned char) sdata->gsfEM4Specific.run_time.ssv_source;
+    p += 1;
+
+    /* The next two byte value contains the maximum port swath width */
+    stemp = htons(sdata->gsfEM4Specific.run_time.max_port_swath_width);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next one byte value contains the beam spacing value */
+    *p = (unsigned char) sdata->gsfEM4Specific.run_time.beam_spacing;
+    p += 1;
+
+    /* The next one byte value contains the port coverage in degrees */
+    *p = (unsigned char) sdata->gsfEM4Specific.run_time.max_port_coverage;
+    p += 1;
+
+    /* The next one byte value contains the yaw and pitch stabilization mode */
+    *p = (unsigned char) sdata->gsfEM4Specific.run_time.stabilization;
+    p += 1;
+
+    /* The next one byte value contains the starboard coverage in degrees */
+    *p = (unsigned char) sdata->gsfEM4Specific.run_time.max_stbd_coverage;
+    p += 1;
+
+    /* The next two byte value contains the maximum starboard swath width */
+    stemp = htons(sdata->gsfEM4Specific.run_time.max_stbd_swath_width);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the transmit along track tilt in degrees */
+    dtemp = sdata->gsfEM4Specific.run_time.tx_along_tilt * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next one byte value contains the filter ID 2, with the value for the penetration filter */
+    *p = (unsigned char) sdata->gsfEM4Specific.run_time.filter_id_2;
+    p += 1;
+
+    /* The next 16 bytes of space on the byte stream are spare space for future use. */
+    memset (p, 0, (size_t) 16);
+    p += 16;
+
+    /* Encode and write the PU status fields. */
+
+    /* The next one byte value contains the processor unit CPU load */
+    *p = (unsigned char) sdata->gsfEM4Specific.pu_status.pu_cpu_load;
+    p += 1;
+
+    /* The next two bytes contain a bit mask detailing valid/invalid status of sensor inputs */
+    stemp = htons(sdata->gsfEM4Specific.pu_status.sensor_status);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next one byte value contains the achieved port coverage */
+    *p = (unsigned char) sdata->gsfEM4Specific.pu_status.achieved_port_coverage;
+    p += 1;
+
+    /* The next one byte value contains the achieved starboard coverage */
+    *p = (unsigned char) sdata->gsfEM4Specific.pu_status.achieved_stbd_coverage;
+    p += 1;
+
+    /* The next two bytes contain the yaw stabilization */
+    dtemp = sdata->gsfEM4Specific.pu_status.yaw_stabilization * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next 16 bytes are reserved for future use */
+    memset (p, 0, (size_t) 16);
+    p += 16;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+*
+* Function Name : EncodeKMALLSpecific
+*
+* Description : This function encodes the Kongsberg kmall
+*  sensor specific information into external byte stream form.
+*
+* Inputs :
+*    sptr = a pointer to an unsigned char buffer to write into
+*    sdata = a pointer to a union of sensor specific data.
+*    ft = a pointer to the gsf file table, this is used to determine
+*        is the run-time parameters should be written with this record.
+*
+* Returns : This function returns the number of bytes encoded.
+*
+* Error Conditions : none
+*
+********************************************************************/
+
+static int
+EncodeKMALLSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfsShort       sstemp;
+    gsfuLong        ltemp;
+    gsfuLong        ltemp_i;
+    gsfsLong        sltemp;
+    double          dtemp;
+    int             i = 0;
+
+    /* First byte contains a GSF sensor specific version number for this subrecord. This
+	 *  field, (gsfKMALLVersion) is a placeholder to support potential future growth.
+	 */
+    *p = 0;
+	p += 1;
+
+    /* Next byte contains an integer ID describing the MB datagram. */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.dgmType;
+	p += 1;
+
+	/* Next byte contains an integer ID describing KMALL datagram version . */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.dgmVersion;
+	p += 1;
+
+    /* The next byte contains the system id. */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.systemID;
+    p += 1;
+
+	/* The next two bytes contain the echo sounder model */
+    stemp = htons((gsfuShort)sdata->gsfKMALLSpecific.echoSounderID);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next eight bytes are spare */
+    memset(p, 0, (size_t) 8);
+    p += 8;
+
+    /* Next section is from the cmnPart */
+
+	/* The next two bytes contain the size of the CmnPart */
+    stemp = htons((gsfuShort)sdata->gsfKMALLSpecific.numBytesCmnPart);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The two bytes contain the ping counter */
+    stemp = htons((gsfuShort)sdata->gsfKMALLSpecific.pingCnt);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next byte contains the number of recieve fans per ping */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.rxFansPerPing;
+    p += 1;
+
+    /* The next byte contains the recieve fan index */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.rxFanIndex;
+    p += 1;
+
+    /* The next byte contains the number of swaths per ping */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.swathsPerPing;
+    p += 1;
+
+    /* The next byte contains the along ship index of this swath */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.swathAlongPosition;
+    p += 1;
+
+    /* The next byte contains the transmitter index */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.txTransducerInd;
+    p += 1;
+
+    /* The next byte contains the reciever index */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.rxTransducerInd;
+    p += 1;
+
+    /* The next byte contains the number of recieve transducers */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.numRxTransducers;
+    p += 1;
+
+    /* The next byte contains the algorithm type */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.algorithmType;
+    p += 1;
+
+    /* The next sixteen bytes are spare */
+    memset(p, 0, (size_t) 16);
+    p += 16;
+
+    /* Next section is from the pingInfo */
+
+    /* The next two bytes contain the size of the ping info structure */
+    stemp = htons((gsfuShort) sdata->gsfKMALLSpecific.numBytesInfoData);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next four bytes contains the ping rate, saved with a precision of 0.00001. */
+    dtemp = sdata->gsfKMALLSpecific.pingRate_Hz * 1.0e5;
+    dtemp += 0.501;
+	ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The next byte contains the beam spacing mode */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.beamSpacing;
+    p += 1;
+
+    /* The next byte contains the depth mode */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.depthMode;
+    p += 1;
+
+    /* The next byte contains the depth mode */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.subDepthMode;
+    p += 1;
+
+    /* The next byte contains the distance between swaths */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.distanceBtwSwath;
+    p += 1;
+
+    /* The next byte contains the detection mode */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.detectionMode;
+    p += 1;
+
+    /* The next byte contains the pulse type */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.pulseForm;
+    p += 1;
+
+    /* The four bytes contains the frequency mode */
+    dtemp = sdata->gsfKMALLSpecific.frequencyMode_Hz;
+	if (sdata->gsfKMALLSpecific.frequencyMode_Hz > 10000.0)
+    {
+        dtemp += 0.501;
+    }
+	ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The four bytes contains the lowest center frequency of all sectors for this swath */
+    dtemp = sdata->gsfKMALLSpecific.freqRangeLowLim_Hz * 1.0e3;
+	dtemp += 0.501;
+	ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The four bytes contains the highest center frequency of all sectors for this swath */
+    dtemp = sdata->gsfKMALLSpecific.freqRangeHighLim_Hz * 1.0e3;
+	dtemp += 0.501;
+	ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The four bytes contains the total signal length of the sector with the longest Tx pulse */
+    dtemp = (sdata->gsfKMALLSpecific.maxTotalTxPulseLength_sec * 1.0e6) + 0.501;
+	ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The four bytes contains the effective signal length (-3 dB) of the sector with the longest tx pulse */
+    dtemp = (sdata->gsfKMALLSpecific.maxEffTxPulseLength_sec * 1.0e6) + 0.501;
+	ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The four bytes contains the effective bandwidth (-3 dB) of the sector with the highest bandwith */
+    dtemp = (sdata->gsfKMALLSpecific.maxEffTxBandWidth_Hz * 1.0e3) + 0.501;
+	ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The four bytes contains the average absorption coefficient in dB/km */
+    dtemp = (sdata->gsfKMALLSpecific.absCoeff_dBPerkm * 1.0e3) + 0.501;
+	ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The two bytes contains the swath coverage to the port side in degrees */
+    dtemp = (sdata->gsfKMALLSpecific.portSectorEdge_deg * 1.0e2);
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sstemp = htons((gsfsShort) dtemp);
+    memcpy(p,&sstemp,2);
+    p += 2;
+
+    /* The two bytes contains the swath coverage to the starboard side in degrees */
+    dtemp = (sdata->gsfKMALLSpecific.starbSectorEdge_deg * 1.0e2);
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sstemp = htons((gsfsShort) dtemp);
+    memcpy(p,&sstemp,2);
+    p += 2;
+
+    /* The two bytes contains the swath coverage actually achieved to the port side in degrees */
+    dtemp = (sdata->gsfKMALLSpecific.portMeanCov_deg * 1.0e2);
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sstemp = htons((gsfsShort) dtemp);
+    memcpy(p,&sstemp,2);
+    p += 2;
+
+    /* The two bytes contains the swath coverage actually achieved to the starboard side in degrees */
+    dtemp = (sdata->gsfKMALLSpecific.starbMeanCov_deg * 1.0e2);
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sstemp = htons((gsfsShort) dtemp);
+    memcpy(p,&sstemp,2);
+    p += 2;
+
+    /* The two bytes contains the swath coverage actually achieved to the port side in degrees */
+    dtemp = (sdata->gsfKMALLSpecific.portMeanCov_deg * 1.0e2);
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sstemp = htons((gsfsShort) dtemp);
+    memcpy(p,&sstemp,2);
+    p += 2;
+
+    /* The two bytes contains the swath coverage actually achieved to the starboard side in degrees */
+    dtemp = (sdata->gsfKMALLSpecific.starbMeanCov_deg * 1.0e2);
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sstemp = htons((gsfsShort) dtemp);
+    memcpy(p,&sstemp,2);
+    p += 2;
+
+    /* The two bytes contains the swath coverage actually achieved to the port side, output from sonar as two byte value in whole meters */
+    dtemp = (sdata->gsfKMALLSpecific.portMeanCov_m);
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sstemp = htons((gsfsShort) dtemp);
+    memcpy(p,&sstemp,2);
+    p += 2;
+
+    /* The two bytes contains the swath coverage actually achieved to the starboard, output from sonar as two byte value in whole meters */
+    dtemp = (sdata->gsfKMALLSpecific.starbMeanCov_m);
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sstemp = htons((gsfsShort) dtemp);
+    memcpy(p,&sstemp,2);
+    p += 2;
+
+    /* The next byte contains the mode and stabilization settings */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.modeAndStabilisation;
+    p += 1;
+
+    /* The next byte contains a first group of operator selectable filter settings */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.runtimeFilter1;
+    p += 1;
+
+    /* The next byte contains a second group of operator selectable filter settings */
+    stemp = htons((gsfuShort) sdata->gsfKMALLSpecific.runtimeFilter2);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next four bytes contains the pipe tracking status */
+    ltemp = (gsfuLong) sdata->gsfKMALLSpecific.pipeTrackingStatus;
+	ltemp = htonl(ltemp);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The next two bytes contain the transmit array size used */
+    dtemp = sdata->gsfKMALLSpecific.transmitArraySizeUsed_deg * 1.0e3;
+	dtemp += 0.501;
+	stemp = htons((gsfuShort) dtemp);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next two bytes contain the receive array size used */
+    dtemp = sdata->gsfKMALLSpecific.receiveArraySizeUsed_deg * 1.0e3;
+	dtemp += 0.501;
+	stemp = htons((gsfuShort) dtemp);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next two bytes contain the transmit power */
+    dtemp = sdata->gsfKMALLSpecific.transmitPower_dB * 1.0e2;
+	dtemp += 0.501;
+	sstemp = htons((gsfsShort) dtemp);
+    memcpy(p,&sstemp,2);
+    p += 2;
+
+    /* The next two bytes contain the source level ramp up time remaining */
+	stemp = htons((gsfuShort) sdata->gsfKMALLSpecific.SLrampUpTimeRemaining);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next four bytes contains the yaw angle applied */
+    dtemp = sdata->gsfKMALLSpecific.yawAngle_deg * 1.0e6;
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next two bytes contain the number of transmit sectors */
+	stemp = htons((gsfuShort) sdata->gsfKMALLSpecific.numTxSectors);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next two bytes contain the number of bytes per transmit sector */
+	stemp = htons((gsfuShort) sdata->gsfKMALLSpecific.numBytesPerTxSector);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next four bytes contains the heading of the vessel at the midpoint of the first Tx pulse */
+    dtemp = sdata->gsfKMALLSpecific.headingVessel_deg * 1.0e6;
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next four bytes contains the sound speed at transmit transducer depth at time of first tx pulse */
+    dtemp = sdata->gsfKMALLSpecific.soundSpeedAtTxDepth_mPerSec * 1.0e6;
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next four bytes contains the Tx transducer depth below the waterline at the time of the first tx pulse */
+    dtemp = sdata->gsfKMALLSpecific.txTransducerDepth_m * 1.0e6;
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next four bytes contains the distance between the water line and the vessel reference point in meters at the time of first tx pulse */
+    dtemp = sdata->gsfKMALLSpecific.z_waterLevelReRefPoint_m * 1.0e6;
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next four bytes contains the X distance between .all reference point and the .kmall reference point */
+    dtemp = sdata->gsfKMALLSpecific.x_kmallToall_m * 1.0e6;
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next four bytes contains the Y distance between .all reference point and the .kmall reference point */
+    dtemp = sdata->gsfKMALLSpecific.y_kmallToall_m * 1.0e6;
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next byte contains the method of position determination */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.latLongInfo;
+    p += 1;
+
+    /* The next byte contains the status of the active positioning sensor */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.posSensorStatus;
+    p += 1;
+
+    /* The next byte contains the status of the active attitude sensor */
+    *p = (unsigned char) sdata->gsfKMALLSpecific.attitudeSensorStatus;
+    p += 1;
+
+    /* The next four bytes contains the latitude of the RP at the time of the first pulse */
+    dtemp = sdata->gsfKMALLSpecific.latitude_deg * 1.0e7;
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next four bytes contains the longitude of the RP at the time of the first pulse */
+    dtemp = sdata->gsfKMALLSpecific.longitude_deg * 1.0e7;
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next four bytes contains the ellipsoidal height of the RP at the time of the first pulse */
+    dtemp = sdata->gsfKMALLSpecific.ellipsoidHeightReRefPoint_m * 1.0e3;
+	if (dtemp < 0.0)
+	{
+		dtemp -= 0.501;
+	}
+	else
+	{
+		dtemp += 0.501;
+	}
+	sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next thirty two bytes are spare */
+    memset(p, 0, (size_t) 32);
+    p += 32;
+
+    /* Now loop over the transmit sectors to encode the sector specific information */
+    for(i = 0; i < sdata->gsfKMALLSpecific.numTxSectors; ++i)
+    {
+        /* The next byte contains the sector number */
+        *p = (unsigned char) sdata->gsfKMALLSpecific.sector[i].txSectorNumb;
+        p += 1;
+
+        /* The next byte contains the array number */
+        *p = (unsigned char) sdata->gsfKMALLSpecific.sector[i].txArrNumber;
+        p += 1;
+
+        /* The next byte contains the subarray number */
+        *p = (unsigned char) sdata->gsfKMALLSpecific.sector[i].txSubArray;
+        p += 1;
+
+        /* The next four bytes contain the sector delay */
+        dtemp = sdata->gsfKMALLSpecific.sector[i].sectorTransmitDelay_sec * 1.0e6;
+        if(dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong)dtemp);
+        memcpy(p,&ltemp,4);
+        p += 4;
+
+        /* The next four bytes contain the tilt angle */
+        dtemp = sdata->gsfKMALLSpecific.sector[i].tiltAngleReTx_deg * 1.0e6;
+        if(dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        sltemp = htonl((gsfsLong)dtemp);
+        memcpy(p,&sltemp,4);
+        p += 4;
+
+        /* The next four bytes contain the nominal source level */
+        dtemp = sdata->gsfKMALLSpecific.sector[i].txNominalSourceLevel_dB * 1.0e6;
+        if(dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        sltemp = htonl((gsfsLong)dtemp);
+        memcpy(p,&sltemp,4);
+        p += 4;
+
+        /* The next four bytes contain the focus range */
+        dtemp = sdata->gsfKMALLSpecific.sector[i].txFocusRange_m * 1.0e3;
+        if(dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong)dtemp);
+        memcpy(p,&ltemp,4);
+        p += 4;
+
+        /* The next four bytes contain the center frequency */
+        dtemp = sdata->gsfKMALLSpecific.sector[i].centreFreq_Hz * 1.0e3;
+        if(dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong)dtemp);
+        memcpy(p,&ltemp,4);
+        p += 4;
+
+        /* The next four bytes contain the signal bandwidth */
+        dtemp = sdata->gsfKMALLSpecific.sector[i].signalBandWidth_Hz * 1.0e3;
+        if(dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong)dtemp);
+        memcpy(p,&ltemp,4);
+        p += 4;
+
+        /* The next four bytes contain the signal length */
+        dtemp = sdata->gsfKMALLSpecific.sector[i].totalSignalLength_sec * 1.0e6;
+        if(dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong)dtemp);
+        memcpy(p,&ltemp,4);
+        p += 4;
+
+        /* The next byte contains the pulse shading */
+        *p = (unsigned char) sdata->gsfKMALLSpecific.sector[i].pulseShading;
+        p += 1;
+
+        /* The next byte contains the signal waveform */
+        *p = (unsigned char) sdata->gsfKMALLSpecific.sector[i].signalWaveForm;
+        p += 1;
+
+        /* The next four bytes contain the high voltage level */
+        dtemp = sdata->gsfKMALLSpecific.sector[i].highVoltageLevel_dB * 1.0e6;
+        if(dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        sltemp = htonl((gsfsLong)dtemp);
+        memcpy(p,&sltemp,4);
+        p += 4;
+
+        /* The next four bytes contain the sector tracking correction level */
+        dtemp = sdata->gsfKMALLSpecific.sector[i].sectorTrackiongCorr_dB * 1.0e6;
+        if(dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        sltemp = htonl((gsfsLong)dtemp);
+        memcpy(p,&sltemp,4);
+        p += 4;
+
+        /* The next four bytes contain the effective signal length in seconds */
+        dtemp = sdata->gsfKMALLSpecific.sector[i].effectiveSignalLength_sec * 1.0e6;
+        if(dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        sltemp = htonl((gsfsLong)dtemp);
+        memcpy(p,&sltemp,4);
+        p += 4;
+
+        /* The next 8 bytes are our spare for later use */
+        memset(p,0,(size_t)8);
+        p += 8;
+    }
+
+    /* Next section is the rxInfo data */
+
+    /* The next two bytes contain the number of bytes in the RxInfo structure */
+    stemp = htons(sdata->gsfKMALLSpecific.numBytesRxInfo);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next two bytes contain the number of soundings, extra detections excluded */
+    stemp = htons(sdata->gsfKMALLSpecific.numSoundingsMaxMain);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next two bytes contain the number of valid soundings, extra detections excluded */
+    stemp = htons(sdata->gsfKMALLSpecific.numSoundingsValidMain);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next two bytes contain the number of bytes per element of the EMdgmMrZ_sounding_def */
+    stemp = htons(sdata->gsfKMALLSpecific.numBytesPerSounding);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next four bytes contain the integer portion of the water column sample rate */
+    ltemp_i = (gsfuLong) sdata->gsfKMALLSpecific.WCSampleRate;
+    ltemp = htonl((gsfuLong)ltemp_i);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The next four bytes contain the fractional portion of the water column sample rate */
+    dtemp = (sdata->gsfKMALLSpecific.WCSampleRate - (double) ltemp_i) * 1.0e9;
+    if(dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+	ltemp = htonl((gsfuLong)dtemp);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The next four bytes contain the integer portion of the seabed image sample rate */
+    ltemp_i = (gsfuLong) sdata->gsfKMALLSpecific.seabedImageSampleRate;
+    ltemp = htonl((gsfuLong)ltemp_i);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The next four bytes contain the fractional portion of the seabed image sample rate */
+    dtemp = (sdata->gsfKMALLSpecific.seabedImageSampleRate - (double) ltemp_i) * 1.0e9;
+    if(dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+	ltemp = htonl((gsfuLong)dtemp);
+    memcpy(p,&ltemp,4);
+    p += 4;
+
+    /* The next four bytes contain the backscatter level at normal incidence */
+    dtemp = sdata->gsfKMALLSpecific.BSnormal_dB * 1.0e6;
+    if(dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    sltemp = htonl((gsfsLong)dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next four bytes contain the backscatter level at oblique incidence */
+    dtemp = sdata->gsfKMALLSpecific.BSoblique_dB * 1.0e6;
+    if(dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    sltemp = htonl((gsfsLong)dtemp);
+    memcpy(p,&sltemp,4);
+    p += 4;
+
+    /* The next two bytes contain the sum of alarm flags for extra detections */
+    stemp = htons(sdata->gsfKMALLSpecific.extraDetectionAlarmFlag);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next two bytes contain the number of extra detections */
+    stemp = htons(sdata->gsfKMALLSpecific.numExtraDetections);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next two bytes contain the number of extra detection classes */
+    stemp = htons(sdata->gsfKMALLSpecific.numExtraDetectionClasses);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next two bytes contain the number of bytes per extra detection class */
+    stemp = htons(sdata->gsfKMALLSpecific.numBytesPerClass);
+    memcpy(p,&stemp,2);
+    p += 2;
+
+    /* The next 32 bytes are our spare for later use */
+    memset(p,0,(size_t)32);
+    p += 32;
+
+    /* Now loop over the extra detection classes */
+    for(i = 0; i < sdata->gsfKMALLSpecific.numExtraDetectionClasses; ++i)
+    {
+        /* The next 2 bytes contain the number of extra detections of this class */
+        stemp = htons(sdata->gsfKMALLSpecific.extraDetClassInfo[i].numExtraDetInClass);
+        memcpy(p,&stemp,2);
+        p += 2;
+
+        /* The next byte contains the alarm flag */
+        *p = (unsigned char) sdata->gsfKMALLSpecific.extraDetClassInfo[i].alarmFlag;
+        p += 1;
+
+        /* The next 32 bytes are our spare for later use */
+        memset(p,0,(size_t)32);
+        p += 32;
+    }
+
+    /* The next 32 bytes are our spare for later use */
+    memset(p,0,(size_t)32);
+    p += 32;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeGeoSwathPlusSpecific
+ *
+ * Description : This function encodes the GeoAcoustic GS+
+ *  sensor specific information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeGeoSwathPlusSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+
+    /* First 2 bytes contain the data source (0 = CBF, 1 = RDF) */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.data_source);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the ping side (0 port, 1 = stbd)  */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.side);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the model number  */
+    stemp = htons(sdata->gsfGeoSwathPlusSpecific.model_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the frequency (Hz) */
+    dtemp = (sdata->gsfGeoSwathPlusSpecific.frequency / 10.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the echosounder type */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.echosounder_type);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 4 bytes contain the ping number */
+    ltemp = htonl(sdata->gsfGeoSwathPlusSpecific.ping_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next 2 bytes contain the num_nav_samples */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_nav_samples);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the num_attitude_samples */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_attitude_samples);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the num_heading_samples */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_heading_samples);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the num_miniSVS_samples */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_miniSVS_samples);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the num_echosounder_samples */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_echosounder_samples);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the num_raa_samples (range-angle-amplitude) */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.num_raa_samples);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the mean SV (m/s) */
+    dtemp = (sdata->gsfGeoSwathPlusSpecific.mean_sv * 20.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the surface velocity (m/s)  */
+    dtemp = (sdata->gsfGeoSwathPlusSpecific.surface_velocity * 20.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the number of valid beams  */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.valid_beams);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the sample rate (Hz) */
+    dtemp = (sdata->gsfGeoSwathPlusSpecific.sample_rate / 10.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the pulse length (usec) */
+    dtemp = sdata->gsfGeoSwathPlusSpecific.pulse_length;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the ping length (m) */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.ping_length);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the transmit power (dB) */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.transmit_power);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the sidescan gain channel (0 - 3) */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.sidescan_gain_channel);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the stabilization flag (0 or 1) */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.stabilization);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the GPS quality */
+    stemp = htons((gsfuShort) sdata->gsfGeoSwathPlusSpecific.gps_quality);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the range uncertainty. */
+    dtemp = (sdata->gsfGeoSwathPlusSpecific.range_uncertainty * 1000.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the angle uncertainty. */
+    dtemp = (sdata->gsfGeoSwathPlusSpecific.angle_uncertainty * 100.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 32 bytes are spare, but are preserved for the future */
+    memcpy (p, &sdata->gsfGeoSwathPlusSpecific.spare, sizeof (unsigned char) * 32);
+    p += 32;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeKlein5410BssSpecific
+ *
+ * Description : This function encodes the Klein 5410 Bathy Sidescan
+ *  sensor specific information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeKlein5410BssSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+
+    /* First 2 bytes contain the data source (0 = SDF) */
+    stemp = htons((gsfuShort) sdata->gsfKlein5410BssSpecific.data_source);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the ping side (0 port, 1 = stbd)  */
+    stemp = htons((gsfuShort) sdata->gsfKlein5410BssSpecific.side);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the sonar model number  */
+    stemp = htons((gsfuShort) sdata->gsfKlein5410BssSpecific.model_number);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four bytes contain the system frequency */
+    dtemp = sdata->gsfKlein5410BssSpecific.acoustic_frequency * 1.0e03;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contain the sampling frequency */
+    dtemp = sdata->gsfKlein5410BssSpecific.sampling_frequency * 1.0e03;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contain the ping number */
+    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.ping_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contain the total number of samples in the ping */
+    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.num_samples);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contain the number of valid range, angle, amplitude
+    samples in the ping */
+    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.num_raa_samples);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contain the error flags */
+    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.error_flags);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contain the range */
+    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.range);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contain the reading from the towfish pressure sensor in Volts */
+    dtemp = sdata->gsfKlein5410BssSpecific.fish_depth * 1.0e03;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contain the towfish altitude in m */
+    dtemp = sdata->gsfKlein5410BssSpecific.fish_altitude * 1.0e03;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four bytes contain the speed of sound at the transducer face in m/sec */
+    dtemp = sdata->gsfKlein5410BssSpecific.sound_speed * 1.0e03;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next 2 bytes contain the transmit pulse waveform number */
+    stemp = htons((gsfuShort) sdata->gsfKlein5410BssSpecific.tx_waveform);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 2 bytes contain the altimeter status: 0 = passive, 1 = active  */
+    stemp = htons((gsfuShort) sdata->gsfKlein5410BssSpecific.altimeter);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four bytes contain the raw data configuration */
+    ltemp = htonl((gsfuLong) sdata->gsfKlein5410BssSpecific.raw_data_config);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next 32 bytes are spare, but are reserved for the future */
+    memcpy (p, &sdata->gsfKlein5410BssSpecific.spare, sizeof (unsigned char) * 32);
+    p += 32;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeReson8100Specific
+ *
+ * Description : This function encodes the Reson 8100 sensor specific
+ *  information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeReson8100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+
+    /* First two byte integer contains the sonar latency */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.latency);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the ping number */
+    ltemp = htonl((gsfuLong) sdata->gsfReson8100Specific.ping_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the sonar id */
+    ltemp = htonl((gsfuLong) sdata->gsfReson8100Specific.sonar_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the sonar model */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.sonar_model);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sonar frequency */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.frequency);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sea surface sound speed * 10 */
+    dtemp = sdata->gsfReson8100Specific.surface_velocity * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sample rate */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.sample_rate);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the ping rate */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.ping_rate);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sonar mode of operation */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.mode);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sonar range setting */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.range);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the power setting */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.power);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the gain setting */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.gain);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the pulse width, in microseconds */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.pulse_width);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the tvg spreading coefficient * 4 */
+    *p = (unsigned char) (sdata->gsfReson8100Specific.tvg_spreading);
+    p += 1;
+
+    /* Next byte contains the tvg absorption coefficient */
+    *p = (unsigned char) (sdata->gsfReson8100Specific.tvg_absorption);
+    p += 1;
+
+    /* Next byte contains the fore/aft beam width */
+    *p = (unsigned char) ((sdata->gsfReson8100Specific.fore_aft_bw * 10.0) + 0.501);
+    p += 1;
+
+    /* Next byte contains the athwartships beam width */
+    *p = (unsigned char) ((sdata->gsfReson8100Specific.athwart_bw * 10.0) + 0.501);
+    p += 1;
+
+    /* Next byte contains the projector type */
+    *p = (unsigned char) (sdata->gsfReson8100Specific.projector_type);
+    p += 1;
+
+    /* Next two byte integer contains the projector angle, in deg * 100 */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.projector_angle);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the range filter min */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.range_filt_min);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the range filter max */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.range_filt_max);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the depth filter min */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.depth_filt_min);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the depth filter max */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.depth_filt_max);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the filters active flags */
+    *p = (unsigned char) (sdata->gsfReson8100Specific.filters_active);
+    p += 1;
+
+    /* Next two byte integer contains the temperature at the sonar head */
+    stemp = htons((gsfuShort) sdata->gsfReson8100Specific.temperature);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the across track angular beam spacing * 10000 */
+    dtemp = sdata->gsfReson8100Specific.beam_spacing * 10000.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes are reserved as spare space. */
+    *p = (unsigned char) (sdata->gsfReson8100Specific.spare[0]);
+    p += 1;
+    *p = (unsigned char) (sdata->gsfReson8100Specific.spare[1]);
+    p += 1;
+
+    return (p - sptr);
+}
+
+
+/********************************************************************
+ *
+ * Function Name : EncodeReson7100Specific
+ *
+ * Description : This function encodes the Reson 7100 sensor specific
+ *   information into external byte stream form.
+ *
+ * Inputs :
+ *   sptr = a pointer to an unsigned char buffer to write into
+ *   sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeReson7100Specific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+
+    /* First two bytes contains the data format definition version number */
+    stemp = htons((gsfuShort) sdata->gsfReson7100Specific.protocol_version);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next four bytes contains the sonar device ID */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.device_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next 16 bytes are spare space for future growth */
+    memset(p, 0, 16);
+    p += 16;
+
+    /* The next four byte integer contains the high order four bytes of the sonar serial number */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.major_serial_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four byte integer contains the low order four bytes of the sonar id */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.minor_serial_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the ping number */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.ping_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the multi_ping_sequence */
+    stemp = htons((gsfuShort) sdata->gsfReson7100Specific.multi_ping_seq);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the sonar frequency in Hz * 1,000.0 */
+    dtemp = (sdata->gsfReson7100Specific.frequency * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the sample rate in Hz * 10,000.0 */
+    dtemp = (sdata->gsfReson7100Specific.sample_rate * 1.0e4) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the receiver bandwidth, in Hz * 10,000.0 */
+    dtemp = (sdata->gsfReson7100Specific.receiver_bandwdth * 1.0e4) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the pulse length, in seconds * 10,000,000.0 */
+    dtemp = (sdata->gsfReson7100Specific.tx_pulse_width * 1.0e7) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the pulse type id */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.tx_pulse_type_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the pulse envelope id */
+    ltemp = htonl((gsfuShort) sdata->gsfReson7100Specific.tx_pulse_envlp_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+
+    /* Next four byte integer contains the pulse envelope parameter */
+    dtemp = (sdata->gsfReson7100Specific.tx_pulse_envlp_param * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains additional pulse information */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.tx_pulse_reserved);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the maximum ping rate in pings/second * 1,000,000.0 */
+    dtemp = (sdata->gsfReson7100Specific.max_ping_rate * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the ping period in seconds since last ping * 1,000,000.0 */
+    dtemp = (sdata->gsfReson7100Specific.ping_period * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the sonar range setting in meters * 100.0 */
+    dtemp = (sdata->gsfReson7100Specific.range * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the power setting * 100.0 */
+    dtemp = (sdata->gsfReson7100Specific.power * 1.0e2);
+    if (dtemp < 0.0)
+    {
+        dtemp = dtemp - 0.501;
+    }
+    else
+    {
+        dtemp = dtemp + 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the gain setting * 100.0 */
+    dtemp = (sdata->gsfReson7100Specific.gain * 1.0e2);
+    if (dtemp < 0.0)
+    {
+        dtemp = dtemp - 0.501;
+    }
+    else
+    {
+        dtemp = dtemp + 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the control flags */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.control_flags);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the projector type */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.projector_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the projector steering angle, in deg * 1000.0 */
+    dtemp = (sdata->gsfReson7100Specific.projector_steer_angl_vert * 1.0e3);
+    if (dtemp < 0.0)
+    {
+        dtemp = dtemp - 0.501;
+    }
+    else
+    {
+        dtemp = dtemp + 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the projector steering angle, in deg * 1000.0 */
+    dtemp = (sdata->gsfReson7100Specific.projector_steer_angl_horz * 1.0e3);
+    if (dtemp < 0.0)
+    {
+        dtemp = dtemp - 0.501;
+    }
+    else
+    {
+        dtemp = dtemp + 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the fore/aft beam width in degrees * 100.0 */
+    dtemp = (sdata->gsfReson7100Specific.projector_beam_wdth_vert * 1.0e2) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the athwartships beam width in degrees * 100.0 */
+    dtemp = (sdata->gsfReson7100Specific.projector_beam_wdth_horz * 1.0e2) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the projector beam focal point in meters * 100.0 */
+    dtemp = (sdata->gsfReson7100Specific.projector_beam_focal_pt * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the projector beam weighting window type */
+    ltemp = htonl ((gsfuLong) sdata->gsfReson7100Specific.projector_beam_weighting_window_type);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the projector beam weighting window parameter */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.projector_beam_weighting_window_param);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the transmit flags */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.transmit_flags);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the hydrophone type */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.hydrophone_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the receive beam weighting window type */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.receiving_beam_weighting_window_type);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the receive beam weighting window param */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.receiving_beam_weighting_window_param);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the receive flags */
+    ltemp = htonl((gsfuLong) sdata->gsfReson7100Specific.receive_flags);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte value contains the receive beam width in degrees * 100.0 */
+    dtemp = (sdata->gsfReson7100Specific.receive_beam_width * 1.0e2) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte value contains the range filter min in meters * 10 */
+    dtemp = (sdata->gsfReson7100Specific.range_filt_min * 1.0e1) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte value contains the range filter max in meters * 10 */
+    dtemp = (sdata->gsfReson7100Specific.range_filt_max * 1.0e1) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte value contains the depth filter min in meters * 10 */
+    dtemp = (sdata->gsfReson7100Specific.depth_filt_min * 1.0e1) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte value contains the depth filter max in meters * 10 */
+    dtemp = (sdata->gsfReson7100Specific.depth_filt_max * 1.0e1) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte value contains the absorption in dB/kilometer * 1,000.0 */
+    dtemp = (sdata->gsfReson7100Specific.absorption * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the sound velocity * 10 */
+    dtemp = (sdata->gsfReson7100Specific.sound_velocity * 1.0e1) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the spreading loss in dB * 1,000.0 */
+    dtemp = (sdata->gsfReson7100Specific.spreading * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+     /* The next byte contains the inverted beam angle flag*/
+    *p = sdata->gsfReson7100Specific.raw_data_from_7027;
+    p += 1;
+
+    /* The next 15 bytes are spare space for future growth */
+    memset(p, 0, 15);
+    p += 15;
+
+    /* The next byte contains the sv source */
+    *p = sdata->gsfReson7100Specific.sv_source;
+    p += 1;
+
+    /* The next byte contains the layer compensation flag */
+    *p = sdata->gsfReson7100Specific.layer_comp_flag;
+    p += 1;
+
+    /* The next 8 bytes are spare space for future growth */
+    memset(p, 0, 8);
+    p += 8;
+
+    return (p - sptr);
+}
+
+
+/********************************************************************
+ *
+ * Function Name : EncodeResonTSeriesSpecific
+ *
+ * Description : This function encodes the Reson T series
+ *   sensor-specific information into external byte stream form.
+ *
+ * Inputs :
+ *   sptr = a pointer to an unsigned char buffer to write into.
+ *   sdata = a pointer to a union of sensor specific data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeResonTSeriesSpecific(unsigned char *sptr, gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+	gsfsLong        sltemp;
+    double          dtemp;
+
+    /* First two bytes contains the data format definition version number */
+    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.protocol_version);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next four bytes contains the sonar device ID */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.device_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contain the number of devices */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.number_devices);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next 2 bytes contain the system enumerator */
+    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.system_enumerator);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next 10 bytes are spare space for future growth */
+    memset(p, 0, 10);
+    p += 10;
+
+    /* The next four byte integer contains the high order four bytes of the sonar serial number */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.major_serial_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four byte integer contains the low order four bytes of the sonar id */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.minor_serial_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the ping number */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.ping_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the multi_ping_sequence */
+    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.multi_ping_seq);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the sonar frequency in Hz * 1,000.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.frequency * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the sample rate in Hz * 10,000.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.sample_rate * 1.0e4) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the receiver bandwidth, in Hz * 10,000.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.receiver_bandwdth * 1.0e4) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the pulse length, in seconds * 10,000,000.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.tx_pulse_width * 1.0e7) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the pulse type id */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.tx_pulse_type_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the pulse envelope id */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.tx_pulse_envlp_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the pulse envelope parameter */
+    dtemp = (sdata->gsfResonTSeriesSpecific.tx_pulse_envlp_param * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the multi_ping_sequence */
+    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.tx_pulse_mode);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains additional pulse information */
+    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.tx_pulse_reserved);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the maximum ping rate in pings/second * 1,000,000.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.max_ping_rate * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the ping period in seconds since last ping * 1,000,000.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.ping_period * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the sonar range setting in meters * 100.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.range * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the power setting * 100.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.power * 1.0e2);
+    if (dtemp < 0.0)
+    {
+        dtemp = dtemp - 0.501;
+    }
+    else
+    {
+        dtemp = dtemp + 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the gain setting * 100.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.gain * 1.0e2);
+    if (dtemp < 0.0)
+    {
+        dtemp = dtemp - 0.501;
+    }
+    else
+    {
+        dtemp = dtemp + 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the control flags */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.control_flags);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the projector type */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.projector_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the projector steering angle, in deg * 1000.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.projector_steer_angl_vert * 1.0e3);
+    if (dtemp < 0.0)
+    {
+        dtemp = dtemp - 0.501;
+    }
+    else
+    {
+        dtemp = dtemp + 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the projector steering angle, in deg * 1000.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.projector_steer_angl_horz * 1.0e3);
+    if (dtemp < 0.0)
+    {
+        dtemp = dtemp - 0.501;
+    }
+    else
+    {
+        dtemp = dtemp + 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the fore/aft beam width in degrees * 100.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.projector_beam_wdth_vert * 1.0e2) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the athwartships beam width in degrees * 100.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.projector_beam_wdth_horz * 1.0e2) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the projector beam focal point in meters * 100.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.projector_beam_focal_pt * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the projector beam weighting window type */
+    ltemp = htonl ((gsfuLong) sdata->gsfResonTSeriesSpecific.projector_beam_weighting_window_type);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the projector beam weighting window parameter */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.projector_beam_weighting_window_param);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the transmit flags */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.transmit_flags);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the hydrophone type */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.hydrophone_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the receive beam weighting window type */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.receiving_beam_weighting_window_type);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the receive beam weighting window param */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.receiving_beam_weighting_window_param);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the receive flags */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.receive_flags);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte value contains the receive beam width in degrees * 100.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.receive_beam_width * 1.0e2) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte value contains the range filter min in meters * 10 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.range_filt_min * 1.0e1) + 0.501;
+    sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &sltemp, 4);
+    p += 4;
+
+    /* Next four byte value contains the range filter max in meters * 10 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.range_filt_max * 1.0e1) + 0.501;
+    sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &sltemp, 4);
+    p += 4;
+
+    /* Next four byte value contains the depth filter min in meters * 10 */
+    if (sdata->gsfResonTSeriesSpecific.depth_filt_min < 0.0) {
+        dtemp = (sdata->gsfResonTSeriesSpecific.depth_filt_min * 1.0e1) - 0.501;
+    } else {
+        dtemp = (sdata->gsfResonTSeriesSpecific.depth_filt_min * 1.0e1) + 0.501;
+    }
+
+    sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &sltemp, 4);
+    p += 4;
+
+    /* Next four byte value contains the depth filter max in meters * 10 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.depth_filt_max * 1.0e1) + 0.501;
+    sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &sltemp, 4);
+    p += 4;
+
+    /* Next four byte value contains the absorption in dB/kilometer * 1,000.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.absorption * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the sound velocity * 10 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.sound_velocity * 1.0e1) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next byte contains the sv source */
+    *p = sdata->gsfResonTSeriesSpecific.sv_source;
+    p += 1;
+
+    /* Next four byte integer contains the spreading loss in dB * 1,000.0 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.spreading * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the beam spacing mode */
+    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.beam_spacing_mode);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two byte integer contains the sonar source mode */
+    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.sonar_source_mode);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the coverage mode */
+    *p = sdata->gsfResonTSeriesSpecific.coverage_mode;
+    p += 1;
+
+    /* Next four byte integer contains the coverage angle in degrees * 100 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.coverage_angle * 1.0e2);
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the horizontal receiver steering angle in degrees * 100 */
+    dtemp = (sdata->gsfResonTSeriesSpecific.horizontal_receiver_steering_angle * 1.0e2);
+    if (dtemp < 0.0)
+    {
+        dtemp = dtemp - 0.501;
+    }
+    else
+    {
+        dtemp = dtemp + 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next 3 bytes are spare space for future growth */
+    memset(p, 0, 3);
+    p += 3;
+
+    /* Next four byte integer contains the uncertainty type */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.uncertainty_type);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains transmitter steering angle*/
+    dtemp = (sdata->gsfResonTSeriesSpecific.transmitter_steering_angle * 1.0e5);
+    if (dtemp < 0.0)
+    {
+        dtemp = dtemp - 0.501;
+    }
+    else
+    {
+        dtemp = dtemp + 0.501;
+    }
+    sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &sltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains applied roll information*/
+    dtemp = (sdata->gsfResonTSeriesSpecific.applied_roll * 1.0e5);
+    if (dtemp < 0.0)
+    {
+        dtemp = dtemp - 0.501;
+    }
+    else
+    {
+        dtemp = dtemp + 0.501;
+    }
+    sltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &sltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the detection_algorithm */
+    stemp = htons((gsfuShort) sdata->gsfResonTSeriesSpecific.detection_algorithm);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains detection flags */
+    ltemp = htonl((gsfuLong) sdata->gsfResonTSeriesSpecific.detection_flags);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next 60 bytes are the module description */
+    memcpy(p, (unsigned char *) sdata->gsfResonTSeriesSpecific.device_description, 60);
+    p += 60;
+
+    /* Next four byte integer contains sound speed with higher precision*/
+    dtemp = (sdata->gsfResonTSeriesSpecific.sound_velocity * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next 60 bytes are spare space for future growth in the 7027 datagram*/
+    memset(p, 0, 60);
+    p += 60;
+    
+    /* Next byte contains the operation field for the match filter */
+    *p = (unsigned char)sdata->gsfResonTSeriesSpecific.match_filter_control;
+    p += 1;
+    
+    /* Next four byte integer contains the start frequency for the match filter in Hz */
+    dtemp = (sdata->gsfResonTSeriesSpecific.match_filter_start_freq * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+    
+    /* Next four byte integer contains the end frequency for the match filter in Hz */
+    dtemp = (sdata->gsfResonTSeriesSpecific.match_filter_end_freq * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+    
+    /* Next byte contains the window type for the match filter */
+    *p = (unsigned char)sdata->gsfResonTSeriesSpecific.match_filter_window_type;
+    p += 1;
+    
+    /* Next four byte integer contains the shading value for the match filter */
+    dtemp = (sdata->gsfResonTSeriesSpecific.match_filter_shading_value * 1.0e4) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+    
+    /* Next four byte integer contains the effective pulse width for the match filter in seconds */
+    dtemp = (sdata->gsfResonTSeriesSpecific.match_filter_effect_pulse_width * 1.0e11) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next 52 bytes are spare space for future growth in the 7002 datagram */
+    memset(p, 0, sizeof(unsigned int) * 13);
+    p += 52;
+    
+    /* The next 32 bytes are spare space for future growth */
+    memset(p, 0, 32);
+    p += 32;
+    
+    /* The next 264 bytes are spare space for future growth */
+    memset(p, 0, 288);
+    p += 288;
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeDeltaTSpecific
+ *
+ * Description : This function encodes the Imagenex Delta T
+ *  sensor specific information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeDeltaTSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+
+    /* The next four bytes contains the file extension */
+    memcpy (p, (unsigned char *) (sdata->gsfDeltaTSpecific.decode_file_type), 4);
+    p += 4;
+
+    /* The next byte contains the version number */
+    *p = (unsigned char) sdata->gsfDeltaTSpecific.version;
+    p += 1;
+
+    /* The next two bytes contains the ping byte size field */
+    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.ping_byte_size);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 8 bytes contains the original sonar interrogation time */
+    ltemp = htonl(sdata->gsfDeltaTSpecific.interrogation_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+    ltemp = htonl(sdata->gsfDeltaTSpecific.interrogation_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next two bytes contains the samples per beam field */
+    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.samples_per_beam);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contains the sector size field */
+    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.sector_size);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contains the start angle field. */
+    dtemp = ((sdata->gsfDeltaTSpecific.start_angle + 180.0) * 100.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contains the angle increment field. */
+    dtemp = ((sdata->gsfDeltaTSpecific.angle_increment) * 100.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contains the acoustic range field */
+    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.acoustic_range);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contains the acoustic frequency field */
+    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.acoustic_frequency);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contains the sound speed field. */
+    dtemp = ((sdata->gsfDeltaTSpecific.sound_velocity) * 10.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contains the range resolution field. */
+    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.range_resolution);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contains the profile tilt field. */
+    dtemp = ((sdata->gsfDeltaTSpecific.profile_tilt_angle) + 180.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contains the repetition rate field. */
+    stemp = htons((gsfuShort) sdata->gsfDeltaTSpecific.repetition_rate);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next four bytes contains the ping number field */
+    ltemp = htonl((gsfuLong) sdata->gsfDeltaTSpecific.ping_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next byte contains the intensity flag field. */
+    *p = (unsigned char) sdata->gsfDeltaTSpecific.intensity_flag;
+    p += 1;
+
+    /* The next two bytes contains the ping latency field. */
+    dtemp = ((sdata->gsfDeltaTSpecific.ping_latency) * 10000.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes contains the data latency field. */
+    dtemp = ((sdata->gsfDeltaTSpecific.data_latency) * 10000.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next byte contains the sample rate flag field. */
+    *p = (unsigned char) sdata->gsfDeltaTSpecific.sample_rate_flag;
+    p += 1;
+
+    /* The next byte contains the option flags field. */
+    *p = (unsigned char) sdata->gsfDeltaTSpecific.option_flags;
+    p += 1;
+
+    /* The next byte contains the number of pings averaged field. */
+    *p = (unsigned char) sdata->gsfDeltaTSpecific.num_pings_avg;
+    p += 1;
+
+    /* The next two bytes contains the center ping time offset field. */
+    dtemp = ((sdata->gsfDeltaTSpecific.center_ping_time_offset) * 10000.0) + 0.501;
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next byte contains the user defined byte field. */
+    *p = (unsigned char) sdata->gsfDeltaTSpecific.user_defined_byte;
+    p += 1;
+
+    /* Next four byte integer contains the altitude field.*/
+    dtemp = ((sdata->gsfDeltaTSpecific.altitude) * 100.0) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next byte contains the external sensor flags field. */
+    *p = (unsigned char) sdata->gsfDeltaTSpecific.external_sensor_flags;
+    p += 1;
+
+    /* Next four byte integer contains the pulse length field.*/
+    dtemp = (sdata->gsfDeltaTSpecific.pulse_length * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next byte contains the fore aft beamwidth field. */
+    dtemp = (sdata->gsfDeltaTSpecific.fore_aft_beamwidth * 10.0) + 0.501;
+    *p = (unsigned char) dtemp;
+    p += 1;
+
+    /* The next byte contains the athwartships beamwidth field. */
+    dtemp = (sdata->gsfDeltaTSpecific.athwartships_beamwidth * 10.0) + 0.501;
+    *p = (unsigned char) dtemp;
+    p += 1;
+
+    /* The next 32 bytes are spare space for future growth */
+    memset(p, 0, 32);
+    p += 32;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeR2SonicSpecific
+ *
+ * Description : This function encodes the R2Sonic 2020/2022/2024
+ *  sensor specific information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+static int
+EncodeR2SonicSpecific(unsigned char *sptr, const gsfSensorSpecific *sdata)
+{
+    int i;
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+
+    /* The next 12 bytes contains the model number */
+    memcpy (p, (unsigned char *) (sdata->gsfR2SonicSpecific.model_number), 12);
+    p += 12;
+
+    /* The next 12 bytes contains the serial number */
+    memcpy (p, (unsigned char *) (sdata->gsfR2SonicSpecific.serial_number), 12);
+    p += 12;
+
+    /* The next four bytes contains the time in seconds */
+    ltemp = htonl((gsfuLong) sdata->gsfR2SonicSpecific.dg_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the fractional portion of the time in nanoseconds */
+    ltemp = htonl((gsfuLong) sdata->gsfR2SonicSpecific.dg_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the ping number */
+    ltemp = htonl((gsfuLong) sdata->gsfR2SonicSpecific.ping_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the ping period * 1,000,000 */
+    dtemp = (sdata->gsfR2SonicSpecific.ping_period * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the sound speed * 100 */
+    dtemp = (sdata->gsfR2SonicSpecific.sound_speed * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the frequency * 1000 */
+    dtemp = (sdata->gsfR2SonicSpecific.frequency * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit source level * 100 */
+    dtemp = (sdata->gsfR2SonicSpecific.tx_power * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit pulse width * 10,000,000.0*/
+    dtemp = (sdata->gsfR2SonicSpecific.tx_pulse_width * 1.0e7) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit beamwidth in the vertical * 1,000,000 */
+    dtemp = (sdata->gsfR2SonicSpecific.tx_beamwidth_vert * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit beamwidth in the horizontal * 1,000,000*/
+    dtemp = (sdata->gsfR2SonicSpecific.tx_beamwidth_horiz * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit steering in the vertical  * 1,000,000*/
+    dtemp = sdata->gsfR2SonicSpecific.tx_steering_vert * 1.0e6;
+    if (dtemp < 0.0)
+        dtemp -= 0.501;
+    else
+        dtemp += 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit steering in the horizontal  * 1,000,000*/
+    dtemp = sdata->gsfR2SonicSpecific.tx_steering_horiz * 1.0e6;
+    if (dtemp < 0.0)
+        dtemp -= 0.501;
+    else
+        dtemp += 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains misc. transmit info */
+    ltemp = htonl((gsfuLong) sdata->gsfR2SonicSpecific.tx_misc_info);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver bandwidth * 10,000 */
+    dtemp = (sdata->gsfR2SonicSpecific.rx_bandwidth * 1.0e4) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver sample rate * 1000 */
+    dtemp = (sdata->gsfR2SonicSpecific.rx_sample_rate * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver range * 100,000 */
+    dtemp = (sdata->gsfR2SonicSpecific.rx_range * 1.0e5) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver gain * 100 */
+    dtemp = (sdata->gsfR2SonicSpecific.rx_gain * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver spreading law coefficient * 1000 */
+    dtemp = (sdata->gsfR2SonicSpecific.rx_spreading * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver absorption coefficient * 1000 */
+    dtemp = (sdata->gsfR2SonicSpecific.rx_absorption * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver mount tilt angle * 1,000,000 */
+    dtemp = sdata->gsfR2SonicSpecific.rx_mount_tilt * 1.0e6;
+    if (dtemp < 0.0)
+        dtemp -= 0.501;
+    else
+        dtemp += 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains misc. receiver info */
+    ltemp = htonl((gsfuLong) sdata->gsfR2SonicSpecific.rx_misc_info);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next two bytes are reserved */
+    stemp = htons((gsfuShort) sdata->gsfR2SonicSpecific.reserved);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes are for the number of beams */
+    stemp = htons((gsfuShort) sdata->gsfR2SonicSpecific.num_beams);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next set of 6x4 (24) bytes contains reserved fields from the A0 subgroup of the BTH0 */
+    for (i=0; i<6; i++)
+    {
+        dtemp = sdata->gsfR2SonicSpecific.A0_more_info[i] * 1.0e6;
+        if (dtemp < 0.0)
+            dtemp -= 0.501;
+        else
+            dtemp += 0.501;
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+    }
+
+    /* The next set of 6x4 (24) bytes contains reserved fields from the A2 subgroup of BTH0 */
+    for (i=0; i<6; i++)
+    {
+        dtemp = sdata->gsfR2SonicSpecific.A2_more_info[i] * 1.0e6;
+        if (dtemp < 0.0)
+            dtemp -= 0.501;
+        else
+            dtemp += 0.501;
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+    }
+
+    /* The next four bytes contain minimum depth gate from the G0 subgroup of BTH0 */
+    dtemp = (sdata->gsfR2SonicSpecific.G0_depth_gate_min * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contain maximum depth gate from the G0 subgroup of BTH0 */
+    dtemp = (sdata->gsfR2SonicSpecific.G0_depth_gate_max * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contain the depth gate slope from the G0 subgroup of BTH0 */
+    dtemp = sdata->gsfR2SonicSpecific.G0_depth_gate_slope * 1.0e6;
+    if (dtemp < 0.0)
+        dtemp -= 0.501;
+    else
+        dtemp += 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* write the spare bytes */
+    memcpy(p, sdata->gsfR2SonicSpecific.spare, 32);
+    p += 32;
+
+    return (p - sptr);
+} /* end EncodeR2SonicSpecific() */
+
+/********************************************************************
+ *
+ * Function Name : EncodeSBEchotracSpecific
+ *
+ * Description : This function encodes the Bathy 2000 and echotrac
+ *  sensor specific data from the HSPS source files.
+ *
+ * Inputs :
+ *   sptr = a pointer to an unsigned char buffer to write into
+ *   sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSBEchotracSpecific(unsigned char *sptr, const t_gsfSBEchotracSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the navigation error */
+    stemp = htons((gsfuShort) (sdata->navigation_error));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+        /* Next byte contains the most probable position source navigation */
+    *p = (unsigned char) sdata->mpp_source;
+    p += 1;
+
+    /* Next byte contains the tide source */
+    *p = (unsigned char) sdata->tide_source;
+    p += 1;
+
+    /* Next two byte integer contains the dynamic draft. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = sdata->dynamic_draft * 100.0;
+    if (dtemp < 0.0)
+    {
+            dtemp -= 0.501;
+    }
+    else
+    {
+            dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* write the spare bytes */
+    memcpy(p, sdata->spare, 4);
+    p += 4;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSBMGD77Specific
+ *
+ * Description : This function encodes the MGD77 fields
+ * into an MGD77 record. The MGD77 Singlebeam is essentially
+ * survey trackline data, and actual survey data can be retrieved
+ * from the source.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSBMGD77Specific(unsigned char *sptr, const t_gsfSBMGD77Specific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuLong        ltemp;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte integer contains the time zone correction */
+    stemp = htons((gsfuShort) (sdata->time_zone_corr));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The Next two byte integer contains how the navigation was obtained */
+    stemp = htons((gsfuShort) (sdata->position_type_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The Next two byte integer contains on how the sound velocity
+       correction was made */
+    stemp = htons((gsfuShort) (sdata->correction_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The Next two byte integer contains how the bathymetry was obtained */
+    stemp = htons((gsfuShort) (sdata->bathy_type_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The Next two byte integer contains the quality code for Nav */
+    stemp = htons((gsfuShort) (sdata->quality_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next four byte integer contains the the two way travel time */
+    dtemp = sdata->travel_time * 10000;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* write the spare bytes */
+    memcpy(p, sdata->spare, 4);
+    p += 4;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSBBDBSpecific
+ *
+ * Description : This function encodes the BDB fields
+ * into a BDB record.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSBBDBSpecific(unsigned char *sptr, const t_gsfSBBDBSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuLong        ltemp;
+
+    /* Next four byte integer contains the the document number */
+    ltemp = htonl((gsfuLong) (sdata->doc_no));
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next byte contains the evaluation flag */
+    *p = (unsigned char) sdata->eval;
+    p += 1;
+
+    /* Next byte contains the classification flag */
+    *p = (unsigned char) sdata->classification;
+    p += 1;
+
+    /* Next byte contains the track adjustment flag */
+    *p = (unsigned char) sdata->track_adj_flag;
+    p += 1;
+
+    /* Next byte contains the source flag */
+    *p = (unsigned char) sdata->source_flag;
+    p += 1;
+
+    /* Next byte contains the discrete point or track line flag */
+    *p = (unsigned char) sdata->pt_or_track_ln;
+    p += 1;
+
+    /* Next byte contains the datum flag */
+    *p = (unsigned char) sdata->datum_flag;
+    p += 1;
+
+    /* write the spare bytes */
+    memcpy(p, sdata->spare, 4);
+    p += 4;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSBNOSHDBSpecific
+ *
+ * Description : This function encodes the NOSHDB fields into a
+ *               NOSHDB record.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSBNOSHDBSpecific(unsigned char *sptr, const t_gsfSBNOSHDBSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+
+    /* First two byte integer contains the depth type code */
+    stemp = htons((gsfuShort) (sdata->type_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The Next two byte integer contains the cartographic code */
+    stemp = htons((gsfuShort) (sdata->carto_code));
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* write the spare bytes */
+    memcpy(p, sdata->spare, 4);
+    p += 4;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeSBNavisoundSpecific
+ *
+ * Description : This function encodes the Navisound
+ *  sensor specific data
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data
+ *    major_version = the major version of GSF used to create the file.
+ *    minor_version = the minor version of GSF used to create the file.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeSBNavisoundSpecific(unsigned char *sptr, const t_gsfSBNavisoundSpecific *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* First two byte value contains the pulse length */
+    dtemp = sdata->pulse_length * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* write the spare bytes */
+    memcpy(p, sdata->spare, 8);
+    p += 8;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEM3ImagerySpecific
+ *
+ * Description : This function encodes the Simrad EM3000 series sensor
+ *  specific imagery information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific imagery data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeEM3ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    double          dtemp;
+
+    /* Next two bytes contain the range to normal incidence to correct amplitudes */
+    stemp = htons((gsfuShort) sdata->gsfEM3ImagerySpecific.range_norm);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the start range sample of TVG ramp */
+    stemp = htons((gsfuShort) sdata->gsfEM3ImagerySpecific.start_tvg_ramp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the stop range sample of TVG ramp */
+    stemp = htons((gsfuShort) sdata->gsfEM3ImagerySpecific.stop_tvg_ramp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next byte contains the normal incidence BS in dB */
+    *p = (unsigned char) (sdata->gsfEM3ImagerySpecific.bsn);
+    p += 1;
+
+    /* Next byte contains the oblique BS in dB */
+    *p = (unsigned char) (sdata->gsfEM3ImagerySpecific.bso);
+    p += 1;
+
+    /* The next two byte value contains the mean absorption coefficient */
+    dtemp = sdata->gsfEM3ImagerySpecific.mean_absorption * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the imagery offset value used to positive bias the imagery values. This value has been added to all imagery samples
+     *  as the Kongsberg imagery datagram is decoded into GSF.
+     */
+    stemp = htons((gsfsShort) sdata->gsfEM3ImagerySpecific.offset);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the imagery scale value as specified by the manufacturer.  This value is 2 for the EM3000/EM3002/EM1002/EM300/EM120.
+     *  The following formula can be used to convert from the GSF positive biased value to dB:
+     *  dB_value = (GSF_I_value - offset) / scale
+     */
+    stemp = htons((gsfsShort) sdata->gsfEM3ImagerySpecific.scale);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* write the spare bytes */
+    memcpy(p, sdata->gsfEM3ImagerySpecific.spare, 4);
+    p += 4;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeEM4ImagerySpecific
+ *
+ * Description : This function encodes the Simrad EM4 series sensor
+ *  specific imagery information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific imagery data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeEM4ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+
+    /* The next four bytes contains the integer portion of the sampling frequency in Hz */
+    ltemp = htonl((gsfuLong) sdata->gsfEM4ImagerySpecific.sampling_frequency);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contain the fractional portion of the sampling frequency in Hz scaled by 4.0e9 */
+    dtemp = sdata->gsfEM4ImagerySpecific.sampling_frequency - ((gsfuLong) sdata->gsfEM4ImagerySpecific.sampling_frequency);
+    dtemp *= 4.0e9;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two bytes contain the mean absorption coefficient in dB/KM. */
+    dtemp = sdata->gsfEM4ImagerySpecific.mean_absorption * 100.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the transmit pulse length in microseconds. */
+    dtemp = sdata->gsfEM4ImagerySpecific.tx_pulse_length;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the range to normal incidence to correct amplitudes */
+    stemp = htons((gsfuShort) sdata->gsfEM4ImagerySpecific.range_norm);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the start range sample of TVG ramp */
+    stemp = htons((gsfuShort) sdata->gsfEM4ImagerySpecific.start_tvg_ramp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the stop range sample of TVG ramp */
+    stemp = htons((gsfuShort) sdata->gsfEM4ImagerySpecific.stop_tvg_ramp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the normal incidence BS in dB */
+    dtemp = sdata->gsfEM4ImagerySpecific.bsn * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the oblique incidence BS in dB */
+    dtemp = sdata->gsfEM4ImagerySpecific.bso * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfsShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the transmit beam width value in degrees */
+    dtemp = sdata->gsfEM4ImagerySpecific.tx_beam_width * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two byte value contains the TVG cross over anlge in degrees */
+    dtemp = sdata->gsfEM4ImagerySpecific.tvg_cross_over * 10.0;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    stemp = htons((gsfuShort) dtemp);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the imagery offset value used to positive bias the imagery values. This value has been added to all imagery samples
+     *  as the Kongsberg imagery datagram is decoded into GSF.
+     */
+    stemp = htons((gsfsShort) sdata->gsfEM4ImagerySpecific.offset);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the imagery scale value as specified by the manufacturer.  This value is 10 for the EM710/EM302/EM122/EM2040/ME70BO.
+     *  The following formula can be used to convert from the GSF positive biased value to dB:
+     *  dB_value = (GSF_I_value - offset) / scale
+     */
+    stemp = htons((gsfsShort) sdata->gsfEM4ImagerySpecific.scale);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* write the spare bytes */
+    memcpy(p, sdata->gsfEM4ImagerySpecific.spare, 20);
+    p += 20;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+*
+* Function Name : EncodeKMALLImagerySpecific
+*
+* Description : This function encodes the kongsberg kmall compliant sensor
+*  specific imagery information into external byte stream form.
+*
+* Inputs :
+*    sptr = a pointer to an unsigned char buffer to write into
+*    sdata = a pointer to a union of sensor specific imagery data.
+*
+* Returns : This function returns the number of bytes encoded.
+*
+* Error Conditions : none
+*
+********************************************************************/
+
+static int
+EncodeKMALLImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata)
+{
+    unsigned char  *p = sptr;
+
+   /* The next 32 bytes are our spare for later use */
+    memset(p,0,(size_t)64);
+    p += 64;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeKlein5410BssSpecific
+ *
+ * Description : This function encodes the Simrad EM4 series sensor
+ *  specific imagery information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific imagery data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeKlein5410BssImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata)
+{
+    int i;
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+
+    /* First two bytes contain the descriptor for resolution mode. */
+    stemp = htons((gsfuShort) sdata->gsfKlein5410BssImagerySpecific.res_mode);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next two bytes contain the TVG page. */
+    stemp = htons((gsfuShort) sdata->gsfKlein5410BssImagerySpecific.tvg_page);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next 10 bytes contain an array of beam identifiers */
+    for (i = 0; i < 5; i++)
+    {
+        stemp = htons((gsfuShort) sdata->gsfKlein5410BssImagerySpecific.beam_id[i]);
+        memcpy(p, &stemp, 2);
+        p += 2;
+    }
+
+    /* write the spare bytes */
+    memcpy(p, sdata->gsfKlein5410BssImagerySpecific.spare, 4);
+    p += 4;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeReson7100ImagerySpecific
+ *
+ * Description : This function encodes the Reson 7100 series sensor
+ *  specific imagery information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific imagery data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeReson7100ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+
+    stemp = htons ((gsfuShort) sdata->gsfReson7100ImagerySpecific.size);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* write the spare bytes */
+    memcpy(p, sdata->gsfReson7100ImagerySpecific.spare, 64);
+    p += 64;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeReson8100ImagerySpecific
+ *
+ * Description : This function encodes the Reson 8100 series sensor
+ *  specific imagery information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific imagery data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeReson8100ImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata)
+{
+    unsigned char  *p = sptr;
+
+    /* write the spare bytes */
+    memcpy(p, sdata->gsfReson8100ImagerySpecific.spare, 8);
+    p += 8;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeResonTSeriesImagerySpecific
+ *
+ * Description : This function encodes the Reson 7100 series sensor
+ *  specific imagery information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific imagery data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+static int
+EncodeResonTSeriesImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata)
+{
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+
+    stemp = htons ((gsfuShort) sdata->gsfResonTSeriesImagerySpecific.size);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* write the spare bytes */
+    memcpy(p, sdata->gsfResonTSeriesImagerySpecific.spare, 64);
+    p += 64;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : EncodeR2SonicImagerySpecific
+ *
+ * Description : This function encodes the R2Sonic 2020/2022/2024
+ *  sensor specific imagery information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    sdata = a pointer to a union of sensor specific data.
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+static int
+EncodeR2SonicImagerySpecific(unsigned char *sptr, const gsfSensorImagery *sdata)
+{
+    int i;
+    unsigned char  *p = sptr;
+    gsfuShort       stemp;
+    gsfuLong        ltemp;
+    double          dtemp;
+
+    /* The next 12 bytes contains the model number */
+    memcpy (p, (unsigned char *) (sdata->gsfR2SonicImagerySpecific.model_number), 12);
+    p += 12;
+
+    /* The next 12 bytes contains the serial number */
+    memcpy (p, (unsigned char *) (sdata->gsfR2SonicImagerySpecific.serial_number), 12);
+    p += 12;
+
+    /* The next four bytes contains the time in seconds */
+    ltemp = htonl((gsfuLong) sdata->gsfR2SonicImagerySpecific.dg_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the fractional portion of the time in nanoseconds */
+    ltemp = htonl((gsfuLong) sdata->gsfR2SonicImagerySpecific.dg_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the ping number */
+    ltemp = htonl((gsfuLong) sdata->gsfR2SonicImagerySpecific.ping_number);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the ping period * 1,000,000 */
+    dtemp = (sdata->gsfR2SonicImagerySpecific.ping_period * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the sound speed * 100 */
+    dtemp = (sdata->gsfR2SonicImagerySpecific.sound_speed * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the frequency * 1000 */
+    dtemp = (sdata->gsfR2SonicImagerySpecific.frequency * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit source level * 100 */
+    dtemp = (sdata->gsfR2SonicImagerySpecific.tx_power * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit pulse width * 10,000,000.0*/
+    dtemp = (sdata->gsfR2SonicImagerySpecific.tx_pulse_width * 1.0e7) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit beamwidth in the vertical * 1,000,000 */
+    dtemp = (sdata->gsfR2SonicImagerySpecific.tx_beamwidth_vert * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit beamwidth in the horizontal * 1,000,000*/
+    dtemp = (sdata->gsfR2SonicImagerySpecific.tx_beamwidth_horiz * 1.0e6) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit steering in the vertical  * 1,000,000*/
+    dtemp = sdata->gsfR2SonicImagerySpecific.tx_steering_vert * 1.0e6;
+    if (dtemp < 0.0)
+        dtemp -= 0.501;
+    else
+        dtemp += 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the transmit steering in the horizontal  * 1,000,000*/
+    dtemp = sdata->gsfR2SonicImagerySpecific.tx_steering_horiz * 1.0e6;
+    if (dtemp < 0.0)
+        dtemp -= 0.501;
+    else
+        dtemp += 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains misc. transmit info */
+    ltemp = htonl((gsfuLong) sdata->gsfR2SonicImagerySpecific.tx_misc_info);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver bandwidth * 10,000 */
+    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_bandwidth * 1.0e4) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver sample rate * 1000 */
+    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_sample_rate * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver range * 100,000 */
+    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_range * 1.0e5) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver gain * 100 */
+    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_gain * 1.0e2) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver spreading law coefficient * 1000 */
+    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_spreading * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver absorption coefficient * 1000 */
+    dtemp = (sdata->gsfR2SonicImagerySpecific.rx_absorption * 1.0e3) + 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains the receiver mount tilt angle * 1,000,000 */
+    dtemp = sdata->gsfR2SonicImagerySpecific.rx_mount_tilt * 1.0e6;
+    if (dtemp < 0.0)
+        dtemp -= 0.501;
+    else
+        dtemp += 0.501;
+    ltemp = htonl((gsfuLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four bytes contains misc. receiver info */
+    ltemp = htonl((gsfuLong) sdata->gsfR2SonicImagerySpecific.rx_misc_info);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next two bytes are reserved */
+    stemp = htons((gsfuShort) sdata->gsfR2SonicImagerySpecific.reserved);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next two bytes are for the number of beams */
+    stemp = htons((gsfuShort) sdata->gsfR2SonicImagerySpecific.num_beams);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next set of 6x4 (24) bytes contains "more_info" from the SNI0 datagram */
+    for (i=0; i<6; i++)
+    {
+        dtemp = sdata->gsfR2SonicImagerySpecific.more_info[i] * 1.0e6;
+        if (dtemp < 0.0)
+            dtemp -= 0.501;
+        else
+            dtemp += 0.501;
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+    }
+
+    /* write the spare bytes */
+    memcpy(p, sdata->gsfR2SonicImagerySpecific.spare, 32);
+    p += 32;
+
+    return (p - sptr);
+} /* end EncodeR2SonicImagerySpecific() */
+/********************************************************************
+ *
+ * Function Name : EncodeBRBIntensity
+ *
+ * Description : This function encodes the Bathymetric Receive Beam
+ *  time series intensity information into external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write into
+ *    idata = a pointer to the gsfBRBIntensity structure containg
+ *            imagery data
+ *    num_beams = the integer number of beams (number of
+ *                gsfTimeSeriesIntensity structures in the array)
+ *    sensor_id = the sensor specific subrecord id
+ *
+ * Returns :
+ *   This function returns the number of bytes encoded if successful,
+ *   or -1 if an error occurred.
+ *
+ * Error Conditions :
+ *   GSF_MB_PING_RECORD_ENCODE_FAILED
+ *   GSF_RECORD_SIZE_ERROR
+ *
+ ********************************************************************/
+
+static int
+EncodeBRBIntensity(unsigned char *sptr, const gsfBRBIntensity *idata, int num_beams, int sensor_id, int bytes_used)
+{
+    unsigned char  *ptr = sptr;
+    unsigned char  *temp_ptr;
+    gsfuLong        ltemp;
+    gsfuShort       stemp;
+    int             i, j;
+    int             size;
+    int             sensor_size;
+    int             bytes_per_sample;
+    unsigned char   bytes_to_pack[4];
+
+    /* check to make sure the bits per sample value is supported */
+    if ((idata->bits_per_sample != 8) &&
+        (idata->bits_per_sample != 12) &&
+        (idata->bits_per_sample != 16) &&
+        (idata->bits_per_sample != 32))
+    {
+        /* unsupported number of bits per sample, return an error */
+        gsfError = GSF_MB_PING_RECORD_ENCODE_FAILED;
+        return -1;
+    }
+
+    /* Save the current pointer, and leave room for the four byte subrecord identifier. */
+    temp_ptr = ptr;
+    ptr += 4;
+
+    /* write the bits per sample */
+    *ptr = idata->bits_per_sample;
+    ptr += 1;
+
+    /* write the sample applied corrections description */
+    ltemp = htonl(idata->applied_corrections);
+    memcpy(ptr, &ltemp, 4);
+    ptr += 4;
+
+    /* write the spare header bytes */
+    memcpy(ptr, idata->spare, 16);
+    ptr += 16;
+
+    /* write the sensor specifiuc imagery info */
+    switch (sensor_id)
+    {
+        case (GSF_SWATH_BATHY_SUBRECORD_EM2000_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3000_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM1002_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM300_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM120_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3002_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3000D_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3002D_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM121A_SIS_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM2000_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3000_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM1002_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM300_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM120_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3002_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3000D_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM3002D_RAW_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM121A_SIS_RAW_SPECIFIC):
+            sensor_size = EncodeEM3ImagerySpecific(ptr, &idata->sensor_imagery);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_7125_SPECIFIC):
+            sensor_size = EncodeReson7100ImagerySpecific(ptr, &idata->sensor_imagery);
+            break;
+		case (GSF_SWATH_BATHY_SUBRECORD_RESON_TSERIES_SPECIFIC):
+            sensor_size = EncodeResonTSeriesImagerySpecific(ptr, &idata->sensor_imagery);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8101_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8111_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8124_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8125_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8150_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_RESON_8160_SPECIFIC):
+            sensor_size = EncodeReson8100ImagerySpecific(ptr, &idata->sensor_imagery);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_EM122_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM302_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM710_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_EM2040_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_ME70BO_SPECIFIC):
+            sensor_size = EncodeEM4ImagerySpecific(ptr, &idata->sensor_imagery);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_KMALL_SPECIFIC):
+            sensor_size = EncodeKMALLImagerySpecific(ptr,&idata->sensor_imagery);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_KLEIN_5410_BSS_SPECIFIC):
+            sensor_size = EncodeKlein5410BssImagerySpecific(ptr, &idata->sensor_imagery);
+            break;
+
+        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2020_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2022_SPECIFIC):
+        case (GSF_SWATH_BATHY_SUBRECORD_R2SONIC_2024_SPECIFIC):
+            sensor_size = EncodeR2SonicImagerySpecific(ptr, &idata->sensor_imagery);
+            break;
+
+        default:
+            sensor_size = 0;
+            break;
+    }
+    ptr += sensor_size;
+
+    bytes_per_sample = idata->bits_per_sample / 8;
+    for (i = 0; i < num_beams; i++)
+    {
+
+        /* check to see if the GSF_MAX_RECORD_SIZE will get exceeded */
+        if (12 + idata->time_series[i].sample_count * idata->bits_per_sample / 8  + bytes_used + ptr - sptr > GSF_MAX_RECORD_SIZE)
+        {
+            /* the GSF_MAX_RECORD_SIZE would be exceeded. return an error */
+            gsfError = GSF_RECORD_SIZE_ERROR;
+            return -1;
+        }
+
+        stemp = htons ((gsfuShort) idata->time_series[i].sample_count);
+        memcpy(ptr, &stemp, 2);
+        ptr += 2;
+
+        stemp = htons ((gsfuShort) idata->time_series[i].detect_sample);
+        memcpy(ptr, &stemp, 2);
+        ptr += 2;
+
+        /* write the kmall start value */
+        stemp = htons ((gsfuShort) idata->time_series[i].start_range_samples);
+        memcpy(ptr, &stemp, 2);
+        ptr += 2;
+
+        memset(ptr, 0, 6);
+        ptr += 6;
+
+        if (idata->bits_per_sample == 12)
+        {
+            for (j = 0; j < idata->time_series[i].sample_count; j+=2)
+            {
+                /* pack 2 samples into 3 bytes */
+
+                /* pack the first sample */
+                ltemp = htonl ((gsfuLong) idata->time_series[i].samples[j]);
+                memcpy (bytes_to_pack, &ltemp, 4);
+
+                /* Although bytes_to_pack is 4 bytes, we know that bytes 0 and 1 are zero. */
+                /* We want to save the lower bits of byte 2 in the upper bits of ptr[0] (we */
+                /* know the upper bits of byte 2 are zero) */
+                ptr[0] = bytes_to_pack[2] << 4;
+
+                /* We sant to save the upper bits of bytes_to_pack[3] in the lower bits of */
+                /* ptr[0].  The lower bits of bytes_to_pack[3] need to be saved in the upper */
+                /* bits of ptr[1] */
+                ptr[0] |= (bytes_to_pack[3] & 0xf0) >> 4;
+                ptr[1] = bytes_to_pack[3] << 4;
+                if (j+1 < idata->time_series[i].sample_count)
+                {
+                    /* pack the second sample */
+                    ltemp = htonl ((gsfuLong) idata->time_series[i].samples[j+1]);
+                    memcpy (bytes_to_pack, &ltemp, 4);
+                    /* We know the upper bits of bytes_to_pack[2] are 0, so save the lower */
+                    /* bits in the lower bits of ptr[1].  Then save bytes_to_pack[3] in ptr[2] */
+                    ptr[1] |= (bytes_to_pack[2] & 0x0f);
+                    ptr[2] = bytes_to_pack[3];
+                }
+                else
+                {
+                    ptr[2] = 0;
+                }
+                ptr += 3;
+            }
+        }
+        else
+        {
+            for (j=0; j < idata->time_series[i].sample_count; j++)
+            {
+                if (bytes_per_sample == 1)
+                {
+                    *ptr = (unsigned char) idata->time_series[i].samples[j];
+                    ptr++;;
+                }
+                else if (bytes_per_sample == 2)
+                {
+                    stemp = htons ((gsfuShort) idata->time_series[i].samples[j]);
+                    memcpy(ptr, &stemp, 2);
+                    ptr += 2;
+                }
+                else if (bytes_per_sample == 4)
+                {
+                    ltemp = htonl ((gsfuLong) idata->time_series[i].samples[j]);
+                    memcpy(ptr, &ltemp, 4);
+                    ptr += 4;
+                }
+                else
+                {
+                    memcpy (ptr, &idata->time_series[i].samples[j], bytes_per_sample);
+                    ptr += bytes_per_sample;
+                }
+            }
+        }
+    }
+
+    /* subrecord identifier has array id in first byte, and size in the
+    *  remaining three bytes
+    */
+    size = ptr - sptr;
+    ltemp = GSF_SWATH_BATHY_SUBRECORD_INTENSITY_SERIES_ARRAY << 24;
+    ltemp |= size;
+    ltemp = htonl(ltemp);
+    memcpy(temp_ptr, &ltemp, 4);
+
+    return (ptr - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeSoundVelocityProfile
+ *
+ * Description : This function encodes a GSF sound velocity profile
+ *   record from internal form to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to be written to
+ *    svp = a pointer to the gsfSVP structure to read from
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+int
+gsfEncodeSoundVelocityProfile(unsigned char *sptr, gsfSVP * svp)
+{
+    unsigned char  *p = sptr;
+    double          dtemp;
+    gsfuLong        ltemp;
+    int             i;
+
+    /* First four byte integer contains the observation time seconds */
+    ltemp = htonl(svp->observation_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the observation time nanoseconds */
+    ltemp = htonl(svp->observation_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the seconds portion of the time the
+    *  new profile was put into use by the sonar system
+    */
+    ltemp = htonl(svp->application_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the application time nanoseconds */
+    ltemp = htonl(svp->application_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the longitude of profile observation.
+     * Round the scaled quantity to the nearest whole integer.
+     */
+    dtemp = svp->longitude * 1.0e7;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the latitude. Round the scaled
+     * quantity to the nearest whole integer.
+     */
+    dtemp = svp->latitude * 1.0e7;
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the number of points in the profile */
+    ltemp = htonl((gsfuLong) (svp->number_points));
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Now loop to encode the depth/sound speed pairs
+    * Scale both the depth and sound speed by 100
+    */
+    for (i = 0; i < svp->number_points; i++)
+    {
+        /* Next four byte integer contains the depth. Round the scaled
+         * quantity to the nearest whole integer.
+         */
+        dtemp = svp->depth[i] * 100.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+
+        /* Next four byte integer contains the sound_speed. Round the scaled
+         * quantity to the nearest whole integer.
+         */
+        dtemp = svp->sound_speed[i] * 100.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        ltemp = htonl((gsfuLong) dtemp);
+        memcpy(p, &ltemp, 4);
+        p += 4;
+    }
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeProcessingParameters
+ *
+ * Description : This function encodes into external GSF byte stream form
+ *   a record of processing parameters.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write to
+ *    param = a pointer to the gsfProcessingParameters structure to read from
+ *
+ * Returns : This function returns the number of bytes encoded
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+int
+gsfEncodeProcessingParameters(unsigned char *sptr, gsfProcessingParameters * param)
+{
+    unsigned char  *p = sptr;
+    gsfuLong        ltemp;
+    gsfuShort       stemp;
+    int             i;
+
+    /* First four byte integer contains the seconds portion of the time
+    *  application of the new parameters.
+    */
+    ltemp = htonl(param->param_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the application time nanoseconds */
+    ltemp = htonl(param->param_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the number of parameters in this record */
+    stemp = htons(param->number_parameters);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Now loop to encode these parameters */
+    for (i = 0; i < param->number_parameters; i++)
+    {
+        if (param->param[i] != (char *) NULL) 
+        {
+            /* next is the size of the parameter name as a two byte integer */
+            param->param_size[i] = strlen(param->param[i]) + 1;     /* add one to carry null */
+
+            stemp = htons(param->param_size[i]);
+            memcpy(p, &stemp, 2);
+            p += 2;
+            memcpy(p, param->param[i], param->param_size[i]);
+            p += param->param_size[i];
+        }
+    }
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeSensorParameters
+ *
+ * Description : This function encodes into external GSF byte stream form
+ *   a record of sonar parameters.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write to
+ *    param = a pointer to a gsfSensorParameters structure to read from
+ *
+ * Returns : This function returns the number of bytes encoded
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+int
+gsfEncodeSensorParameters(unsigned char *sptr, gsfSensorParameters * param)
+{
+    unsigned char  *p = sptr;
+    gsfuLong        ltemp;
+    gsfuShort       stemp;
+    int             i;
+
+    /* First four byte integer contains the seconds portion of the time
+    *  application of the new parameters.
+    */
+    ltemp = htonl(param->param_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the application time nanoseconds */
+    ltemp = htonl(param->param_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the number of parameters in this record */
+    stemp = htons(param->number_parameters);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Now loop to encode these parameters */
+    for (i = 0; i < param->number_parameters; i++)
+    {
+        if (param->param[i] != (char *) NULL) 
+        {
+            /* next is the size of the parameter name as a two byte integer */
+            param->param_size[i] = strlen(param->param[i]) + 1;     /* add one to carry null */
+
+            stemp = htons(param->param_size[i]);
+            memcpy(p, &stemp, 2);
+            p += 2;
+            memcpy(p, param->param[i], param->param_size[i]);
+            p += param->param_size[i];
+        }
+    }
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeComment
+ *
+ * Description : This function is used to encode a gsfComment record
+ *  from internal to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to be written to
+ *    comment = a pointer to the gsfComment structure to read from
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+int
+gsfEncodeComment(unsigned char *sptr, gsfComment * comment)
+{
+    unsigned char  *p = sptr;
+    gsfuLong        ltemp;
+
+    /* First four byte integer contains the seconds portion of the time
+    *  the operator comment was made.
+    */
+    ltemp = htonl(comment->comment_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the nanoseconds portion of the
+    * comment time
+    */
+    ltemp = htonl(comment->comment_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the length of the comment */
+    ltemp = htonl(comment->comment_length);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next "length" bytes contain the operator comment */
+    memcpy(p, comment->comment, comment->comment_length);
+    p += comment->comment_length;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeHistory
+ *
+ * Description : This function encodes a GSF history record from internal
+ *   to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write to
+ *    history = a pointer to a gsfHistory structure to read from
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+int
+gsfEncodeHistory(unsigned char *sptr, gsfHistory * history)
+{
+    unsigned char  *p = sptr;
+    int             len;
+    gsfuLong        ltemp;
+    gsfuShort       stemp;
+
+    /* First four byte integer contains the seconds portion of the time
+    *  the history record was added to the data.
+    */
+    ltemp = htonl(history->history_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the nanoseconds portion of the
+    * history time.
+    */
+    ltemp = htonl(history->history_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next 2 bytes contains the size of the machines host name */
+    len = strlen(history->host_name) + 1;
+    stemp = htons(len);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next "len" bytes contains the host name of the machine used to process the data */
+    memcpy(p, history->host_name, len);
+    p += len;
+
+    /* Next two byte integer contains the size of the of operator field  */
+    len = strlen(history->operator_name) + 1;
+    stemp = htons(len);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next "len" bytes contains the name of the operator who processed this data */
+    memcpy(p, history->operator_name, len);
+    p += len;
+
+    /* Next two byte integer contains the size of the command line field */
+    if (history->command_line == (char *) NULL)
+    {
+        history->command_line = "";
+    }
+    len = strlen(history->command_line) + 1;
+    stemp = htons(len);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next "len" bytes contains the command line used to run the processing program */
+    memcpy(p, history->command_line, len);
+    p += len;
+
+    /* Next two byte integer contains the size of the history record comment */
+    if (history->comment == (char *) NULL)
+    {
+        history->comment = "";
+    }
+    len = strlen(history->comment);
+    stemp = htons(len);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* Next "len" bytes contains the comment for this history record */
+    memcpy(p, history->comment, len);
+    p += len;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeNavigationError
+ *
+ * Description : This function encodes a navigation error record from
+ *  internal to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write to
+ *    nav_error = a pointer to a gsfNavigationError structure to read from
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+int
+gsfEncodeNavigationError(unsigned char *sptr, gsfNavigationError * nav_error)
+{
+    unsigned char  *p = sptr;
+    gsfuLong        ltemp;
+
+    /* First four byte integer contains the seconds portion of the time
+    *  of navigation error.
+    */
+    ltemp = htonl(nav_error->nav_error_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the nanoseconds portion of the
+    * history time.
+    */
+    ltemp = htonl(nav_error->nav_error_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the record id for the record
+    *  containing a position with this error. (registry and type number)
+    */
+    ltemp = htonl(nav_error->record_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the longitude error estimate */
+    ltemp = htonl((gsfuLong) (nav_error->longitude_error * 10.0 + 0.501));
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the latitude error estimate */
+    ltemp = htonl((gsfuLong) (nav_error->latitude_error * 10.0 + 0.501));
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeHVNavigationError
+ *
+ * Description : This function encodes the new horizontal and vertical
+ *  navigation error record.
+ *
+ * Inputs :
+ *   sptr = a pointer to an unsigned char buffer to write to
+ *   hv_nav_error = a pointer to a gsfHVNavigationError structure to read from
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+int
+gsfEncodeHVNavigationError(unsigned char *sptr, gsfHVNavigationError *hv_nav_error)
+{
+    double          dtemp;
+    unsigned char  *p = sptr;
+    int             length;
+    gsfsLong        ltemp;
+    gsfsShort       stemp;
+    gsfuShort       utemp;
+
+    /* First four byte integer contains the seconds portion of the time
+    *  of navigation error.
+    */
+    ltemp = htonl(hv_nav_error->nav_error_time.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four byte integer contains the nanoseconds portion of the
+    * history time.
+    */
+    ltemp = htonl(hv_nav_error->nav_error_time.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four byte integer contains the record id for the record
+    *  containing a position with this error. (registry and type number)
+    */
+    ltemp = htonl(hv_nav_error->record_id);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four byte integer contains the horizontal error estimate */
+    dtemp = (hv_nav_error->horizontal_error * 1000.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.501;
+    }
+    else
+    {
+        dtemp += 0.501;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next four byte integer contains the vertical error estimate */
+    dtemp = (hv_nav_error->vertical_error * 1000.0);
+    if (dtemp < 0.0)
+    {
+        dtemp -= 0.5;
+    }
+    else
+    {
+        dtemp += 0.5;
+    }
+    ltemp = htonl((gsfsLong) dtemp);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* The next two bytes contains the SEP uncertainty estimate.
+     * This value is always >= 0.0, so rounding is a simple addition
+     */
+    dtemp = (hv_nav_error->SEP_uncertainty * 100.0);
+    dtemp += 0.501;
+    utemp = htons((gsfuShort) dtemp);
+    memcpy(p, &utemp, 2);
+    p += 2;
+
+    /* The next two bytes are reserved for future use */
+    *p = (unsigned char) (hv_nav_error->spare[0]);
+    p += 1;
+    *p = (unsigned char) (hv_nav_error->spare[1]);
+    p += 1;
+
+    /* The next two byte integer contains the length of the positioning system type string */
+    if (hv_nav_error->position_type == (char *) NULL)
+    {
+        length = 0;
+    }
+    else
+    {
+        length = strlen(hv_nav_error->position_type);
+    }
+    stemp = htons(length);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    /* The next length bytes contains the positioning system type string. */
+    if (hv_nav_error->position_type == (char *) NULL)
+    {
+        /* Put a null character down only if there is no string to record */
+        *p = '\0';
+        p += 1;
+    }
+    else
+    {
+        memcpy(p, hv_nav_error->position_type, length);
+        p += length;
+    }
+
+    return (p - sptr);
+}
+/********************************************************************
+ *
+ * Function Name : LocalSubtractTimes
+ *
+ * Description : Subtract two times given in a timespec structure
+ *   and return the result expressed as a double.
+ *
+ * Inputs :
+ *   base_time = The first time given in a timespec struct.
+ *   subtrahend = The second time given in a timespec struct.
+ *	 difference = The difference returned to the calling program
+ *
+ * Returns : none.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+static void LocalSubtractTimes (const struct timespec *base_time, const struct timespec *subtrahend, double *difference)
+{
+    double fraction = 0.0;
+    double seconds  = 0.0;
+
+    seconds  = difftime(base_time->tv_sec, subtrahend->tv_sec);
+    fraction = ((double)(base_time->tv_nsec - subtrahend->tv_nsec))/1.0e9;
+
+    *difference = seconds + fraction;
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfEncodeAttitude
+ *
+ * Description : This function encodes a GSF attitude record from internal
+ *  to external byte stream form.
+ *
+ * Inputs :
+ *    sptr = a pointer to an unsigned char buffer to write to
+ *    attitude = a pointer to a gsfAttitude structure to read from
+ *
+ * Returns : This function returns the number of bytes encoded.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+
+int
+gsfEncodeAttitude(unsigned char *sptr, gsfAttitude * attitude)
+{
+    unsigned char  *p = sptr;
+    gsfuLong        ltemp;
+    gsfuShort       stemp;
+    double          dtemp;
+    int             i;
+    struct timespec basetime;
+    double          time_offset;
+
+    /* write the full time for the first time in the record, and save subsequent times
+     *  as an offset from this basetime
+     */
+    basetime = attitude->attitude_time[0];
+
+    /* First four byte integer contains the seconds portion of the base
+     *  time for the attitude record
+     */
+    ltemp = htonl(basetime.tv_sec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next four byte integer contains the nanoseconds portion of the
+    * attitude base time.
+    */
+    ltemp = htonl(basetime.tv_nsec);
+    memcpy(p, &ltemp, 4);
+    p += 4;
+
+    /* Next two byte integer contains the number of measurements */
+    stemp = htons(attitude->num_measurements);
+    memcpy(p, &stemp, 2);
+    p += 2;
+
+    for (i = 0; i < attitude->num_measurements; i++)
+    {
+        /* Next two byte integer contains the time offset from basetime for this
+         * measurement. Round the scaled quantity to the nearest whole integer.
+         */
+        LocalSubtractTimes (&attitude->attitude_time[i], &basetime, &time_offset);
+        stemp = htons((gsfuShort) (time_offset * 1000.0 + 0.501));
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* Next two byte integer contains the pitch. Round the scaled quantity
+         * to the nearest whole integer.
+         */
+        dtemp = attitude->pitch[i] * 100.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        stemp = htons((gsfsShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* Next two byte integer contains the roll. Round the scaled quantity
+         * to the nearest whole integer.
+         */
+        dtemp = attitude->roll[i] * 100.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        stemp = htons((gsfsShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* Next two byte integer contains the heave. Round the scaled quantity
+         * to the nearest whole integer.
+         */
+        dtemp = attitude->heave[i] * 100.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        stemp = htons((gsfsShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+
+        /* Next two byte integer contains the heading. Round the scaled quantity
+         * to the nearest whole integer.
+         */
+        dtemp = attitude->heading[i] * 100.0;
+        if (dtemp < 0.0)
+        {
+            dtemp -= 0.501;
+        }
+        else
+        {
+            dtemp += 0.501;
+        }
+        stemp = htons((gsfuShort) dtemp);
+        memcpy(p, &stemp, 2);
+        p += 2;
+    }
+
+    return (p - sptr);
+}
+
+/********************************************************************
+ *
+ * Function Name : gsfSetDefaultScaleFactor
+ *
+ * Description : This function is used to estimate and set scale
+ *               factors for a ping record
+ *
+ * Inputs :
+ *    mb_ping - a pointer to a ping record.  The scale factors
+ *              will be set in this record.
+ *
+ * Returns : This function returns 0.
+ *
+ * Error Conditions : none
+ *
+ ********************************************************************/
+int gsfSetDefaultScaleFactor(gsfSwathBathyPing *mb_ping)
+{
+    const double GSF_DEPTH_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_ACROSS_TRACK_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_ALONG_TRACK_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_TRAVEL_TIME_ASSUMED_HIGHEST_PRECISION = 10e6;
+    const double GSF_BEAM_ANGLE_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_MEAN_CAL_AMPLITUDE_ASSUMED_HIGHEST_PRECISION = 10;
+    const double GSF_MEAN_REL_AMPLITUDE_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_ECHO_WIDTH_ASSUMED_HIGHEST_PRECISION = 10e5;
+    const double GSF_QUALITY_FACTOR_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_RECEIVE_HEAVE_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_DEPTH_ERROR_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_ACROSS_TRACK_ERROR_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_ALONG_TRACK_ERROR_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_NOMINAL_DEPTH_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_QUALITY_FLAGS_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_BEAM_FLAGS_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_SIGNAL_TO_NOISE_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_BEAM_ANGLE_FORWARD_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_TVG_dB_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_VERTICAL_ERROR_ASSUMED_HIGHEST_PRECISION = 200;
+    const double GSF_HORIZONTAL_ERROR_ASSUMED_HIGHEST_PRECISION = 200;
+    const double GSF_SECTOR_NUMBER_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_DETECTION_INFO_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_INCIDENT_BEAM_ADJ_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_SYSTEM_CLEANING_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_DOPPLER_CORRECTION_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_SONAR_VERT_UNCERT_ASSUMED_HIGHEST_PRECISION = 100;
+    const double GSF_MEAN_ABS_COEFF_ASSUMED_HIGHEST_PRECISION = 100;
+
+    int             i, j; /* iterators */
+    double          *dptr; /* pointer to ping array */
+    unsigned short  *usptr; /* pointer to ping array */
+    unsigned char   *ucptr; /* pointer to ping array */
+    int             id; /* type of ping array subrecord */
+    double          max, min; /* min and max value of each ping array */
+    double          max_scale_factor, min_scale_factor; /* min and max allowable size of values in ping array */
+    double          highest_precision; /* starting value for multiplier */
+
+    for (i = 1; i <= GSF_MAX_PING_ARRAY_SUBRECORDS; i++)
+    {
+        dptr = NULL;
+        usptr = NULL;
+
+        switch (i)
+        {
+            case GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY:
+                dptr = mb_ping->depth;
+                highest_precision = GSF_DEPTH_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_DEPTH_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY:
+                dptr = mb_ping->across_track;
+                highest_precision = GSF_ACROSS_TRACK_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ARRAY;
+                max_scale_factor = SHRT_MAX;
+                min_scale_factor = SHRT_MIN;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY:
+                dptr = mb_ping->along_track;
+                highest_precision = GSF_ALONG_TRACK_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ARRAY;
+                max_scale_factor = SHRT_MAX;
+                min_scale_factor = SHRT_MIN;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY:
+                dptr = mb_ping->travel_time;
+                highest_precision = GSF_TRAVEL_TIME_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_TRAVEL_TIME_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_ARRAY:
+                dptr = mb_ping->beam_angle;
+                highest_precision = GSF_BEAM_ANGLE_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_ARRAY;
+                max_scale_factor = SHRT_MAX;
+                min_scale_factor = SHRT_MIN;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY:
+                dptr = mb_ping->mc_amplitude;
+                highest_precision = GSF_MEAN_CAL_AMPLITUDE_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_MEAN_CAL_AMPLITUDE_ARRAY;
+                max_scale_factor = SCHAR_MAX;
+                min_scale_factor = SCHAR_MIN;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY:
+                dptr = mb_ping->mr_amplitude;
+                highest_precision = GSF_MEAN_REL_AMPLITUDE_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_MEAN_REL_AMPLITUDE_ARRAY;
+                max_scale_factor = UCHAR_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY:
+                dptr = mb_ping->echo_width;
+                highest_precision = GSF_ECHO_WIDTH_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_ECHO_WIDTH_ARRAY;
+                max_scale_factor = UCHAR_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_QUALITY_FACTOR_ARRAY:
+                dptr = mb_ping->quality_factor;
+                highest_precision = GSF_QUALITY_FACTOR_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_QUALITY_FACTOR_ARRAY;
+                max_scale_factor = UCHAR_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_RECEIVE_HEAVE_ARRAY:
+                dptr = mb_ping->receive_heave;
+                highest_precision = GSF_RECEIVE_HEAVE_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_RECEIVE_HEAVE_ARRAY;
+                max_scale_factor = UCHAR_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_DEPTH_ERROR_ARRAY:
+                dptr = mb_ping->depth_error;
+                highest_precision = GSF_DEPTH_ERROR_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_DEPTH_ERROR_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ERROR_ARRAY:
+                dptr = mb_ping->across_track_error;
+                highest_precision = GSF_ACROSS_TRACK_ERROR_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_ACROSS_TRACK_ERROR_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ERROR_ARRAY:
+                dptr = mb_ping->along_track_error;
+                highest_precision = GSF_ALONG_TRACK_ERROR_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_ALONG_TRACK_ERROR_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY:
+                dptr = mb_ping->nominal_depth;
+                highest_precision = GSF_NOMINAL_DEPTH_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_NOMINAL_DEPTH_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_QUALITY_FLAGS_ARRAY:
+                ucptr = mb_ping->quality_flags;
+                highest_precision = GSF_QUALITY_FLAGS_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_QUALITY_FLAGS_ARRAY;
+                max_scale_factor = UCHAR_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_BEAM_FLAGS_ARRAY:
+                ucptr = mb_ping->beam_flags;
+                highest_precision = GSF_BEAM_FLAGS_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_BEAM_FLAGS_ARRAY;
+                max_scale_factor = UCHAR_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_SIGNAL_TO_NOISE_ARRAY:
+                dptr = mb_ping->signal_to_noise;
+                highest_precision = GSF_SIGNAL_TO_NOISE_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_SIGNAL_TO_NOISE_ARRAY;
+                max_scale_factor = UCHAR_MAX;
+                min_scale_factor = 0;
+                break;
+           case GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_FORWARD_ARRAY:
+                dptr = mb_ping->beam_angle_forward;
+                highest_precision = GSF_BEAM_ANGLE_FORWARD_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_BEAM_ANGLE_FORWARD_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY:
+                dptr = mb_ping->TVG_dB;
+                highest_precision = GSF_TVG_dB_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_TVG_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_VERTICAL_ERROR_ARRAY:
+                dptr = mb_ping->vertical_error;
+                highest_precision = GSF_VERTICAL_ERROR_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_VERTICAL_ERROR_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_HORIZONTAL_ERROR_ARRAY:
+                dptr = mb_ping->horizontal_error;
+                highest_precision = GSF_HORIZONTAL_ERROR_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_HORIZONTAL_ERROR_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_SECTOR_NUMBER_ARRAY:
+                usptr = mb_ping->sector_number;
+                highest_precision = GSF_SECTOR_NUMBER_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_SECTOR_NUMBER_ARRAY;
+                max_scale_factor = UCHAR_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_DETECTION_INFO_ARRAY:
+                usptr = mb_ping->detection_info;
+                highest_precision = GSF_DETECTION_INFO_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_DETECTION_INFO_ARRAY;
+                max_scale_factor = UCHAR_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_INCIDENT_BEAM_ADJ_ARRAY:
+                dptr = mb_ping->incident_beam_adj;
+                highest_precision = GSF_INCIDENT_BEAM_ADJ_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_INCIDENT_BEAM_ADJ_ARRAY;
+                max_scale_factor = SCHAR_MAX;
+                min_scale_factor = SCHAR_MIN;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_SYSTEM_CLEANING_ARRAY:
+                usptr = mb_ping->system_cleaning;
+                highest_precision = GSF_SYSTEM_CLEANING_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_SYSTEM_CLEANING_ARRAY;
+                max_scale_factor = UCHAR_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_DOPPLER_CORRECTION_ARRAY:
+                dptr = mb_ping->doppler_corr;
+                highest_precision = GSF_DOPPLER_CORRECTION_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_DOPPLER_CORRECTION_ARRAY;
+                max_scale_factor = SCHAR_MAX;
+                min_scale_factor = SCHAR_MIN;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_SONAR_VERT_UNCERT_ARRAY:
+                dptr = mb_ping->sonar_vert_uncert;
+                highest_precision = GSF_SONAR_VERT_UNCERT_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_SONAR_VERT_UNCERT_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+            case GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY:
+                dptr = mb_ping->mean_abs_coeff;
+                highest_precision = GSF_MEAN_ABS_COEFF_ASSUMED_HIGHEST_PRECISION;
+                id = GSF_SWATH_BATHY_SUBRECORD_MEAN_ABS_COEF_ARRAY;
+                max_scale_factor = USHRT_MAX;
+                min_scale_factor = 0;
+                break;
+        }
+
+        if (dptr != NULL || usptr != NULL)
+        {
+            max = DBL_MIN;
+            min = DBL_MAX;
+
+            if (dptr != NULL)
+            {
+                for (j = 0; j < mb_ping->number_beams; j++)
+                {
+                    if (dptr[j] > max)
+                        max = dptr[j];
+                    if (dptr[j] < min)
+                        min = dptr[j];
+                }
+            }
+            else if (usptr != NULL)
+            {
+                for (j = 0; j < mb_ping->number_beams; j++)
+                {
+                    if (usptr[j] > max)
+                        max = (double) usptr[j];
+                    if (usptr[j] < min)
+                        min = (double) usptr[j];
+                }
+            }
+            else if (ucptr != NULL)
+            {
+                for (j = 0; j < mb_ping->number_beams; j++)
+                {
+                    if (ucptr[j] > max)
+                        max = (double) ucptr[j];
+                    if (ucptr[j] < min)
+                        min = (double) ucptr[j];
+                }
+            }
+
+            mb_ping->scaleFactors.scaleTable[id - 1].offset = 0;
+            mb_ping->scaleFactors.scaleTable[id - 1].multiplier = highest_precision;
+            /* Clear the high order 4 bits of the compression flag field */
+            mb_ping->scaleFactors.scaleTable[id - 1].compressionFlag &= 0x0F;
+            /* set these bits to specify the default field size */
+            mb_ping->scaleFactors.scaleTable[id - 1].compressionFlag |= GSF_FIELD_SIZE_DEFAULT;
+
+            /* apply the multiplier and offset to the maximum value, if
+             * the new value is greater then the max scale factor multiplier
+             * size, decrease the multiplier by 2 until this condition is no
+             * longer violated. */
+            while (((( max + mb_ping->scaleFactors.scaleTable[id - 1].offset) * mb_ping->scaleFactors.scaleTable[id - 1].multiplier) > max_scale_factor)
+                    || ((( min + mb_ping->scaleFactors.scaleTable[id - 1].offset) * mb_ping->scaleFactors.scaleTable[id - 1].multiplier) < min_scale_factor ))
+            {
+                mb_ping->scaleFactors.scaleTable[id - 1].multiplier = (int) ( mb_ping->scaleFactors.scaleTable[id - 1].multiplier / 2.0 );
+            }
+
+            if (mb_ping->scaleFactors.scaleTable[id - 1].multiplier < 1.0)
+            {
+                mb_ping->scaleFactors.scaleTable[id - 1].multiplier = 1.0;
+            }
+        }
+    }
+
+    return 0;
+}

--- a/src/gsf/gsf_indx.c
+++ b/src/gsf/gsf_indx.c
@@ -94,10 +94,17 @@
 #if defined(OS2) || defined(WIN32) || defined(WIN64)
     #include <process.h>
     #if defined (__MINGW32__) || defined (__MINGW64__)
+        #ifdef _WIN32
+        #include "unistd_w.h"
+        #else
         #include <unistd.h>
+        #endif
     #endif
     #if defined (__BORLANDC__)
         #define _getpid getpid
+    #endif
+    #ifdef _WIN32
+    #include "unistd_w.h"
     #endif
 #else
     #include <unistd.h>

--- a/src/htmlsrc/man2html.c
+++ b/src/htmlsrc/man2html.c
@@ -149,11 +149,16 @@
 /* #include <errno.h> */
 #ifndef LESSTIF
 #include <sys/types.h>
-#include <sys/time.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include "dirent_w.h"
+#include "unistd_w.h"
+#else
+#include <sys/time.h>
 #include <dirent.h>
-#include <errno.h>
 #include <unistd.h>
+#endif
+#include <errno.h>
 #endif
 
 #ifdef  WITH_DMALLOC

--- a/src/mbaux/mb_readwritegrd.c
+++ b/src/mbaux/mb_readwritegrd.c
@@ -34,7 +34,11 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 
 /* include GMT header file gmt_dev.h without including glib headers not needed by MB-System */
 #ifdef HAVE_GLIB_GTHREAD

--- a/src/mbaux/mb_xdr_win32.c
+++ b/src/mbaux/mb_xdr_win32.c
@@ -45,6 +45,12 @@
 
 #define BYTES_PER_XDR_UNIT 4
 
+/* Rename to avoid colliding with winsock2.h's __declspec(dllimport) ntohl/htonl
+   (real ones take u_long, these take long — mb_define.h now force-includes
+   winsock2.h everywhere, so the names collide). */
+#define ntohl xdr_local_ntohl
+#define htonl xdr_local_htonl
+
 static long ntohl(long val) {
  u_long ret,uval;
 

--- a/src/mbgrd2gltf/main.cpp
+++ b/src/mbgrd2gltf/main.cpp
@@ -36,7 +36,9 @@
 #include <typeinfo>
 #include <stdexcept>
 #include <cstdlib>
-#ifndef _WIN32
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
 #endif
 #include <limits.h>

--- a/src/mbio/CMakeLists.txt
+++ b/src/mbio/CMakeLists.txt
@@ -217,10 +217,17 @@ target_include_directories(mbio PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 if(buildGSF)
   target_link_libraries(mbio PRIVATE mbgsf)
 endif()
-target_link_libraries(
-  mbio
-  PRIVATE NetCDF::NetCDF mbbitpack mbbsio mbsapi LibPROJ::LibPROJ
-  PUBLIC TIRPC::TIRPC m)
+if(WIN32)
+  target_link_libraries(
+    mbio
+    PRIVATE NetCDF::NetCDF mbbitpack mbbsio mbsapi LibPROJ::LibPROJ
+    PUBLIC TIRPC::TIRPC)  # libm is built into MSVC CRT
+else()
+  target_link_libraries(
+    mbio
+    PRIVATE NetCDF::NetCDF mbbitpack mbbsio mbsapi LibPROJ::LibPROJ
+    PUBLIC TIRPC::TIRPC m)
+endif()
 if(WIN32)
   target_link_libraries(mbio PRIVATE mb_xdr_win32)
 endif()

--- a/src/mbio/dirent_w.h
+++ b/src/mbio/dirent_w.h
@@ -1,0 +1,78 @@
+/*--------------------------------------------------------------------
+ *    The MB-system:  dirent_w.h
+ *
+ *    Minimal Windows / MSVC substitute for POSIX <dirent.h> — just the
+ *    opendir / readdir / closedir subset MB-System utilities use, on top of
+ *    the Win32 FindFirstFile API. Selected like unistd_w.h:
+ *
+ *        #ifdef _WIN32
+ *        #include "dirent_w.h"
+ *        #else
+ *        #include <dirent.h>
+ *        #endif
+ *--------------------------------------------------------------------*/
+#ifndef DIRENT_W_H
+#define DIRENT_W_H
+
+#if defined(_WIN32)
+
+#include <windows.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#ifndef NAME_MAX
+#define NAME_MAX 260
+#endif
+
+struct dirent {
+    char d_name[NAME_MAX + 1];
+};
+
+typedef struct {
+    HANDLE           h;
+    WIN32_FIND_DATAA fd;
+    int              first;
+    struct dirent    de;
+} DIR;
+
+static __inline DIR *opendir(const char *path)
+{
+    if (!path || !*path) { errno = ENOENT; return NULL; }
+    size_t n = strlen(path);
+    char *pat = (char *)malloc(n + 3);
+    if (!pat) { errno = ENOMEM; return NULL; }
+    memcpy(pat, path, n);
+    /* append "\*" (or "*" if the path already ends in a separator) */
+    if (n && (path[n - 1] == '/' || path[n - 1] == '\\')) { pat[n] = '*'; pat[n + 1] = '\0'; }
+    else { pat[n] = '\\'; pat[n + 1] = '*'; pat[n + 2] = '\0'; }
+    DIR *d = (DIR *)calloc(1, sizeof(DIR));
+    if (!d) { free(pat); errno = ENOMEM; return NULL; }
+    d->h = FindFirstFileA(pat, &d->fd);
+    free(pat);
+    if (d->h == INVALID_HANDLE_VALUE) { free(d); errno = ENOENT; return NULL; }
+    d->first = 1;
+    return d;
+}
+
+static __inline struct dirent *readdir(DIR *d)
+{
+    if (!d) return NULL;
+    if (d->first) d->first = 0;
+    else if (!FindNextFileA(d->h, &d->fd)) return NULL;
+    strncpy(d->de.d_name, d->fd.cFileName, NAME_MAX);
+    d->de.d_name[NAME_MAX] = '\0';
+    return &d->de;
+}
+
+static __inline int closedir(DIR *d)
+{
+    if (!d) return -1;
+    if (d->h != INVALID_HANDLE_VALUE) FindClose(d->h);
+    free(d);
+    return 0;
+}
+
+#endif /* _WIN32 */
+
+#endif /* DIRENT_W_H */

--- a/src/mbio/mb_access.c
+++ b/src/mbio/mb_access.c
@@ -34,7 +34,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 
 #include "mb_define.h"
 #include "mb_format.h"

--- a/src/mbio/mb_define.h
+++ b/src/mbio/mb_define.h
@@ -43,6 +43,9 @@
 #ifdef CMAKE_BUILD_SYSTEM
 
 #ifdef _WIN32
+  /* struct timeval, sockets — MUST precede windows.h on MSVC */
+#  include <winsock2.h>
+#  include <windows.h>
   /* Windows lacks SunRPC/TIRPC, so use the mb_xdr_win32 replacement */
 #  include <mb_xdr_win32.h>
 #else

--- a/src/mbio/mb_esf.c
+++ b/src/mbio/mb_esf.c
@@ -37,7 +37,11 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <time.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 
 #include "mb_define.h"
 #include "mb_process.h"

--- a/src/mbio/mb_format.c
+++ b/src/mbio/mb_format.c
@@ -35,9 +35,19 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 
 #include "mb_define.h"
+
+/* POSIX strtok_r — MSVC has strtok_s with the same signature. */
+#ifdef _WIN32
+#define strtok_r(str, delim, saveptr) strtok_s((str), (delim), (saveptr))
+#endif
+
 #include "mb_format.h"
 #include "mb_io.h"
 #include "mb_process.h"

--- a/src/mbio/mb_get_value.c
+++ b/src/mbio/mb_get_value.c
@@ -37,6 +37,12 @@
 #include <string.h>
 
 #include "mb_define.h"
+
+/* POSIX strtok_r — MSVC has strtok_s with the same signature. */
+#ifdef _WIN32
+#define strtok_r(str, delim, saveptr) strtok_s((str), (delim), (saveptr))
+#endif
+
 #include "mb_status.h"
 #include "mb_swap.h"
 

--- a/src/mbio/mb_io.h
+++ b/src/mbio/mb_io.h
@@ -137,9 +137,23 @@ const char *mb_platform_type(mb_platform_enum platform);
 #define MB_SENSOR_TYPE_PRESSURE 111
 #define MB_SENSOR_TYPE_SOUNDSPEED 120
 
-/* These arrays are defined in mb_platform.c and extern elsewhere */
+/* These arrays are defined in mb_platform.c and extern elsewhere.
+   CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS only auto-exports functions, not data;
+   these need an explicit dllexport/dllimport to cross the mbio.dll boundary. */
+#if defined(_WIN32) && defined(mbio_EXPORTS)
+#define MB_SENSOR_TYPE_API __declspec(dllexport)
+#elif defined(_WIN32)
+#define MB_SENSOR_TYPE_API __declspec(dllimport)
+#else
+#define MB_SENSOR_TYPE_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef MB_NEED_SENSOR_TYPE
-const int mb_sensor_type_id[] = {
+MB_SENSOR_TYPE_API const int mb_sensor_type_id[] = {
     MB_SENSOR_TYPE_NONE,                    // 0
     MB_SENSOR_TYPE_SONAR_ECHOSOUNDER,       // 10
     MB_SENSOR_TYPE_SONAR_MULTIECHOSOUNDER,  // 11
@@ -163,7 +177,7 @@ const int mb_sensor_type_id[] = {
     MB_SENSOR_TYPE_PRESSURE,                // 111
     MB_SENSOR_TYPE_SOUNDSPEED,              // 120
 };
-const char *mb_sensor_type_string[] = {"Unknown sensor type",
+MB_SENSOR_TYPE_API const char *mb_sensor_type_string[] = {"Unknown sensor type",
                                         "Sonar echosounder",
                                         "Sonar multiechosounder",
                                         "Sonar sidescan",
@@ -186,9 +200,13 @@ const char *mb_sensor_type_string[] = {"Unknown sensor type",
                                         "Pressure",
                                         "Soundspeed"};
 #else
-extern const int mb_sensor_type_id[];
-extern const char *mb_sensor_type_string[];
+MB_SENSOR_TYPE_API extern const int mb_sensor_type_id[];
+MB_SENSOR_TYPE_API extern const char *mb_sensor_type_string[];
 #endif  // MB_NEED_SENSOR_TYPE
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
 
 /* survey platform sensor capability bitmask defines */
 #define MB_SENSOR_CAPABILITY1_NONE 0x00000000          // All bits = 0

--- a/src/mbio/mb_navint.c
+++ b/src/mbio/mb_navint.c
@@ -40,6 +40,13 @@
 #include "mb_process.h"
 #include "mb_status.h"
 
+/* MSVC has no off_t/fseeko/ftello; use the native 64-bit file APIs instead. */
+#ifdef _WIN32
+typedef __int64 off_t;
+#define ftello _ftelli64
+#define fseeko(fp, off, whence) _fseeki64((fp), (off), (whence))
+#endif
+
 //    #define MB_NAVINT_DEBUG 1
 //    #define MB_ATTINT_DEBUG 1
 //    #define MB_HEDINT_DEBUG 1

--- a/src/mbio/mb_platform.c
+++ b/src/mbio/mb_platform.c
@@ -37,7 +37,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 
 #include "mb_define.h"
 #include "mb_format.h"

--- a/src/mbio/mb_platform_math.c
+++ b/src/mbio/mb_platform_math.c
@@ -34,7 +34,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 
 #include <mb_define.h>
 #include <mb_status.h>

--- a/src/mbio/mb_process.c
+++ b/src/mbio/mb_process.c
@@ -39,7 +39,11 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <time.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 
 #include "mb_define.h"
 #include "mb_format.h"

--- a/src/mbio/mb_proj.c
+++ b/src/mbio/mb_proj.c
@@ -50,7 +50,11 @@
 #include <math.h>
 #include <stdio.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 #include <string.h>
 
 #include "mb_define.h"

--- a/src/mbio/mbr_edgjstar.c
+++ b/src/mbio/mbr_edgjstar.c
@@ -44,6 +44,12 @@
 #include <string.h>
 
 #include "mb_define.h"
+
+/* POSIX strtok_r — MSVC has strtok_s with the same signature. */
+#ifdef _WIN32
+#define strtok_r(str, delim, saveptr) strtok_s((str), (delim), (saveptr))
+#endif
+
 #include "mb_format.h"
 #include "mb_io.h"
 #include "mb_status.h"

--- a/src/mbio/mbr_hypc8101.c
+++ b/src/mbio/mbr_hypc8101.c
@@ -39,6 +39,12 @@
 #include <string.h>
 
 #include "mb_define.h"
+
+/* POSIX strtok_r — MSVC has strtok_s with the same signature. */
+#ifdef _WIN32
+#define strtok_r(str, delim, saveptr) strtok_s((str), (delim), (saveptr))
+#endif
+
 #include "mb_format.h"
 #include "mb_io.h"
 #include "mb_status.h"

--- a/src/mbio/mbr_hysweep1.c
+++ b/src/mbio/mbr_hysweep1.c
@@ -43,6 +43,12 @@
 #include <string.h>
 
 #include "mb_define.h"
+
+/* POSIX strtok_r — MSVC has strtok_s with the same signature. */
+#ifdef _WIN32
+#define strtok_r(str, delim, saveptr) strtok_s((str), (delim), (saveptr))
+#endif
+
 #include "mb_format.h"
 #include "mb_io.h"
 #include "mb_status.h"

--- a/src/mbio/unistd_w.h
+++ b/src/mbio/unistd_w.h
@@ -1,0 +1,37 @@
+/*--------------------------------------------------------------------
+ *    The MB-system:  unistd_w.h
+ *
+ *    Windows / MSVC substitute for POSIX <unistd.h>. MSVC ships no
+ *    <unistd.h>; this provides the small subset MB-System sources rely on.
+ *    Selected at each call site:
+ *
+ *        #ifdef _WIN32
+ *        #include "unistd_w.h"
+ *        #else
+ *        #include <unistd.h>
+ *        #endif
+ *
+ *    The broader POSIX compatibility shim (clock_gettime, strcasecmp, sockets,
+ *    sigaction, getopt, etc.) lives in mb_define.h under #ifdef _WIN32.
+ *--------------------------------------------------------------------*/
+#ifndef UNISTD_W_H
+#define UNISTD_W_H
+
+#include <direct.h>
+#include <process.h>
+#include <io.h>
+
+#ifndef PATH_MAX
+#  define PATH_MAX 1024
+#endif
+
+#ifdef _WIN32
+#  ifndef R_OK
+#    define R_OK 04
+#    define W_OK 02
+#    define X_OK 01
+#    define F_OK 00
+#  endif
+#endif
+
+#endif /* UNISTD_W_H */

--- a/src/mbmesh/mbmesh.cpp
+++ b/src/mbmesh/mbmesh.cpp
@@ -40,9 +40,20 @@
 #include <cstring>
 #include <getopt.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 #include <vector>
 #include <algorithm>
+
+/* POSIX S_ISDIR — MSVC has only the _S_IFMT/_S_IFDIR bit constants. */
+#ifdef _WIN32
+#ifndef S_ISDIR
+#define S_ISDIR(m) (((m) & _S_IFMT) == _S_IFDIR)
+#endif
+#endif
 
 
 // Point cloud GLB export

--- a/src/mbnavadjust/mbnavadjust_invertnav.c
+++ b/src/mbnavadjust/mbnavadjust_invertnav.c
@@ -43,7 +43,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 
 #include "mb_aux.h"
 #include "mb_define.h"

--- a/src/mbnavadjust/mbnavadjust_io.c
+++ b/src/mbnavadjust/mbnavadjust_io.c
@@ -41,7 +41,11 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 #include <errno.h>
 
 #include "mb_aux.h"
@@ -212,10 +216,12 @@ int mbnavadjust_new_project(int verbose, char *projectpath, double section_lengt
       project->use_mode = MBNA_USE_MODE_PRIMARY;
 
       /* create data directory */
+      int mode;
 #ifdef _WIN32
-      if (mkdir(project->datadir) != 0) {
+      mode = mkdir(project->datadir);
+      if (mode != 0) {
 #else
-	  int mode = mkdir(project->datadir, 00775);
+	  mode = mkdir(project->datadir, 00775);
       if (mode != 0) {
 #endif
         fprintf(stderr, "Error creating data directory %s\nmode:%d errno:%d\nError: %s\n", 

--- a/src/mbnavadjust/mbnavadjustmerge.c
+++ b/src/mbnavadjust/mbnavadjustmerge.c
@@ -38,7 +38,11 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 
 #include "mb_aux.h"
 #include "mb_define.h"

--- a/src/otps/mbotps.c
+++ b/src/otps/mbotps.c
@@ -75,9 +75,20 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 
 #include "mb_define.h"
+
+/* POSIX popen/pclose — MSVC has _popen/_pclose with the same signatures. */
+#ifdef _WIN32
+#define popen _popen
+#define pclose _pclose
+#endif
+
 #include "mb_format.h"
 #include "mb_process.h"
 #include "mb_status.h"

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -75,14 +75,14 @@ set(executables
 
 foreach(executable ${executables})
   add_executable(${executable} ${executable}.cc)
-  target_link_libraries(${executable} PRIVATE mbio mbbsio mbaux mbsapi mbgsf pthread)
+  target_link_libraries(${executable} PRIVATE mbio mbbsio mbaux mbsapi mbgsf ${MB_SYSLIBS})
 endforeach()
 
 add_executable(mblevitus mblevitus.cc levitus.h)
-target_link_libraries(mblevitus PRIVATE mbio mbbsio mbaux mbsapi mbgsf pthread)
+target_link_libraries(mblevitus PRIVATE mbio mbbsio mbaux mbsapi mbgsf ${MB_SYSLIBS})
 
 add_executable(mbconfig mbconfig.cc levitus.h)
-target_link_libraries(mbconfig PRIVATE mbio mbbsio mbaux mbsapi mbgsf pthread)
+target_link_libraries(mbconfig PRIVATE mbio mbbsio mbaux mbsapi mbgsf ${MB_SYSLIBS})
 
 # Escape backslashes (e.g. from a Windows path like C:\otps) so that
 # embedding these paths in generated C string literals and compiler

--- a/src/utilities/mb7k2jstar.cc
+++ b/src/utilities/mb7k2jstar.cc
@@ -36,8 +36,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"
@@ -1034,11 +1037,11 @@ int main(int argc, char **argv) {
 					channel->NMEAantennaeO =
 					    s7ksegyheader->NMEAantennaeO; /* 38-39 : Distance to antennae starboard direction in cm */
 					for (int i = 0; i < 2; i++) {
-						channel->reserved4[i] = 0;   /* 40-43 : Reserved – Do not use */
+						channel->reserved4[i] = 0;   /* 40-43 : Reserved â€“ Do not use */
 					}
-					channel->kmOfPipe = 0;      /* 44-47 : Kilometers of Pipe - See Validity Flag (bytes 30 – 31). */
+					channel->kmOfPipe = 0;      /* 44-47 : Kilometers of Pipe - See Validity Flag (bytes 30 â€“ 31). */
 					for (int i = 0; i < 16; i++) {
-						channel->reserved5[i] = 0;  /* 48-79 : Reserved – Do not use */
+						channel->reserved5[i] = 0;  /* 48-79 : Reserved â€“ Do not use */
 					}
 
 					/* -------------------------------------------------------------------- */
@@ -1300,11 +1303,11 @@ int main(int argc, char **argv) {
 					                                               /*   3 = 1 short  per sample  - real part analytic signal */
 					                                               /*   4 = 1 short  per sample  - pixel data / ceros data */
 					for (int i = 0; i < 2; i++) {
-						channel->reserved4[i] = 0;   /* 40-43 : Reserved – Do not use */
+						channel->reserved4[i] = 0;   /* 40-43 : Reserved â€“ Do not use */
 					}
-					channel->kmOfPipe = 0;      /* 44-47 : Kilometers of Pipe - See Validity Flag (bytes 30 – 31). */
+					channel->kmOfPipe = 0;      /* 44-47 : Kilometers of Pipe - See Validity Flag (bytes 30 â€“ 31). */
 					for (int i = 0; i < 16; i++) {
-						channel->reserved5[i] = 0;  /* 48-79 : Reserved – Do not use */
+						channel->reserved5[i] = 0;  /* 48-79 : Reserved â€“ Do not use */
 					}
 
 					/* -------------------------------------------------------------------- */
@@ -1568,11 +1571,11 @@ int main(int argc, char **argv) {
 					                                               /*   3 = 1 short  per sample  - real part analytic signal */
 					                                               /*   4 = 1 short  per sample  - pixel data / ceros data */
 					for (int i = 0; i < 2; i++) {
-						channel->reserved4[i] = 0;   /* 40-43 : Reserved – Do not use */
+						channel->reserved4[i] = 0;   /* 40-43 : Reserved â€“ Do not use */
 					}
-					channel->kmOfPipe = 0;      /* 44-47 : Kilometers of Pipe - See Validity Flag (bytes 30 – 31). */
+					channel->kmOfPipe = 0;      /* 44-47 : Kilometers of Pipe - See Validity Flag (bytes 30 â€“ 31). */
 					for (int i = 0; i < 16; i++) {
-						channel->reserved5[i] = 0;  /* 48-79 : Reserved – Do not use */
+						channel->reserved5[i] = 0;  /* 48-79 : Reserved â€“ Do not use */
 					}
 
 					/* -------------------------------------------------------------------- */
@@ -1846,11 +1849,11 @@ int main(int argc, char **argv) {
 					                                               /*   3 = 1 short  per sample  - real part analytic signal */
 					                                               /*   4 = 1 short  per sample  - pixel data / ceros data */
 					for (int i = 0; i < 2; i++) {
-						channel->reserved4[i] = 0;   /* 40-43 : Reserved – Do not use */
+						channel->reserved4[i] = 0;   /* 40-43 : Reserved â€“ Do not use */
 					}
-					channel->kmOfPipe = 0;      /* 44-47 : Kilometers of Pipe - See Validity Flag (bytes 30 – 31). */
+					channel->kmOfPipe = 0;      /* 44-47 : Kilometers of Pipe - See Validity Flag (bytes 30 â€“ 31). */
 					for (int i = 0; i < 16; i++) {
-						channel->reserved5[i] = 0;  /* 48-79 : Reserved – Do not use */
+						channel->reserved5[i] = 0;  /* 48-79 : Reserved â€“ Do not use */
 					}
 
 					/* -------------------------------------------------------------------- */
@@ -2098,11 +2101,11 @@ int main(int argc, char **argv) {
 					                                               /*   3 = 1 short  per sample  - real part analytic signal */
 					                                               /*   4 = 1 short  per sample  - pixel data / ceros data */
 					for (int i = 0; i < 2; i++) {
-						channel->reserved4[i] = 0;   /* 40-43 : Reserved – Do not use */
+						channel->reserved4[i] = 0;   /* 40-43 : Reserved â€“ Do not use */
 					}
-					channel->kmOfPipe = 0;      /* 44-47 : Kilometers of Pipe - See Validity Flag (bytes 30 – 31). */
+					channel->kmOfPipe = 0;      /* 44-47 : Kilometers of Pipe - See Validity Flag (bytes 30 â€“ 31). */
 					for (int i = 0; i < 16; i++) {
-						channel->reserved5[i] = 0;  /* 48-79 : Reserved – Do not use */
+						channel->reserved5[i] = 0;  /* 48-79 : Reserved â€“ Do not use */
 					}
 
 					/* -------------------------------------------------------------------- */

--- a/src/utilities/mbabsorption.cc
+++ b/src/utilities/mbabsorption.cc
@@ -106,8 +106,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_status.h"
 

--- a/src/utilities/mbareaclean.cc
+++ b/src/utilities/mbareaclean.cc
@@ -52,8 +52,11 @@
 #include <getopt.h>
 #include <sys/stat.h>
 #include <time.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include <algorithm>
 
 #include "mb_define.h"

--- a/src/utilities/mbauvloglist.cc
+++ b/src/utilities/mbauvloglist.cc
@@ -37,8 +37,11 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_aux.h"
 #include "mb_define.h"
 #include "mb_status.h"

--- a/src/utilities/mbbackangle.cc
+++ b/src/utilities/mbbackangle.cc
@@ -42,8 +42,11 @@
 #include <ctime>
 #include <getopt.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_aux.h"
 #include "mb_define.h"
 #include "mb_format.h"

--- a/src/utilities/mbclean.cc
+++ b/src/utilities/mbclean.cc
@@ -71,8 +71,11 @@
 #include <ctime>
 #include <getopt.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"

--- a/src/utilities/mbconfig.cc
+++ b/src/utilities/mbconfig.cc
@@ -36,8 +36,11 @@
 #include <getopt.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "levitus.h"
 
 #include "mb_define.h"

--- a/src/utilities/mbcopy.cc
+++ b/src/utilities/mbcopy.cc
@@ -40,9 +40,18 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
+
+/* POSIX sleep(seconds) — Windows has Sleep(milliseconds). */
+#ifdef _WIN32
+#define sleep(s) Sleep((s) * 1000)
+#endif
+
 #include "mb_format.h"
 #include "mb_io.h"
 #include "mb_status.h"

--- a/src/utilities/mbctdlist.cc
+++ b/src/utilities/mbctdlist.cc
@@ -43,8 +43,11 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_aux.h"
 #include "mb_define.h"
 #include "mb_format.h"

--- a/src/utilities/mbdatalist.cc
+++ b/src/utilities/mbdatalist.cc
@@ -35,8 +35,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_process.h"

--- a/src/utilities/mbdefaults.cc
+++ b/src/utilities/mbdefaults.cc
@@ -36,8 +36,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_status.h"
 

--- a/src/utilities/mbdumpesf.cc
+++ b/src/utilities/mbdumpesf.cc
@@ -38,8 +38,11 @@
 #include <getopt.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_process.h"

--- a/src/utilities/mbextractsegy.cc
+++ b/src/utilities/mbextractsegy.cc
@@ -37,8 +37,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_segy.h"

--- a/src/utilities/mbfilter.cc
+++ b/src/utilities/mbfilter.cc
@@ -48,8 +48,11 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"

--- a/src/utilities/mbformat.cc
+++ b/src/utilities/mbformat.cc
@@ -36,8 +36,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_status.h"

--- a/src/utilities/mbgetesf.cc
+++ b/src/utilities/mbgetesf.cc
@@ -39,8 +39,11 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_process.h"

--- a/src/utilities/mbgpstide.cc
+++ b/src/utilities/mbgpstide.cc
@@ -72,9 +72,19 @@
 #include <ctime>
 #include <getopt.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
+
+/* POSIX popen/pclose — MSVC has _popen/_pclose with the same signatures. */
+#ifdef _WIN32
+#define popen _popen
+#define pclose _pclose
+#endif
+
 #include "mb_io.h"
 #include "mb_status.h"
 #include "mb_format.h"

--- a/src/utilities/mbgrid.cc
+++ b/src/utilities/mbgrid.cc
@@ -53,10 +53,20 @@
 #include <ctime>
 #include <getopt.h>
 #include <limits>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_aux.h"
 #include "mb_define.h"
+
+/* POSIX popen/pclose — MSVC has _popen/_pclose with the same signatures. */
+#ifdef _WIN32
+#define popen _popen
+#define pclose _pclose
+#endif
+
 #include "mb_format.h"
 #include "mb_info.h"
 #include "mb_io.h"

--- a/src/utilities/mbhistogram.cc
+++ b/src/utilities/mbhistogram.cc
@@ -38,8 +38,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_status.h"
 

--- a/src/utilities/mbinfo.cc
+++ b/src/utilities/mbinfo.cc
@@ -42,8 +42,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_info.h"
 #include "mb_io.h"

--- a/src/utilities/mblevitus.cc
+++ b/src/utilities/mblevitus.cc
@@ -48,9 +48,18 @@
 #include <cstring>
 #include <getopt.h>
 #include <time.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
+
+/* POSIX strtok_r — MSVC has strtok_s with the same signature. */
+#ifdef _WIN32
+#define strtok_r(str, delim, saveptr) strtok_s((str), (delim), (saveptr))
+#endif
+
 #include "mb_status.h"
 
 #ifndef _WIN32

--- a/src/utilities/mblist.cc
+++ b/src/utilities/mblist.cc
@@ -45,7 +45,11 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 #include <limits>
 
 #include <algorithm>

--- a/src/utilities/mbmakedatalist.cc
+++ b/src/utilities/mbmakedatalist.cc
@@ -58,12 +58,27 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#ifdef _WIN32
+#include "dirent_w.h"
+#else
 #include <dirent.h>
+#endif
 #include <getopt.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
+
+/* POSIX S_ISREG — MSVC has only the _S_IFMT/_S_IFREG bit constants. */
+#ifdef _WIN32
+#ifndef S_ISREG
+#define S_ISREG(m) (((m) & _S_IFMT) == _S_IFREG)
+#endif
+#endif
+
 #include "mb_format.h"
 #include "mb_status.h"
 
@@ -185,7 +200,7 @@ static int get_format(const char *filepath) {
 
 /*--------------------------------------------------------------------
  * Kongsberg filename time-sort comparator.
- * Sort key is "YYYYMMDD^HHMMSS" — plain lexicographic order works
+ * Sort key is "YYYYMMDD^HHMMSS" â€” plain lexicographic order works
  * because the fields are zero-padded numeric strings.
  *--------------------------------------------------------------------*/
 static int kongsberg_cmp(const void *a, const void *b) {
@@ -427,7 +442,7 @@ int main(int argc, char **argv) {
 
     /* The Perl script doubles the threshold because `ls -s` reports sizes
      * in 512-byte blocks and the user supplies KB.  1 KB = 2 blocks of 512
-     * bytes.  We compare against stat.st_size (bytes), so convert KB→bytes. */
+     * bytes.  We compare against stat.st_size (bytes), so convert KBâ†’bytes. */
     long size_threshold_bytes = size_threshold * 1024L;
 
     bool do_kongsberg_sort = is_kongsberg_suffix(suffix) && !disablesorting;

--- a/src/utilities/mbmakeplatform.cc
+++ b/src/utilities/mbmakeplatform.cc
@@ -37,7 +37,11 @@
 #include <getopt.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_io.h"

--- a/src/utilities/mbmapscale.cc
+++ b/src/utilities/mbmapscale.cc
@@ -38,8 +38,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_status.h"
 

--- a/src/utilities/mbminirovnav.cc
+++ b/src/utilities/mbminirovnav.cc
@@ -41,8 +41,11 @@
 #include <getopt.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_aux.h"
 #include "mb_define.h"
 #include "mb_format.h"

--- a/src/utilities/mbmosaic.cc
+++ b/src/utilities/mbmosaic.cc
@@ -42,7 +42,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 #include <limits>
 
 #include "mb_aux.h"

--- a/src/utilities/mbnavlist.cc
+++ b/src/utilities/mbnavlist.cc
@@ -37,8 +37,11 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_status.h"

--- a/src/utilities/mbpreprocess.cc
+++ b/src/utilities/mbpreprocess.cc
@@ -40,8 +40,11 @@
 #include <getopt.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_aux.h"
 #include "mb_define.h"
 #include "mb_format.h"

--- a/src/utilities/mbprocess.cc
+++ b/src/utilities/mbprocess.cc
@@ -55,10 +55,20 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <thread>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_aux.h"
 #include "mb_define.h"
+
+/* MSVC has no fseeko/ftello; use the native 64-bit file APIs instead. */
+#ifdef _WIN32
+#define ftello _ftelli64
+#define fseeko(fp, off, whence) _fseeki64((fp), (off), (whence))
+#endif
+
 #include "mb_format.h"
 #include "mb_process.h"
 #include "mb_status.h"

--- a/src/utilities/mbrolltimelag.cc
+++ b/src/utilities/mbrolltimelag.cc
@@ -41,9 +41,19 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
+
+/* POSIX popen/pclose — MSVC has _popen/_pclose with the same signatures. */
+#ifdef _WIN32
+#define popen _popen
+#define pclose _pclose
+#endif
+
 #include "mb_format.h"
 #include "mb_status.h"
 

--- a/src/utilities/mbroutetime.cc
+++ b/src/utilities/mbroutetime.cc
@@ -38,8 +38,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_status.h"

--- a/src/utilities/mbsegygrid.cc
+++ b/src/utilities/mbsegygrid.cc
@@ -39,7 +39,11 @@
 #include <getopt.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
+#endif
 #include <limits>
 
 #include "mb_aux.h"

--- a/src/utilities/mbsegyinfo.cc
+++ b/src/utilities/mbsegyinfo.cc
@@ -34,8 +34,11 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include <algorithm>
 
 #include "mb_define.h"

--- a/src/utilities/mbsegylist.cc
+++ b/src/utilities/mbsegylist.cc
@@ -37,8 +37,11 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include <limits>
 
 #include "mb_define.h"

--- a/src/utilities/mbsegypsd.cc
+++ b/src/utilities/mbsegypsd.cc
@@ -40,8 +40,11 @@
 #include <limits>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "fftw3.h"
 #include "mb_aux.h"
 #include "mb_define.h"

--- a/src/utilities/mbset.cc
+++ b/src/utilities/mbset.cc
@@ -47,8 +47,11 @@
 #include <getopt.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_process.h"

--- a/src/utilities/mbsslayout.cc
+++ b/src/utilities/mbsslayout.cc
@@ -38,8 +38,11 @@
 #include <getopt.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include <algorithm>
 
 #include "mb_aux.h"

--- a/src/utilities/mbsvplist.cc
+++ b/src/utilities/mbsvplist.cc
@@ -47,8 +47,11 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_status.h"
 #include "mb_format.h"
 #include "mb_define.h"

--- a/src/utilities/mbsvpselect.cc
+++ b/src/utilities/mbsvpselect.cc
@@ -198,8 +198,11 @@
 #include <cstring>
 #include <ctime>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include <geodesic.h>
 
 #include "mb_define.h"

--- a/src/utilities/mbswath2las.cc
+++ b/src/utilities/mbswath2las.cc
@@ -37,8 +37,11 @@
 #include <ctime>
 #include <getopt.h>
 #include <string>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include <proj.h>
 
 #include "mb_define.h"

--- a/src/utilities/mbtime.cc
+++ b/src/utilities/mbtime.cc
@@ -38,8 +38,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_status.h"
 

--- a/src/utilities/mbvoxelclean.cc
+++ b/src/utilities/mbvoxelclean.cc
@@ -59,8 +59,11 @@
 #include <ctime>
 #include <getopt.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include "unistd_w.h"
+#else
 #include <unistd.h>
-
+#endif
 #include "mb_define.h"
 #include "mb_format.h"
 #include "mb_info.h"


### PR DESCRIPTION
Ports the Windows compatibility layer that was missing from this branch: top-level MSVC CMake block (force-included mb_define.h, HAVE_STRUCT_TIMESPEC, Winsock link), winsock2.h/windows.h include in mb_define.h's active Windows branch, unistd.h/dirent.h guarded with unistd_w.h/dirent_w.h shims across gsf/bsio/mbio/mbaux/mbnavadjust/otps/mbmesh/utilities, and per-call-site MSVC equivalents for strtok_r, popen/pclose, S_ISREG/S_ISDIR, fseeko/ftello/off_t.

Also fixes:
- gsf_enc.c had corrupted CR-only line endings that made MSVC's preprocessor silently drop every gsfEncode* function, breaking the mbgsf.dll link.
- gsfError and mb_sensor_type_id/mb_sensor_type_string are cross-DLL globals; CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS only auto-exports functions, not data, so they need explicit dllexport/dllimport (plus extern "C" for the sensor arrays, consumed from a C++ translation unit).
- mbnavadjust_io.c: `mode` was declared only in the non-Windows mkdir() branch but referenced unconditionally in the following error message.
- Hardcoded m/pthread link names in mbio, gsf (dump_gsf), and utilities CMakeLists.txt replaced with ${MB_SYSLIBS}, which is empty on Windows (libm/pthreads are CRT-builtin/globally linked there already).