### PR TITLE
Fix mb update arrayptr

### DIFF
--- a/src/mbio/mb_mem.c
+++ b/src/mbio/mb_mem.c
@@ -931,10 +931,8 @@ int mb_update_arrays(int verbose, void *mbio_ptr, int nbath, int namp, int nss, 
   /* get mbio descriptor */
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-  /* Drop stale freed addresses from prior reallocations. mb_update_arrayptr()
-     used to match *handle against leftover regarray_oldptr[] values, so a
-     recycled heap address could rebind a sidescan pointer to a bathymetry
-     buffer (Linux malloc). Only this call's reallocs should populate oldptr. */
+  /* Discard pointer values from earlier reallocation cycles so allocator
+     address reuse cannot cause a false match in mb_update_arrayptr(). */
   for (int i = 0; i < mb_io_ptr->n_regarray; i++) {
     mb_io_ptr->regarray_oldptr[i] = NULL;
   }
@@ -1178,10 +1176,8 @@ int mb_update_arrayptr(int verbose, void *mbio_ptr, void **handle, int *error) {
   /* get mbio descriptor */
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-  /* Match by the stable handle address. mb_register_array() stores the caller's
-     pointer-to-pointer in regarray_handle[]; that address does not change when
-     the data buffer is reallocated, so this cannot cross-bind bathymetry and
-     sidescan registrations when the heap recycles a freed address. */
+  /* Prefer the registered pointer variable's address, which remains stable
+     when its allocation is resized. */
   bool found = false;
   for (int i = 0; i < mb_io_ptr->n_regarray; i++) {
     if ((void *)handle == mb_io_ptr->regarray_handle[i]) {
@@ -1192,11 +1188,9 @@ int mb_update_arrayptr(int verbose, void *mbio_ptr, void **handle, int *error) {
     }
   }
 
-  /* mb_read(), mb_get(), and mb_get_all() pass addresses of local copies of
-     the data pointers, not the original registered handles. Fall back to
-     matching the stale data pointer against this realloc cycle's oldptr
-     values, which are unique because they were live allocations at the start
-     of mb_update_arrays(). */
+  /* The read APIs call this function with addresses of local pointer copies,
+     which do not match regarray_handle[]. Fall back to the pointer value saved
+     by the current mb_update_arrays() call. */
   if (!found) {
     for (int i = 0; i < mb_io_ptr->n_regarray; i++) {
       if (mb_io_ptr->regarray_oldptr[i] != NULL && *handle == mb_io_ptr->regarray_oldptr[i]) {

--- a/src/mbio/mb_mem.c
+++ b/src/mbio/mb_mem.c
@@ -931,6 +931,14 @@ int mb_update_arrays(int verbose, void *mbio_ptr, int nbath, int namp, int nss, 
   /* get mbio descriptor */
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
+  /* Drop stale freed addresses from prior reallocations. mb_update_arrayptr()
+     used to match *handle against leftover regarray_oldptr[] values, so a
+     recycled heap address could rebind a sidescan pointer to a bathymetry
+     buffer (Linux malloc). Only this call's reallocs should populate oldptr. */
+  for (int i = 0; i < mb_io_ptr->n_regarray; i++) {
+    mb_io_ptr->regarray_oldptr[i] = NULL;
+  }
+
   /* reallocate larger arrays if necessary */
   int status = MB_SUCCESS;
   if (nbath > mb_io_ptr->beams_bath_alloc) {
@@ -1170,12 +1178,32 @@ int mb_update_arrayptr(int verbose, void *mbio_ptr, void **handle, int *error) {
   /* get mbio descriptor */
   struct mb_io_struct *mb_io_ptr = (struct mb_io_struct *)mbio_ptr;
 
-  /* look for handle in registered arrays */
+  /* Match by the stable handle address. mb_register_array() stores the caller's
+     pointer-to-pointer in regarray_handle[]; that address does not change when
+     the data buffer is reallocated, so this cannot cross-bind bathymetry and
+     sidescan registrations when the heap recycles a freed address. */
   bool found = false;
-  for (int i = 0; i < mb_io_ptr->n_regarray && !found; i++) {
-    if (*handle == mb_io_ptr->regarray_oldptr[i]) {
+  for (int i = 0; i < mb_io_ptr->n_regarray; i++) {
+    if ((void *)handle == mb_io_ptr->regarray_handle[i]) {
       *handle = mb_io_ptr->regarray_ptr[i];
+      mb_io_ptr->regarray_oldptr[i] = NULL;
       found = true;
+      break;
+    }
+  }
+
+  /* mb_read(), mb_get(), and mb_get_all() pass addresses of local copies of
+     the data pointers, not the original registered handles. Fall back to
+     matching the stale data pointer against this realloc cycle's oldptr
+     values, which are unique because they were live allocations at the start
+     of mb_update_arrays(). */
+  if (!found) {
+    for (int i = 0; i < mb_io_ptr->n_regarray; i++) {
+      if (mb_io_ptr->regarray_oldptr[i] != NULL && *handle == mb_io_ptr->regarray_oldptr[i]) {
+        *handle = mb_io_ptr->regarray_ptr[i];
+        mb_io_ptr->regarray_oldptr[i] = NULL;
+        break;
+      }
     }
   }
 

--- a/test/mbio/mb_mem_test.cc
+++ b/test/mbio/mb_mem_test.cc
@@ -111,10 +111,8 @@ void InitMinimalMbio(struct mb_io_struct *mbio, int beams, int pixels) {
   mbio->pixels_ss_alloc = pixels;
 }
 
-// mb_read() holds local copies of registered data pointers. After a ping that
-// grows both bathymetry and sidescan (e.g. EM304 GSF with BRB intensity),
-// mb_update_arrayptr() must rebind those copies to the matching allocation
-// rather than a recycled heap address from a different type.
+// Simulate mb_read() after bathymetry and sidescan arrays grow in one cycle;
+// each local pointer copy must be rebound to its registered allocation.
 TEST(MbMem, UpdateArrayptrLocalCopyAfterBathAndSidescanGrow) {
   int error = MB_ERROR_NO_ERROR;
   const int verbose = 0;
@@ -192,6 +190,9 @@ TEST(MbMem, UpdateArrayptrLocalCopyAfterStagedBathThenSidescanGrow) {
   ASSERT_EQ(MB_SUCCESS, mb_update_arrayptr(verbose, &mbio, (void **)&bath_local, &error));
   EXPECT_EQ(bath_local, bath);
 
+  // Simulate allocator reuse: the stale bathymetry address now identifies the
+  // current sidescan allocation.
+  mbio.regarray_oldptr[0] = sslon;
   double *sslon_local = sslon;
   ASSERT_EQ(MB_SUCCESS, mb_update_arrays(verbose, &mbio, 800, 800, 9664, &error));
   EXPECT_EQ(mbio.regarray_oldptr[0], nullptr);

--- a/test/mbio/mb_mem_test.cc
+++ b/test/mbio/mb_mem_test.cc
@@ -4,8 +4,10 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 
 #include "mb_define.h"
+#include "mb_io.h"
 #include "mb_status.h"
 
 #include <gmock/gmock.h>
@@ -97,10 +99,107 @@ TEST(MbDebug, FreeNullptr) {
 // TODO(schwehr): Test mb_memory_clear
 // TODO(schwehr): Test mb_memory_status
 // TODO(schwehr): Test mb_memory_list
-// TODO(schwehr): Test mb_register_array
-// TODO(schwehr): Test mb_update_arrays
-// TODO(schwehr): Test mb_update_arrayptr
 // TODO(schwehr): Test mb_list_arrays
-// TODO(schwehr): Test mb_deall_ioarrays
+
+void InitMinimalMbio(struct mb_io_struct *mbio, int beams, int pixels) {
+  memset(mbio, 0, sizeof(*mbio));
+  mbio->beams_bath_max = beams;
+  mbio->beams_amp_max = beams;
+  mbio->pixels_ss_max = pixels;
+  mbio->beams_bath_alloc = beams;
+  mbio->beams_amp_alloc = beams;
+  mbio->pixels_ss_alloc = pixels;
+}
+
+// mb_read() holds local copies of registered data pointers. After a ping that
+// grows both bathymetry and sidescan (e.g. EM304 GSF with BRB intensity),
+// mb_update_arrayptr() must rebind those copies to the matching allocation
+// rather than a recycled heap address from a different type.
+TEST(MbMem, UpdateArrayptrLocalCopyAfterBathAndSidescanGrow) {
+  int error = MB_ERROR_NO_ERROR;
+  const int verbose = 0;
+  struct mb_io_struct mbio;
+  InitMinimalMbio(&mbio, 254, 8192);
+
+  double *bath = nullptr;
+  double *sslon = nullptr;
+  ASSERT_EQ(MB_SUCCESS, mb_register_array(verbose, &mbio, MB_MEM_TYPE_BATHYMETRY,
+                                          sizeof(double), (void **)&bath, &error));
+  ASSERT_EQ(MB_SUCCESS, mb_register_array(verbose, &mbio, MB_MEM_TYPE_SIDESCAN,
+                                          sizeof(double), (void **)&sslon, &error));
+  ASSERT_NE(bath, nullptr);
+  ASSERT_NE(sslon, nullptr);
+  ASSERT_NE(bath, sslon);
+
+  double *bath_local = bath;
+  double *sslon_local = sslon;
+
+  ASSERT_EQ(MB_SUCCESS, mb_update_arrays(verbose, &mbio, 800, 800, 9664, &error));
+  ASSERT_EQ(MB_SUCCESS, mb_update_arrayptr(verbose, &mbio, (void **)&bath_local, &error));
+  ASSERT_EQ(MB_SUCCESS, mb_update_arrayptr(verbose, &mbio, (void **)&sslon_local, &error));
+
+  EXPECT_EQ(bath_local, bath);
+  EXPECT_EQ(sslon_local, sslon);
+  EXPECT_NE(bath_local, sslon_local);
+
+  sslon_local[mbio.pixels_ss_max - 1] = 42.0;
+  EXPECT_EQ(sslon_local[mbio.pixels_ss_max - 1], 42.0);
+
+  EXPECT_EQ(MB_SUCCESS, mb_deall_ioarrays(verbose, &mbio, &error));
+}
+
+TEST(MbMem, UpdateArrayptrMatchesHandleNotStaleOldptr) {
+  int error = MB_ERROR_NO_ERROR;
+  const int verbose = 0;
+  struct mb_io_struct mbio;
+  InitMinimalMbio(&mbio, 254, 8192);
+
+  double *bath = nullptr;
+  double *sslon = nullptr;
+  ASSERT_EQ(MB_SUCCESS, mb_register_array(verbose, &mbio, MB_MEM_TYPE_BATHYMETRY,
+                                          sizeof(double), (void **)&bath, &error));
+  ASSERT_EQ(MB_SUCCESS, mb_register_array(verbose, &mbio, MB_MEM_TYPE_SIDESCAN,
+                                          sizeof(double), (void **)&sslon, &error));
+
+  double *const sslon_allocation = sslon;
+  double *const bath_allocation = bath;
+  mbio.regarray_oldptr[0] = sslon;
+
+  ASSERT_EQ(MB_SUCCESS, mb_update_arrayptr(verbose, &mbio, (void **)&sslon, &error));
+  EXPECT_EQ(sslon, sslon_allocation);
+  EXPECT_NE(sslon, bath_allocation);
+  EXPECT_EQ(sslon, mbio.regarray_ptr[1]);
+  EXPECT_EQ(mbio.regarray_oldptr[0], sslon_allocation);
+
+  EXPECT_EQ(MB_SUCCESS, mb_deall_ioarrays(verbose, &mbio, &error));
+}
+
+TEST(MbMem, UpdateArrayptrLocalCopyAfterStagedBathThenSidescanGrow) {
+  int error = MB_ERROR_NO_ERROR;
+  const int verbose = 0;
+  struct mb_io_struct mbio;
+  InitMinimalMbio(&mbio, 254, 8192);
+
+  double *bath = nullptr;
+  double *sslon = nullptr;
+  ASSERT_EQ(MB_SUCCESS, mb_register_array(verbose, &mbio, MB_MEM_TYPE_BATHYMETRY,
+                                          sizeof(double), (void **)&bath, &error));
+  ASSERT_EQ(MB_SUCCESS, mb_register_array(verbose, &mbio, MB_MEM_TYPE_SIDESCAN,
+                                          sizeof(double), (void **)&sslon, &error));
+
+  double *bath_local = bath;
+  ASSERT_EQ(MB_SUCCESS, mb_update_arrays(verbose, &mbio, 800, 254, 8192, &error));
+  ASSERT_EQ(MB_SUCCESS, mb_update_arrayptr(verbose, &mbio, (void **)&bath_local, &error));
+  EXPECT_EQ(bath_local, bath);
+
+  double *sslon_local = sslon;
+  ASSERT_EQ(MB_SUCCESS, mb_update_arrays(verbose, &mbio, 800, 800, 9664, &error));
+  EXPECT_EQ(mbio.regarray_oldptr[0], nullptr);
+  ASSERT_EQ(MB_SUCCESS, mb_update_arrayptr(verbose, &mbio, (void **)&sslon_local, &error));
+  EXPECT_EQ(sslon_local, sslon);
+  EXPECT_NE(sslon_local, bath_local);
+
+  EXPECT_EQ(MB_SUCCESS, mb_deall_ioarrays(verbose, &mbio, &error));
+}
 
 }  // namespace


### PR DESCRIPTION
Below is an email conversation regarding the source of these two pull requests, which are being brought into the caress-tmp working branch for testing and evaluation before being committed to the master branch.

From: Danny Neville <danny@spatialnetics.com>
Subject: Re: GSF observations
Date: September 7, 2026 at 4:00:43 PM PDT
To: Vicki Ferrini <ferrini@ldeo.columbia.edu>, David Caress <caress@mbari.org>
Cc: Paul Johnson <pjohnson@ccom.unh.edu>, Lindsay Gee <lindsayjgee@gmail.com>, Madeline Young <myoung@ldeo.columbia.edu>

Thanks Vicki, and hi Dave! I'm not sure if we have met, but we may have exchanged e-mails early in my Fledermaus days. 

What we were seeing was that when mb_update_arrayptr() matched arrays using values from regarray_oldptr[], those values may no longer be valid. So, if the allocator later reused one of those addresses, it could falsely match an earlier array. With EM304 data, the 800 beams and 9,664 intensity samples trigger a reallocation, and then it hits the memory issue. 
We have a proposed fix and some additional tests in our branch here. Please let me know if you need further information, or what the best next steps would be.
https://github.com/Spatialnetics/MB-System/tree/fix-mb-update-arrayptr
Regards,
Danny

From: Vicki Ferrini <[ferrini@ldeo.columbia.edu](mailto:ferrini@ldeo.columbia.edu)>
Sent: Tuesday, September 1, 2026 6:00 PM
To: David Caress <[caress@mbari.org](mailto:caress@mbari.org)>
Cc: Paul Johnson <[pjohnson@ccom.unh.edu](mailto:pjohnson@ccom.unh.edu)>; Lindsay Gee <[lindsayjgee@gmail.com](mailto:lindsayjgee@gmail.com)>; Danny Neville <[danny@spatialnetics.com](mailto:danny@spatialnetics.com)>; Madeline Young <[myoung@ldeo.columbia.edu](mailto:myoung@ldeo.columbia.edu)>
Subject: Fwd: GSF observations
 
Hi Dave,

I hope you're doing well!

As you know, we've been exploring some issues related to GSF files as part of a technical priority within the GEBCO community. I'm writing to connect you with Danny Neville, who has been deep diving on this with Lindsay Gee.

Danny has identified some issues in MB-System related to memory allocation when handling certain GSF files. So far, these problems appear to occur more commonly, perhaps exclusively, in Linux environments. My team at LDEO has also been investigating some additional MB-System issues that are not specific to GSF but may similarly involve memory allocation. I'll save those details for another conversation (perhaps at AGU in December if we don't find time sooner!).

For now, I wanted to connect you with Danny because he has forked the MB-System codebase and developed a potential solution to the GSF-related issue. We're hoping you can provide some guidance on the best path for having his changes reviewed and, if appropriate, incorporated into MB-System.

Danny, I'll let you take it from here and provide the technical details.

Many thanks for your help!

Best,
Vicki


---------- Forwarded message ---------
> On Aug 31, 2026, at 7:55 PM, Danny Neville <[danny@spatialnetics.com](mailto:danny@spatialnetics.com)> wrote:
>
> Hi folks,
>
> I wanted to send out a couple items in advance of the discussion tomorrow.
>
>     • We have reviewed all of the QPS exporting code for GSF, and although there are some smaller inconsistencies, we have found everything to be compliant with the GSF spec.
>     • As you guys also found, there is a bug with mb-system that is triggered by this type of data. We have tracked it down to how memory is reallocated when an array (such as ping or backscatter data) needs to be enlarged. It defaults to 254 beams and 8,192 intensity samples per ping. So, the EM304 data with 800 + 9,664 will immediately cause a memory reallocation.
>     • GlobalMapper does not crash in our tests but stops import with an error about invalid offsets. We are going to try converting the backscatter into different variable types to see if that narrows things down. The GSF spec documentation is behind the reference code, which has more allowable data types for intensity. GlobalMapper may be just using what is in the spec.
>
> We have a fork of MB-System with the fix here: https://github.com/Spatialnetics/MB-System/tree/fix-mb-update-arrayptr and we are reviewing internally to make sure our fix is correct. It has worked correctly with mb-info and for making grids with all of the problematic files so far.
>
> Regards,
> Danny

--
Vicki Ferrini, PhD (she/her)
Marie Tharp Senior Research Scientist
Director, Marine Geoscience Data System | GeoMapApp | GMRT
Head, Atlantic and Indian Oceans Regional Center for Seabed 2030
LDEO Associate Director for Community Impact and Strategy
Lamont-Doherty Earth Observatory
Columbia University